### PR TITLE
Core: Fix ECC spare size offset and update ECC tool label dynamically

### DIFF
--- a/src/core/formats/ps2mc.cpp
+++ b/src/core/formats/ps2mc.cpp
@@ -342,7 +342,7 @@ void PS2MemoryCard::Impl::read_superblock()
 
 	for (int i = 0; i < 32; ++i)
 	{
-		indirect_fat_cluster_list[i] = readLE<uint32_t>(sb_page, 76 + i * 4);
+		indirect_fat_cluster_list[i] = readLE<uint32_t>(sb_page, 80 + i * 4);
 	}
 
 	if (allocatable_cluster_end == 0 || allocatable_cluster_end > 1000000)
@@ -804,7 +804,7 @@ void PS2MemoryCard::Impl::write_superblock(uint32_t first_ifc, uint32_t indirect
 	}
 
 	sb[336] = 2;
-	sb[337] = 0x2B;
+	sb[337] = with_ecc ? 0x52 : 0x50;
 
 	write_page(0, sb);
 }
@@ -1780,7 +1780,10 @@ void PS2MemoryCard::saveAs(const std::string& filename, bool withEcc)
 
 			outFile.write(reinterpret_cast<const char*>(pageData.data()), pImpl->page_size);
 
-			auto spare = eccCalculatePage(pageData, static_cast<int>(pImpl->page_size));
+			uint32_t target_spare = divRoundUp(static_cast<int>(pImpl->page_size), 128) * 4;
+			auto ecc = eccCalculatePage(pageData, static_cast<int>(pImpl->page_size));
+			std::vector<uint8_t> spare(target_spare, 0);
+			std::copy(ecc.begin(), ecc.end(), spare.begin());
 			outFile.write(reinterpret_cast<const char*>(spare.data()), spare.size());
 		}
 	}

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -240,6 +240,7 @@ void MainWindow::onOpenMemoryCard()
 		ui->actionExport->setEnabled(true);
 		ui->actionFormat->setEnabled(true);
 		ui->actionSelectAll->setEnabled(true);
+		updateEccToolLabel();
 	}
 }
 
@@ -282,6 +283,7 @@ void MainWindow::onCreateMemoryCard()
 		ui->actionExport->setEnabled(true);
 		ui->actionFormat->setEnabled(true);
 		ui->actionSelectAll->setEnabled(true);
+		updateEccToolLabel();
 
 		ui->statusBar->showMessage(tr("Created %1 MB memory card").arg(sizeMB), 5000);
 	}
@@ -529,6 +531,7 @@ void MainWindow::closeCard()
 	ui->actionClose->setEnabled(false);
 	ui->actionSaveAs->setEnabled(false);
 	ui->actionEccTool->setEnabled(false);
+	ui->actionEccTool->setText(tr("Add/Remove &ECC and Save As..."));
 	ui->actionImport->setEnabled(false);
 	ui->actionExport->setEnabled(false);
 	ui->actionFormat->setEnabled(false);
@@ -607,6 +610,17 @@ void MainWindow::onEccTool()
 		QMessageBox::critical(this, tr("Error"),
 			tr("Failed to save: %1").arg(e.what()));
 	}
+}
+
+void MainWindow::updateEccToolLabel()
+{
+	if (!memoryCard)
+		return;
+
+	if (memoryCard->hasEcc())
+		ui->actionEccTool->setText(tr("Remove &ECC and Save As..."));
+	else
+		ui->actionEccTool->setText(tr("Add &ECC and Save As..."));
 }
 
 void MainWindow::onToggleAscii()

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -53,6 +53,7 @@ private slots:
 private:
 	void updateCardView();
 	void updateStatusBar();
+	void updateEccToolLabel();
 	void updateForceImportWarning();
 	void closeCard();
 	void importFileToCard(const QString& savePath, const QString& hostFilePath);

--- a/src/ui/MainWindow.ui
+++ b/src/ui/MainWindow.ui
@@ -298,13 +298,13 @@
     <iconset theme="save-fill"/>
    </property>
    <property name="text">
-    <string>Remove &amp;ECC and Save As...</string>
+    <string>Add/Remove &amp;ECC and Save As...</string>
    </property>
    <property name="statusTip">
     <string>Add or remove ECC from the memory card and save to a new file</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+S</string>
+    <string>Ctrl+Shift+E</string>
    </property>
   </action>
   <action name="actionAscii">


### PR DESCRIPTION
### Description of Changes
Fix memory card ECC (remove -> re-add) causing "Seek failed" error. Also fix superblock ifc_list read offset and card_flags. Dynamic ECC tool label.

### Rationale behind Changes
Spare was 12 bytes instead of 16, ifc_list read was off by 4 bytes 

### Suggested Testing Steps
Open card -> remove ECC -> save -> reopen -> add ECC -> save -> reopen. Should work now.

### Did you use AI to help find, test, or implement this issue or feature?
No.