### PR TITLE
Renderer/MTL: fix Metal renderer pipeline, resource handling, and cleanup

### DIFF
--- a/resources/shaders/Metal/background_vs.metal
+++ b/resources/shaders/Metal/background_vs.metal
@@ -6,7 +6,7 @@
 vertex BGVertexOutput BackgroundVSMain(BGVertexInput in [[stage_in]])
 {
     BGVertexOutput out;
-    out.position = float4(in.position, 1.0, 1.0); // Z=1.0 (max depth/back), W=1.0
+    out.position = float4(in.position, 0.0, 1.0);
     out.color = in.color;
     return out;
 }

--- a/resources/shaders/Metal/icon_ps.metal
+++ b/resources/shaders/Metal/icon_ps.metal
@@ -27,12 +27,7 @@ fragment float4 IconPSMain(
         color += lambert * scene.lightColor[i].rgb * baseColor;
     }
 
-    float alpha = in.fragColor.a;
-
-    if (push.enableAlpha != 0)
-    {
-        alpha = push.alphaOverride;
-    }
+    float alpha = (push.enableAlpha != 0) ? in.fragColor.a : push.alphaOverride;
 
     return float4(color, alpha);
 }

--- a/src/common/CocoaTools.mm
+++ b/src/common/CocoaTools.mm
@@ -48,22 +48,23 @@ bool CocoaTools::CreateMetalLayer(WindowInfo* wi)
 
 void CocoaTools::DestroyMetalLayer(WindowInfo* wi)
 {
+	if (!wi)
+		return;
+
 	if (![NSThread isMainThread])
 	{
 		dispatch_sync_f(dispatch_get_main_queue(), wi, [](void* ctx) { DestroyMetalLayer(static_cast<WindowInfo*>(ctx)); });
 		return;
 	}
 
-	NSView* view = (__bridge NSView*)wi->window_handle;
-	CAMetalLayer* layer = (__bridge_transfer CAMetalLayer*)wi->surface_handle;
-	if (!layer)
-		return;
+	void* raw_layer_handle = wi->surface_handle;
 	wi->surface_handle = nullptr;
-	if (view)
-	{
-		[view setLayer:nil];
-		[view setWantsLayer:NO];
-	}
+
+	if (!raw_layer_handle)
+		return;
+
+	// Only release the retained layer reference.
+	(void)(__bridge_transfer CAMetalLayer*)raw_layer_handle;
 }
 
 std::optional<float> CocoaTools::GetViewRefreshRate(const WindowInfo& wi)

--- a/src/common/Config.cpp
+++ b/src/common/Config.cpp
@@ -99,7 +99,11 @@ std::string Config::getRenderer() const
 	}
 	catch (...)
 	{
+#if defined(__APPLE__)
+		return "metal";
+#else
 		return "vulkan";
+#endif
 	}
 }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -157,37 +157,37 @@ if(APPLE)
             target_sources(myMCpp-core PRIVATE ${shader})
             set_source_files_properties(${shader} PROPERTIES LANGUAGE METAL)
         endforeach()
-    else()
-        set(METAL_AIR_FILES)
-        set(METALLIB_OUTPUT ${CMAKE_BINARY_DIR}/default.metallib)
-        
-        foreach(shader IN LISTS METAL_SHADERS)
-            get_filename_component(shader_name ${shader} NAME_WE)
-            set(air_file ${CMAKE_BINARY_DIR}/Metal/${shader_name}.air)
-            list(APPEND METAL_AIR_FILES ${air_file})
-            
-            add_custom_command(
-                OUTPUT ${air_file}
-                COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/Metal
-                COMMAND xcrun metal -ffast-math -std=macos-metal2.0 -target air64-apple-macos10.13
-                    $<$<NOT:$<CONFIG:Release,MinSizeRel>>:-gline-tables-only>
-                    -I ${CMAKE_SOURCE_DIR}/resources/shaders/Metal
-                    -o ${air_file} -c ${shader}
-                DEPENDS ${shader} ${CMAKE_SOURCE_DIR}/resources/shaders/Metal/IconShared.metal
-                COMMENT "Compiling Metal shader ${shader_name}"
-            )
-        endforeach()
-        
-        add_custom_command(
-            OUTPUT ${METALLIB_OUTPUT}
-            COMMAND xcrun metallib -o ${METALLIB_OUTPUT} ${METAL_AIR_FILES}
-            DEPENDS ${METAL_AIR_FILES}
-            COMMENT "Linking Metal library"
-        )
-        
-        add_custom_target(CompileMetalShaders DEPENDS ${METALLIB_OUTPUT})
-        add_dependencies(myMCpp-core CompileMetalShaders)
     endif()
+
+    set(METAL_AIR_FILES)
+    set(METALLIB_OUTPUT ${CMAKE_BINARY_DIR}/default.metallib)
+
+    foreach(shader IN LISTS METAL_SHADERS)
+        get_filename_component(shader_name ${shader} NAME_WE)
+        set(air_file ${CMAKE_BINARY_DIR}/Metal/${shader_name}.air)
+        list(APPEND METAL_AIR_FILES ${air_file})
+
+        add_custom_command(
+            OUTPUT ${air_file}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/Metal
+            COMMAND xcrun metal -ffast-math -std=macos-metal2.0 -target air64-apple-macos10.13
+                $<$<NOT:$<CONFIG:Release,MinSizeRel>>:-gline-tables-only>
+                -I ${CMAKE_SOURCE_DIR}/resources/shaders/Metal
+                -o ${air_file} -c ${shader}
+            DEPENDS ${shader} ${CMAKE_SOURCE_DIR}/resources/shaders/Metal/IconShared.metal
+            COMMENT "Compiling Metal shader ${shader_name}"
+        )
+    endforeach()
+
+    add_custom_command(
+        OUTPUT ${METALLIB_OUTPUT}
+        COMMAND xcrun metallib -o ${METALLIB_OUTPUT} ${METAL_AIR_FILES}
+        DEPENDS ${METAL_AIR_FILES}
+        COMMENT "Linking Metal library"
+    )
+
+    add_custom_target(CompileMetalShaders DEPENDS ${METALLIB_OUTPUT})
+    add_dependencies(myMCpp-core CompileMetalShaders)
 endif()
 
 target_link_libraries(myMCpp-core PRIVATE zlib)

--- a/src/core/renderer/Metal/MetalPipeline.mm
+++ b/src/core/renderer/Metal/MetalPipeline.mm
@@ -20,15 +20,35 @@ bool MetalPipeline::initialize(id<MTLDevice> device)
 	fs::path metallibPath = resourcePath / "shaders" / "Metal" / "default.metallib";
 
 	NSError* error = nil;
-	NSString* path = [NSString stringWithUTF8String:metallibPath.string().c_str()];
-	NSURL* url = [NSURL fileURLWithPath:path];
-	id<MTLLibrary> library = [device newLibraryWithURL:url error:&error];
+	id<MTLLibrary> library = nil;
+
+	if (fs::exists(metallibPath))
+	{
+		NSString* path = [NSString stringWithUTF8String:metallibPath.string().c_str()];
+		NSURL* url = [NSURL fileURLWithPath:path];
+		library = [device newLibraryWithURL:url error:&error];
+	}
 
 	if (!library)
 	{
-		Logger::error("MTL: Failed to load metallib from {}: {}",
-			metallibPath.string(),
-			[[error description] UTF8String]);
+		if (error)
+		{
+			Logger::warn("MTL: Failed to load metallib from {}: {}. Falling back to default library.",
+				metallibPath.string(),
+				[[error description] UTF8String]);
+		}
+		else
+		{
+			Logger::warn("MTL: Metallib not available at {}. Falling back to default library.", metallibPath.string());
+		}
+
+		error = nil;
+		library = [device newDefaultLibrary];
+	}
+
+	if (!library)
+	{
+		Logger::error("MTL: Failed to load shader library from metallib and default library fallback");
 		return false;
 	}
 
@@ -44,7 +64,7 @@ bool MetalPipeline::initialize(id<MTLDevice> device)
 	MTLRenderPipelineDescriptor* psoDesc = [[MTLRenderPipelineDescriptor alloc] init];
 	psoDesc.vertexFunction = vertexFunc;
 	psoDesc.fragmentFunction = fragmentFunc;
-	psoDesc.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+	psoDesc.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm_sRGB;
 	psoDesc.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
 
 	psoDesc.colorAttachments[0].blendingEnabled = YES;
@@ -52,7 +72,7 @@ bool MetalPipeline::initialize(id<MTLDevice> device)
 	psoDesc.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
 	psoDesc.colorAttachments[0].rgbBlendOperation = MTLBlendOperationAdd;
 	psoDesc.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorOne;
-	psoDesc.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+	psoDesc.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorZero;
 	psoDesc.colorAttachments[0].alphaBlendOperation = MTLBlendOperationAdd;
 
 	MTLVertexDescriptor* vertexDesc = [[MTLVertexDescriptor alloc] init];
@@ -116,7 +136,7 @@ bool MetalPipeline::createBackgroundPipeline(id<MTLDevice> device)
 	MTLRenderPipelineDescriptor* psoDesc = [[MTLRenderPipelineDescriptor alloc] init];
 	psoDesc.vertexFunction = vertexFunc;
 	psoDesc.fragmentFunction = fragmentFunc;
-	psoDesc.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+	psoDesc.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm_sRGB;
 	psoDesc.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
 
 	MTLVertexDescriptor* vertexDesc = [[MTLVertexDescriptor alloc] init];
@@ -134,9 +154,20 @@ bool MetalPipeline::createBackgroundPipeline(id<MTLDevice> device)
 	vertexDesc.layouts[0].stepFunction = MTLVertexStepFunctionPerVertex;
 
 	psoDesc.vertexDescriptor = vertexDesc;
+	psoDesc.colorAttachments[0].blendingEnabled = YES;
+	psoDesc.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorSourceAlpha;
+	psoDesc.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+	psoDesc.colorAttachments[0].rgbBlendOperation = MTLBlendOperationAdd;
+	psoDesc.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorOne;
+	psoDesc.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorZero;
+	psoDesc.colorAttachments[0].alphaBlendOperation = MTLBlendOperationAdd;
 
 	NSError* error = nil;
 	m_bgPipelineState = [device newRenderPipelineStateWithDescriptor:psoDesc error:&error];
+	if (!m_bgPipelineState)
+	{
+		Logger::error("MTL: Failed to create background pipeline state: {}", [[error description] UTF8String]);
+	}
 
 	MTLDepthStencilDescriptor* depthDesc = [[MTLDepthStencilDescriptor alloc] init];
 	depthDesc.depthCompareFunction = MTLCompareFunctionAlways;

--- a/src/core/renderer/Metal/MetalRenderer.h
+++ b/src/core/renderer/Metal/MetalRenderer.h
@@ -33,7 +33,7 @@ public:
 	void setVSync(bool enabled) override;
 
 	void setIcon(std::shared_ptr<PS2Icon::Icon> icon) override;
-	bool hasValidIcon() const override { return m_icon != nullptr; }
+	bool hasValidIcon() const override;
 
 	void setAnimationEnabled(bool enabled) override { m_animationEnabled = enabled; }
 	bool isAnimationEnabled() const override { return m_animationEnabled; }

--- a/src/core/renderer/Metal/MetalRenderer.mm
+++ b/src/core/renderer/Metal/MetalRenderer.mm
@@ -67,15 +67,16 @@ void MetalRendererImpl::updateBackgroundData(const MetalResources::FrameResource
 void MetalRendererImpl::updateVertexData(const MetalResources::FrameResources& frameRes, PS2Icon::Icon* icon,
 	bool animationEnabled, std::chrono::steady_clock::time_point animStart, uint32_t& vertexCount)
 {
+	float duration = icon ? static_cast<float>(icon->getFrameLength()) : 1.0f;
 	float time = AnimationUtils::computeAnimationTime(
 		std::chrono::duration<double>(std::chrono::steady_clock::now() - animStart).count(),
-		icon ? static_cast<float>(icon->getFrameLength()) : 1.0f,
+		duration,
 		icon ? icon->getAnimSpeed() : 1.0f);
 
 	std::unordered_map<uint32_t, float> weights;
-	if (icon && animationEnabled)
+	if (icon && animationEnabled && icon->getAnimationShapes() > 1 && icon->getFrameCount() > 0)
 	{
-		weights = AnimationUtils::computeShapeWeights(icon, time, icon ? static_cast<float>(icon->getFrameCount()) : 1.0f);
+		weights = AnimationUtils::computeShapeWeights(icon, time, duration);
 	}
 	else
 	{
@@ -118,7 +119,7 @@ void MetalRendererImpl::updateUniformData(const MetalResources::FrameResources& 
 }
 
 MetalRenderer::MetalRenderer(const WindowInfo& windowInfo, Config* config)
-	: m_initialized(false), m_windowInfo(windowInfo), m_vertexCount(0), m_frameCount(0), m_frameIndex(0), m_icon(nullptr), m_animationEnabled(true), m_iconChanged(false), m_animStart(std::chrono::steady_clock::now()), m_config(config)
+	: m_initialized(false), m_windowInfo(windowInfo), m_vertexCount(0), m_frameCount(0), m_frameIndex(0), m_icon(nullptr), m_animationEnabled(true), m_iconChanged(false), m_animStart(std::chrono::steady_clock::now()), m_config(config), m_impl(std::make_unique<MetalRendererImpl>())
 {
 	m_camera.applyMode();
 	m_lighting.applyMode();
@@ -127,6 +128,7 @@ MetalRenderer::MetalRenderer(const WindowInfo& windowInfo, Config* config)
 
 MetalRenderer::~MetalRenderer()
 {
+	RendererFactory::unregisterRenderer(this);
 	shutdown();
 }
 
@@ -134,6 +136,12 @@ bool MetalRenderer::initialize()
 {
 	if (m_initialized)
 		return true;
+
+	if (!m_impl)
+	{
+		Logger::error("MTL: Internal renderer state was not created");
+		return false;
+	}
 
 	if (!m_impl->device.initialize())
 	{
@@ -149,7 +157,7 @@ bool MetalRenderer::initialize()
 
 	m_impl->metalLayer = (__bridge CAMetalLayer*)m_windowInfo.surface_handle;
 	m_impl->metalLayer.device = m_impl->device.getDevice();
-	m_impl->metalLayer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+	m_impl->metalLayer.pixelFormat = MTLPixelFormatBGRA8Unorm_sRGB;
 	m_impl->metalLayer.framebufferOnly = YES;
 
 	if (!m_impl->pipeline.initialize(m_impl->device.getDevice()))
@@ -172,13 +180,18 @@ bool MetalRenderer::initialize()
 
 	resize(m_windowInfo.surface_width, m_windowInfo.surface_height);
 
+	if (m_config)
+	{
+		setVSync(m_config->getVSync());
+	}
+
 	m_initialized = true;
 	return true;
 }
 
 void MetalRenderer::shutdown()
 {
-	if (m_initialized)
+	if (m_initialized && m_impl)
 	{
 		CocoaTools::DestroyMetalLayer(&m_windowInfo);
 		m_impl->resources.shutdown();
@@ -199,9 +212,14 @@ void MetalRenderer::setIcon(std::shared_ptr<PS2Icon::Icon> icon)
 	}
 }
 
+bool MetalRenderer::hasValidIcon() const
+{
+	return m_icon && m_icon->isValid();
+}
+
 void MetalRenderer::render()
 {
-	if (!m_initialized || !m_impl->metalLayer)
+	if (!m_initialized || !m_impl || !m_impl->metalLayer || !hasValidIcon())
 		return;
 
 	dispatch_semaphore_wait(m_impl->resources.getSemaphore(m_frameIndex), DISPATCH_TIME_FOREVER);
@@ -242,7 +260,20 @@ void MetalRenderer::render()
 	}
 
 	id<MTLCommandBuffer> commandBuffer = [m_impl->device.getCommandQueue() commandBuffer];
+	if (!commandBuffer)
+	{
+		dispatch_semaphore_signal(m_impl->resources.getSemaphore(m_frameIndex));
+		Logger::error("MTL: Failed to acquire command buffer");
+		return;
+	}
+
 	id<MTLRenderCommandEncoder> encoder = [commandBuffer renderCommandEncoderWithDescriptor:passDesc];
+	if (!encoder)
+	{
+		dispatch_semaphore_signal(m_impl->resources.getSemaphore(m_frameIndex));
+		Logger::error("MTL: Failed to create render command encoder");
+		return;
+	}
 
 	if (m_background.shouldRender && m_impl->pipeline.getBackgroundPipelineState())
 	{
@@ -257,6 +288,7 @@ void MetalRenderer::render()
 	{
 		[encoder setRenderPipelineState:m_impl->pipeline.getPipelineState()];
 		[encoder setDepthStencilState:m_impl->pipeline.getDepthStencilState()];
+		[encoder setFrontFacingWinding:MTLWindingCounterClockwise];
 		[encoder setCullMode:MTLCullModeBack];
 
 		[encoder setVertexBuffer:frameRes.uniformBuffer offset:0 atIndex:0];
@@ -274,6 +306,7 @@ void MetalRenderer::render()
 		if (m_impl->resources.getTexture())
 		{
 			[encoder setFragmentTexture:m_impl->resources.getTexture() atIndex:0];
+			[encoder setFragmentSamplerState:m_impl->resources.getSamplerState() atIndex:0];
 		}
 
 		[encoder drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:m_vertexCount];
@@ -298,11 +331,24 @@ void MetalRenderer::resize(uint32_t width, uint32_t height)
 {
 	m_windowInfo.surface_width = width;
 	m_windowInfo.surface_height = height;
+
+	if (!m_impl)
+		return;
+
 	if (m_impl->metalLayer)
 	{
 		m_impl->metalLayer.drawableSize = CGSizeMake(width, height);
 	}
-	m_impl->resources.createDepthTexture(m_impl->device.getDevice(), width, height);
+
+	if (width == 0 || height == 0)
+	{
+		return;
+	}
+
+	if (!m_impl->resources.createDepthTexture(m_impl->device.getDevice(), width, height))
+	{
+		Logger::error("MTL: Failed to create depth texture {}x{}", width, height);
+	}
 }
 
 void MetalRenderer::setRotation(float x, float y, float z) { m_camera.setRotation(x, y, z); }
@@ -325,10 +371,10 @@ void MetalRenderer::setBackgroundColor(float r, float g, float b, float a) { m_b
 
 void MetalRenderer::setVSync(bool enabled)
 {
-	if (m_impl->metalLayer && [m_impl->metalLayer respondsToSelector:@selector(setDisplaySyncEnabled:)])
+	if (m_impl && m_impl->metalLayer && [m_impl->metalLayer respondsToSelector:@selector(setDisplaySyncEnabled:)])
 	{
-		[m_impl->metalLayer setDisplaySyncEnabled:YES];
-		Logger::info("MTL: VSync set to {}", "enabled");
+		[m_impl->metalLayer setDisplaySyncEnabled:(enabled ? YES : NO)];
+		Logger::info("MTL: VSync set to {}", enabled ? "enabled" : "disabled");
 
 		if (m_config)
 		{

--- a/src/core/renderer/Metal/MetalResources.h
+++ b/src/core/renderer/Metal/MetalResources.h
@@ -22,6 +22,7 @@ public:
 
 	void uploadTexture(id<MTLDevice> device, const uint8_t* rgbaData, uint32_t width, uint32_t height);
 	id<MTLTexture> getTexture() const { return m_texture; }
+	id<MTLSamplerState> getSamplerState() const { return m_samplerState; }
 
 	bool createDepthTexture(id<MTLDevice> device, uint32_t width, uint32_t height);
 	id<MTLTexture> getDepthTexture() const { return m_depthTexture; }
@@ -39,6 +40,7 @@ public:
 
 private:
 	id<MTLTexture> m_texture = nil;
+	id<MTLSamplerState> m_samplerState = nil;
 	id<MTLTexture> m_depthTexture = nil;
 
 	std::array<dispatch_semaphore_t, kMaxFramesInFlight> m_renderSemaphores;

--- a/src/core/renderer/Metal/MetalResources.mm
+++ b/src/core/renderer/Metal/MetalResources.mm
@@ -2,6 +2,14 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "MetalResources.h"
+#include "../Common/RendererCommon.h"
+
+namespace
+{
+	constexpr size_t kMaxVertexBufferBytes = 4 * 1024 * 1024;
+	constexpr size_t kUniformBufferBytes = sizeof(UniformBufferUtils::UniformBufferData);
+	constexpr size_t kBackgroundBufferBytes = 4 * (2 * sizeof(float) + 4 * sizeof(uint8_t));
+} // namespace
 
 MetalResources::MetalResources()
 {
@@ -16,23 +24,31 @@ bool MetalResources::initialize(id<MTLDevice> device)
 {
 	for (int i = 0; i < kMaxFramesInFlight; i++)
 	{
-		m_renderSemaphores[i] = dispatch_semaphore_create(kMaxFramesInFlight);
+		m_renderSemaphores[i] = dispatch_semaphore_create(1);
 	}
-
-	const size_t MAX_VERTICES_SIZE = 65536;
-	const size_t UBO_SIZE = 1024;  // Matrices + Lighting
-	const size_t BG_SIZE = 4 * 32; // 4 verts * stride (approx)
 
 	for (int i = 0; i < kMaxFramesInFlight; i++)
 	{
-		m_frames[i].vertexBuffer = [device newBufferWithLength:MAX_VERTICES_SIZE options:MTLResourceStorageModeShared];
-		m_frames[i].uniformBuffer = [device newBufferWithLength:UBO_SIZE options:MTLResourceStorageModeShared];
-		m_frames[i].backgroundBuffer = [device newBufferWithLength:BG_SIZE options:MTLResourceStorageModeShared];
+		m_frames[i].vertexBuffer = [device newBufferWithLength:kMaxVertexBufferBytes options:MTLResourceStorageModeShared];
+		m_frames[i].uniformBuffer = [device newBufferWithLength:kUniformBufferBytes options:MTLResourceStorageModeShared];
+		m_frames[i].backgroundBuffer = [device newBufferWithLength:kBackgroundBufferBytes options:MTLResourceStorageModeShared];
 
 		if (!m_frames[i].vertexBuffer || !m_frames[i].uniformBuffer || !m_frames[i].backgroundBuffer)
 		{
 			return false;
 		}
+	}
+
+	MTLSamplerDescriptor* samplerDesc = [[MTLSamplerDescriptor alloc] init];
+	samplerDesc.minFilter = MTLSamplerMinMagFilterLinear;
+	samplerDesc.magFilter = MTLSamplerMinMagFilterLinear;
+	samplerDesc.sAddressMode = MTLSamplerAddressModeClampToEdge;
+	samplerDesc.tAddressMode = MTLSamplerAddressModeClampToEdge;
+	m_samplerState = [device newSamplerStateWithDescriptor:samplerDesc];
+
+	if (!m_samplerState)
+	{
+		return false;
 	}
 
 	return true;
@@ -41,6 +57,7 @@ bool MetalResources::initialize(id<MTLDevice> device)
 void MetalResources::shutdown()
 {
 	m_texture = nil;
+	m_samplerState = nil;
 	m_depthTexture = nil;
 	for (int i = 0; i < kMaxFramesInFlight; i++)
 	{
@@ -53,6 +70,12 @@ void MetalResources::shutdown()
 
 bool MetalResources::createDepthTexture(id<MTLDevice> device, uint32_t width, uint32_t height)
 {
+	if (!device || width == 0 || height == 0)
+	{
+		m_depthTexture = nil;
+		return false;
+	}
+
 	MTLTextureDescriptor* depthDesc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatDepth32Float
 																						 width:width
 																						height:height
@@ -66,11 +89,22 @@ bool MetalResources::createDepthTexture(id<MTLDevice> device, uint32_t width, ui
 
 void MetalResources::uploadTexture(id<MTLDevice> device, const uint8_t* rgbaData, uint32_t width, uint32_t height)
 {
-	MTLTextureDescriptor* texDesc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA8Unorm
+	if (!device || !rgbaData || width == 0 || height == 0)
+	{
+		return;
+	}
+
+	MTLTextureDescriptor* texDesc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA8Unorm_sRGB
 																					   width:width
 																					  height:height
 																				   mipmapped:NO];
+	texDesc.usage = MTLTextureUsageShaderRead;
 	m_texture = [device newTextureWithDescriptor:texDesc];
+
+	if (!m_texture)
+	{
+		return;
+	}
 
 	MTLRegion region = MTLRegionMake2D(0, 0, width, height);
 	[m_texture replaceRegion:region mipmapLevel:0 withBytes:rgbaData bytesPerRow:width * 4];


### PR DESCRIPTION
### Description of Changes
- Improved Metal renderer stability, lifecycle handling, and resource safety.
- Switched Metal render/texture paths to sRGB and adjusted blending/alpha behavior to have more parity with Vulkan/OpenGL.

### Rationale behind Changes
- Fixes reliability issues in init/render/shutdown edge cases.
- Improves visual correctness (color space + blending).
- Makes Metal startup/build paths more robust on macOS.

### Did you use AI to help find, test, or implement this issue or feature?
No.