### PR TITLE
Core: Auto detect raw dump memory cards without ECC spare data

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,40 +1,45 @@
 # Configuration for actions/labeler
 
-GUI/Qt:
-  - src/ui/**/*
+"GUI/Qt":
+  - any:
+    - 'src/ui/**/*'
 
-Core:
-  - src/core/**/*
+"Core":
+  - any:
+    - 'src/core/**/*'
 
-Build | Project System:
-  - CMakeLists.txt
-  - cmake/**/*
-  - .github/**/*
-  - scripts/**/*
+"Build | Project System":
+  - any:
+    - 'CMakeLists.txt'
+    - 'cmake/**/*'
+    - '.github/**/*'
+    - 'scripts/**/*'
 
-Linux:
+"Linux":
   - any: ['**/*EGL*', '**/*linux*', '**/*Wayland*', '**/*X11*']
 
-Windows:
+"Windows":
   - any: ['**/*WGL*', '**/*win32*', 'resources/myMCpp.rc']
 
-macOS:
+"macOS":
   - any: ['src/core/renderer/Metal/**/*', '**/*AGL*', '**/*.mm', '**/*Cocoa*']
 
-CLI:
-  - src/cli/**/*
+"CLI":
+  - any:
+    - 'src/cli/**/*'
 
-Vulkan:
+"Vulkan":
   - any: ['**/vulkan*', '**/Vulkan*', 'src/core/renderer/Vulkan/**/*']
 
-OpenGL:
+"OpenGL":
   - any: ['**/opengl*', '**/OpenGL*', 'src/core/renderer/OpenGL/**/*']
 
-Metal:
+"Metal":
   - any: ['**/metal*', '**/Metal*', 'src/core/renderer/Metal/**/*']
 
-Documentation:
-  - docs/**/*
-  - README.md
-  - LICENSE.md
-  - build.md
+"Documentation":
+  - any:
+    - 'docs/**/*'
+    - 'README.md'
+    - 'LICENSE.md'
+    - 'build.md'

--- a/src/core/formats/ps2mc.cpp
+++ b/src/core/formats/ps2mc.cpp
@@ -350,6 +350,25 @@ void PS2MemoryCard::Impl::read_superblock()
 		allocatable_cluster_end = clusters_per_card;
 	}
 
+	{
+		uint32_t total_pages = clusters_per_card * pages_per_cluster;
+		uint64_t expected_with_ecc = static_cast<uint64_t>(total_pages) * (page_size + spare_size);
+		uint64_t expected_no_ecc = static_cast<uint64_t>(total_pages) * page_size;
+
+		file.seekg(0, std::ios::end);
+		uint64_t file_size = static_cast<uint64_t>(file.tellg());
+		file.seekg(0, std::ios::beg);
+
+		if (file_size <= expected_no_ecc || file_size < expected_with_ecc)
+		{
+			spare_size = 0;
+			raw_page_size = page_size;
+			ignore_ecc = true;
+			with_ecc = false;
+			page_cache.clear();
+		}
+	}
+
 	read_fat_from_card();
 }
 


### PR DESCRIPTION
### Description of Changes
Fixes memory cards without ECC spare data and fix syntax for labeler

### Rationale behind Changes
Because raw memory cards without ECC didn't work

### Suggested Testing Steps
Test raw memory cards without ECC

### Did you use AI to help find, test, or implement this issue or feature?
No