### PR TITLE
Qt: Make strings translatable

### DIFF
--- a/src/ui/CardActionHandler.cpp
+++ b/src/ui/CardActionHandler.cpp
@@ -25,15 +25,15 @@ PS2MemoryCard* CardActionHandler::openCard(const QString& filename)
 
 		if (statusBar)
 		{
-			statusBar->showMessage(QString("Opened: %1").arg(filename), 3000);
+			statusBar->showMessage(tr("Opened: %1").arg(filename), 3000);
 		}
 
 		return card.release();
 	}
 	catch (const std::exception& e)
 	{
-		QMessageBox::critical(parentWidget, "Error",
-			QString("Failed to open memory card: %1").arg(e.what()));
+		QMessageBox::critical(parentWidget, tr("Error"),
+			tr("Failed to open memory card: %1").arg(e.what()));
 		return nullptr;
 	}
 }
@@ -47,15 +47,15 @@ PS2MemoryCard* CardActionHandler::createCard(const QString& filename, int sizeMB
 
 		if (statusBar)
 		{
-			statusBar->showMessage(QString("Created: %1").arg(filename), 3000);
+			statusBar->showMessage(tr("Created: %1").arg(filename), 3000);
 		}
 
 		return card.release();
 	}
 	catch (const std::exception& e)
 	{
-		QMessageBox::critical(parentWidget, "Error",
-			QString("Failed to create memory card: %1").arg(e.what()));
+		QMessageBox::critical(parentWidget, tr("Error"),
+			tr("Failed to create memory card: %1").arg(e.what()));
 		return nullptr;
 	}
 }
@@ -64,7 +64,7 @@ void CardActionHandler::closeCard()
 {
 	if (statusBar)
 	{
-		statusBar->showMessage("No memory card open");
+		statusBar->showMessage(tr("No memory card open"));
 	}
 }
 
@@ -72,14 +72,14 @@ void CardActionHandler::importSave(PS2MemoryCard* card, const QString& filename)
 {
 	if (!card)
 	{
-		QMessageBox::warning(parentWidget, "Warning", "No memory card open");
+		QMessageBox::warning(parentWidget, tr("Warning"), tr("No memory card open"));
 		return;
 	}
 
 	if (!QFileInfo(filename).exists())
 	{
-		QMessageBox::critical(parentWidget, "Error",
-			QString("File not found: %1").arg(filename));
+		QMessageBox::critical(parentWidget, tr("Error"),
+			tr("File not found: %1").arg(filename));
 		return;
 	}
 
@@ -91,8 +91,8 @@ void CardActionHandler::importSave(PS2MemoryCard* card, const QString& filename)
 		const auto& entries = saveFile.getEntries();
 		if (entries.empty())
 		{
-			QMessageBox::warning(parentWidget, "Warning",
-				"Save file is empty or contains no valid entries");
+			QMessageBox::warning(parentWidget, tr("Warning"),
+				tr("Save file is empty or contains no valid entries"));
 			return;
 		}
 
@@ -102,19 +102,19 @@ void CardActionHandler::importSave(PS2MemoryCard* card, const QString& filename)
 
 		if (result)
 		{
-			QMessageBox::information(parentWidget, "Success",
-				QString("Successfully imported save: %1")
+			QMessageBox::information(parentWidget, tr("Success"),
+				tr("Successfully imported save: %1")
 					.arg(QString::fromStdString(saveName)));
 
 			if (statusBar)
 			{
-				statusBar->showMessage(QString("Imported: %1").arg(QString::fromStdString(saveName)), 3000);
+				statusBar->showMessage(tr("Imported: %1").arg(QString::fromStdString(saveName)), 3000);
 			}
 		}
 		else
 		{
-			auto reply = QMessageBox::question(parentWidget, "Save Exists",
-				QString("Save '%1' already exists. Overwrite?")
+			auto reply = QMessageBox::question(parentWidget, tr("Save Exists"),
+				tr("Save '%1' already exists. Overwrite?")
 					.arg(QString::fromStdString(saveName)),
 				QMessageBox::Yes | QMessageBox::No);
 
@@ -124,12 +124,12 @@ void CardActionHandler::importSave(PS2MemoryCard* card, const QString& filename)
 
 				if (result)
 				{
-					QMessageBox::information(parentWidget, "Success",
-						"Successfully imported and overwrote existing save");
+					QMessageBox::information(parentWidget, tr("Success"),
+						tr("Successfully imported and overwrote existing save"));
 
 					if (statusBar)
 					{
-						statusBar->showMessage(QString("Imported (overwrite): %1")
+						statusBar->showMessage(tr("Imported (overwrite): %1")
 												   .arg(QString::fromStdString(saveName)),
 							3000);
 					}
@@ -139,8 +139,8 @@ void CardActionHandler::importSave(PS2MemoryCard* card, const QString& filename)
 	}
 	catch (const std::exception& e)
 	{
-		QMessageBox::critical(parentWidget, "Error",
-			QString("Failed to import save: %1").arg(e.what()));
+		QMessageBox::critical(parentWidget, tr("Error"),
+			tr("Failed to import save: %1").arg(e.what()));
 	}
 }
 
@@ -148,7 +148,7 @@ void CardActionHandler::exportSave(PS2MemoryCard* card, const QString& savePath,
 {
 	if (!card)
 	{
-		QMessageBox::warning(parentWidget, "Warning", "No memory card open");
+		QMessageBox::warning(parentWidget, tr("Warning"), tr("No memory card open"));
 		return;
 	}
 
@@ -165,18 +165,18 @@ void CardActionHandler::exportSave(PS2MemoryCard* card, const QString& savePath,
 
 		saveFile.save(outputFilename.toStdString(), format);
 
-		QMessageBox::information(parentWidget, "Success",
-			QString("Successfully exported save to:\n%1").arg(outputFilename));
+		QMessageBox::information(parentWidget, tr("Success"),
+			tr("Successfully exported save to:\n%1").arg(outputFilename));
 
 		if (statusBar)
 		{
-			statusBar->showMessage(QString("Exported: %1").arg(savePath), 3000);
+			statusBar->showMessage(tr("Exported: %1").arg(savePath), 3000);
 		}
 	}
 	catch (const std::exception& e)
 	{
-		QMessageBox::critical(parentWidget, "Error",
-			QString("Failed to export save: %1").arg(e.what()));
+		QMessageBox::critical(parentWidget, tr("Error"),
+			tr("Failed to export save: %1").arg(e.what()));
 	}
 }
 
@@ -184,7 +184,7 @@ void CardActionHandler::deleteSave(PS2MemoryCard* card, const QString& savePath)
 {
 	if (!card)
 	{
-		QMessageBox::warning(parentWidget, "Warning", "No memory card open");
+		QMessageBox::warning(parentWidget, tr("Warning"), tr("No memory card open"));
 		return;
 	}
 
@@ -194,8 +194,8 @@ void CardActionHandler::deleteSave(PS2MemoryCard* card, const QString& savePath)
 		saveName = saveName.mid(1);
 	}
 
-	int ret = QMessageBox::question(parentWidget, "Confirm Delete",
-		QString("Delete this save?\n\n%1").arg(saveName),
+	int ret = QMessageBox::question(parentWidget, tr("Confirm Delete"),
+		tr("Delete this save?\n\n%1").arg(saveName),
 		QMessageBox::Yes | QMessageBox::No);
 
 	if (ret == QMessageBox::Yes)
@@ -206,13 +206,13 @@ void CardActionHandler::deleteSave(PS2MemoryCard* card, const QString& savePath)
 
 			if (statusBar)
 			{
-				statusBar->showMessage(QString("Deleted: %1").arg(saveName), 3000);
+				statusBar->showMessage(tr("Deleted: %1").arg(saveName), 3000);
 			}
 		}
 		catch (const std::exception& e)
 		{
-			QMessageBox::critical(parentWidget, "Error",
-				QString("Failed to delete save:\n\n%1").arg(e.what()));
+			QMessageBox::critical(parentWidget, tr("Error"),
+				tr("Failed to delete save:\n\n%1").arg(e.what()));
 		}
 	}
 }
@@ -221,13 +221,13 @@ void CardActionHandler::formatCard(PS2MemoryCard* card, const QString& cardPath,
 {
 	if (!card)
 	{
-		QMessageBox::warning(parentWidget, "Warning", "No memory card open");
+		QMessageBox::warning(parentWidget, tr("Warning"), tr("No memory card open"));
 		return;
 	}
 
-	int ret = QMessageBox::warning(parentWidget, "Format Card",
-		"WARNING: This will erase ALL data on the memory card!\n\n"
-		"Are you sure you want to continue?",
+	int ret = QMessageBox::warning(parentWidget, tr("Format Card"),
+		tr("WARNING: This will erase ALL data on the memory card!\n\n"
+		"Are you sure you want to continue?"),
 		QMessageBox::Yes | QMessageBox::No,
 		QMessageBox::No);
 
@@ -240,16 +240,16 @@ void CardActionHandler::formatCard(PS2MemoryCard* card, const QString& cardPath,
 
 			if (statusBar)
 			{
-				statusBar->showMessage("Card formatted successfully", 3000);
+				statusBar->showMessage(tr("Card formatted successfully"), 3000);
 			}
 
-			QMessageBox::information(parentWidget, "Success",
-				QString("Memory card formatted successfully (%1 MB)").arg(sizeMB));
+			QMessageBox::information(parentWidget, tr("Success"),
+				tr("Memory card formatted successfully (%1 MB)").arg(sizeMB));
 		}
 		catch (const std::exception& e)
 		{
-			QMessageBox::critical(parentWidget, "Error",
-				QString("Failed to format card:\n\n%1").arg(e.what()));
+			QMessageBox::critical(parentWidget, tr("Error"),
+				tr("Failed to format card:\n\n%1").arg(e.what()));
 		}
 	}
 }

--- a/src/ui/MainWindow.ui
+++ b/src/ui/MainWindow.ui
@@ -265,7 +265,7 @@
     <iconset theme="trash-fill"/>
    </property>
    <property name="text">
-    <string>&amp;Delete</string>
+    <string>&amp;Delete Save</string>
    </property>
    <property name="statusTip">
     <string>Delete the selected save</string>

--- a/src/ui/Translations/myMCpp_en.ts
+++ b/src/ui/Translations/myMCpp_en.ts
@@ -2,14 +2,410 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="en">
 <context>
+    <name>AdvancedSettingsWidget</name>
+    <message>
+        <location filename="../Settings/AdvancedSettingsWidget.cpp" line="+19"/>
+        <source>Debug Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Enable verbose logging to standard output for debugging purposes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BehaviorSettingsWidget</name>
+    <message>
+        <location filename="../Settings/BehaviorSettingsWidget.cpp" line="+19"/>
+        <source>Warn Before Deleting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Show a warning dialog when attempting to delete files from a memory card.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Hide to System Tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Minimize the application to the system tray instead of the taskbar.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Behavior</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CardActionHandler</name>
+    <message>
+        <location filename="../CardActionHandler.cpp" line="+28"/>
+        <source>Opened: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <location line="+22"/>
+        <location line="+24"/>
+        <location line="+61"/>
+        <location line="+36"/>
+        <location line="+36"/>
+        <location line="+37"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-215"/>
+        <source>Failed to open memory card: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>Created: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Failed to create memory card: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+8"/>
+        <location line="+76"/>
+        <location line="+36"/>
+        <location line="+37"/>
+        <source>No memory card open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-149"/>
+        <location line="+19"/>
+        <location line="+57"/>
+        <location line="+36"/>
+        <location line="+37"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-142"/>
+        <source>File not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Save file is empty or contains no valid entries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <location line="+22"/>
+        <location line="+41"/>
+        <location line="+78"/>
+        <source>Success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-140"/>
+        <source>Successfully imported save: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Imported: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Save Exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Save &apos;%1&apos; already exists. Overwrite?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Successfully imported and overwrote existing save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Imported (overwrite): %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Failed to import save: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+26"/>
+        <source>Successfully exported save to:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Exported: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Failed to export save: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>Confirm Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Delete this save?
+
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Deleted: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Failed to delete save:
+
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Format Card</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>WARNING: This will erase ALL data on the memory card!
+
+Are you sure you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>Card formatted successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Memory card formatted successfully (%1 MB)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Failed to format card:
+
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FilesSettingsWidget</name>
+    <message>
+        <location filename="../Settings/FilesSettingsWidget.cpp" line="+23"/>
+        <source>Memory Card Directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>The default directory where memory card images are stored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Browse Directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Open a file dialog to select the memory card directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+29"/>
+        <source>Select Memory Card Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>InterfaceSettingsWidget</name>
+    <message>
+        <location filename="../Settings/InterfaceSettingsWidget.cpp" line="+25"/>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Select the language for the application interface.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Select the color theme for the application.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Thumbnail Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Adjust the size of the save icons in the main view.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Renderer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Select the graphics API used for rendering the 3D icons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Camera Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Change the camera angle used to view the 3D icons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Lighting Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Select how the icons are lit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Animate Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Enable rotating animations for the 3D icons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Dark (Default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Windows Vista</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Flat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Near</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Icon Lighting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Lighting Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Alternate 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Alternate 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MainWindow</name>
     <message>
-        <location filename="../MainWindow.cpp" line="+81"/>
+        <location filename="../MainWindow.cpp" line="+63"/>
+        <source>Settings...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
         <source>Imported %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+31"/>
         <source>Open Memory Card</source>
         <translation type="unfinished"></translation>
     </message>
@@ -25,12 +421,12 @@
     </message>
     <message>
         <location line="+2"/>
-        <location line="+274"/>
+        <location line="+275"/>
         <source>PCSX2 Memory Card (*.ps2);;MemCard PRO2 (*.mc2 *.mcd);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-249"/>
+        <location line="-250"/>
         <source>Created %1 MB memory card</source>
         <translation type="unfinished"></translation>
     </message>
@@ -90,12 +486,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <source>About myMCpp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+34"/>
+        <location line="+71"/>
         <source>Check for Updates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -161,10 +552,83 @@ For updates, visit: https://github.com/SternXD/myMCpp/releases</source>
     </message>
 </context>
 <context>
-    <name>SettingsDialog</name>
+    <name>MemoryCardBrowser</name>
     <message>
-        <location filename="../dialogs/SettingsDialog.cpp" line="+144"/>
-        <source>Select Memory Card Folder</source>
+        <location filename="../widgets/MemoryCardBrowser.cpp" line="+93"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Failed to read memory card: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SaveDetailsPanel</name>
+    <message>
+        <location filename="../widgets/SaveDetailsPanel.cpp" line="+92"/>
+        <source>Size: %1
+Modified: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+17"/>
+        <source>
+Files: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+73"/>
+        <source>No save selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>No details available</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <location filename="../Settings/SettingsWindow.cpp" line="+34"/>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&lt;strong&gt;Interface Settings&lt;/strong&gt;&lt;hr&gt;These options control how the software looks throughout the application.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Behavior</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&lt;strong&gt;Behavior Settings&lt;/strong&gt;&lt;hr&gt;Configure how the application behaves, including warnings and shutdown confirmations.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&lt;strong&gt;File Settings&lt;/strong&gt;&lt;hr&gt;Manage default paths for memory cards and other resources.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&lt;strong&gt;Advanced Settings&lt;/strong&gt;&lt;hr&gt;Advanced options for debugging and developer tools.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/ui/widgets/MemoryCardBrowser.cpp
+++ b/src/ui/widgets/MemoryCardBrowser.cpp
@@ -90,8 +90,8 @@ void MemoryCardBrowser::loadCard(PS2MemoryCard* card)
 	}
 	catch (const std::exception& e)
 	{
-		QMessageBox::critical(nullptr, "Error",
-			QString("Failed to read memory card: %1").arg(e.what()));
+		QMessageBox::critical(nullptr, tr("Error"),
+			tr("Failed to read memory card: %1").arg(e.what()));
 	}
 }
 

--- a/src/ui/widgets/SaveDetailsPanel.cpp
+++ b/src/ui/widgets/SaveDetailsPanel.cpp
@@ -89,7 +89,7 @@ void SaveDetailsPanel::setSave(PS2MemoryCard* card, const QString& savePath,
 
 	ui->titleLabel->setText(fullTitle);
 
-	QString details = QString("Size: %1\nModified: %2").arg(size, modified);
+	QString details = tr("Size: %1\nModified: %2").arg(size, modified);
 
 	try
 	{
@@ -106,7 +106,7 @@ void SaveDetailsPanel::setSave(PS2MemoryCard* card, const QString& savePath,
 
 		if (fileCount > 0)
 		{
-			details += QString("\nFiles: %1").arg(fileCount);
+			details += tr("\nFiles: %1").arg(fileCount);
 		}
 	}
 	catch (...)
@@ -179,9 +179,9 @@ void SaveDetailsPanel::setSave(PS2MemoryCard* card, const QString& savePath,
 void SaveDetailsPanel::clear()
 {
 	if (ui->titleLabel)
-		ui->titleLabel->setText("No save selected");
+		ui->titleLabel->setText(tr("No save selected"));
 	if (ui->detailsLabel)
-		ui->detailsLabel->setText("No details available");
+		ui->detailsLabel->setText(tr("No details available"));
 	if (iconWidget)
 		iconWidget->hide();
 	currentCard = nullptr;


### PR DESCRIPTION
## Summary
Update UI to make all strings translatable, and update `Delete` to say `Delete Save` and update `ts` file

## Motivation
Because translation good

## Platform Impact
- Windows
- Linux
- macOS

## AI Assistance
No.