### PR TITLE
Qt: Add camera controls to IconWidget

### DIFF
--- a/src/ui/widgets/IconWidget.cpp
+++ b/src/ui/widgets/IconWidget.cpp
@@ -6,6 +6,8 @@
 #include "../../common/Logger.h"
 #include "../common/WindowInfo.h"
 #include <QResizeEvent>
+#include <QMouseEvent>
+#include <QWheelEvent>
 #if defined(__linux__)
 #include <qpa/qplatformnativeinterface.h>
 #endif
@@ -127,7 +129,9 @@ bool IconWidget::loadIcon(const std::vector<uint8_t>& iconData)
 		m_icon = std::make_shared<PS2Icon::Icon>();
 		if (!m_icon->load(iconData))
 		{
-			emit iconLoadFailed(QString::fromStdString(m_icon->getError()));
+			QString err = QString::fromStdString(m_icon->getError());
+			m_icon.reset();
+			emit iconLoadFailed(err);
 			return false;
 		}
 
@@ -190,6 +194,8 @@ bool IconWidget::isAnimationEnabled() const
 
 void IconWidget::setRotation(float x, float y, float z)
 {
+	m_rotX = x;
+	m_rotY = y;
 	ensureRenderer();
 	if (m_renderer)
 	{
@@ -200,12 +206,36 @@ void IconWidget::setRotation(float x, float y, float z)
 
 void IconWidget::setZoom(float zoom)
 {
+	m_zoom = std::clamp(zoom, 0.1f, 10.0f);
 	ensureRenderer();
 	if (m_renderer)
 	{
-		m_renderer->setZoom(zoom);
+		m_renderer->setZoom(m_zoom);
 		renderFrame();
 	}
+}
+
+void IconWidget::resetCamera()
+{
+	m_rotX = 0.0f;
+	m_rotY = 0.0f;
+	m_zoom = 1.0f;
+	ensureRenderer();
+	if (m_renderer)
+	{
+		m_renderer->resetCamera();
+		renderFrame();
+	}
+}
+
+void IconWidget::zoomIn()
+{
+	setZoom(m_zoom - 0.2f);
+}
+
+void IconWidget::zoomOut()
+{
+	setZoom(m_zoom + 0.2f);
 }
 
 void IconWidget::setLightingFromIconSys(PS2IconSys* iconSys)
@@ -452,6 +482,63 @@ void IconWidget::renderFrame()
 		qWarning() << "IconWidget: render exception, recreating renderer:" << e.what();
 		recreateRenderer();
 	}
+}
+
+void IconWidget::mousePressEvent(QMouseEvent* event)
+{
+	if (event->button() == Qt::LeftButton)
+	{
+		m_dragging = true;
+		m_lastDragPos = event->pos();
+	}
+	QWidget::mousePressEvent(event);
+}
+
+void IconWidget::mouseMoveEvent(QMouseEvent* event)
+{
+	if (m_dragging && (event->buttons() & Qt::LeftButton))
+	{
+		const QPoint delta = event->pos() - m_lastDragPos;
+		m_lastDragPos = event->pos();
+		m_rotY += static_cast<float>(delta.x()) * 0.005f;
+		m_rotX += static_cast<float>(delta.y()) * 0.005f;
+		ensureRenderer();
+		if (m_renderer)
+		{
+			m_renderer->setRotation(m_rotX, m_rotY, 0.0f);
+			renderFrame();
+		}
+	}
+	QWidget::mouseMoveEvent(event);
+}
+
+void IconWidget::mouseReleaseEvent(QMouseEvent* event)
+{
+	if (event->button() == Qt::LeftButton)
+		m_dragging = false;
+	QWidget::mouseReleaseEvent(event);
+}
+
+void IconWidget::wheelEvent(QWheelEvent* event)
+{
+	const float steps = static_cast<float>(event->angleDelta().y()) / 120.0f;
+	setZoom(m_zoom - steps * 0.15f);
+	event->accept();
+}
+
+QSize IconWidget::sizeHint() const
+{
+	return QSize(256, 256);
+}
+
+bool IconWidget::hasHeightForWidth() const
+{
+	return true;
+}
+
+int IconWidget::heightForWidth(int w) const
+{
+	return w;
 }
 
 void IconWidget::timerEvent(QTimerEvent* event)

--- a/src/ui/widgets/IconWidget.h
+++ b/src/ui/widgets/IconWidget.h
@@ -37,6 +37,10 @@ public:
 	void startRendering();
 	void stopRendering();
 
+	void resetCamera();
+	void zoomIn();
+	void zoomOut();
+
 	Renderer* getRenderer() const { return m_renderer.get(); }
 
 signals:
@@ -44,10 +48,17 @@ signals:
 	void iconLoadFailed(const QString& error);
 
 protected:
+	QSize sizeHint() const override;
+	bool hasHeightForWidth() const override;
+	int heightForWidth(int w) const override;
 	void timerEvent(QTimerEvent* event) override;
 	void resizeEvent(QResizeEvent* event) override;
 	void showEvent(QShowEvent* event) override;
 	QPaintEngine* paintEngine() const override;
+	void mousePressEvent(QMouseEvent* event) override;
+	void mouseMoveEvent(QMouseEvent* event) override;
+	void mouseReleaseEvent(QMouseEvent* event) override;
+	void wheelEvent(QWheelEvent* event) override;
 
 private:
 	void printPlatformInfo();
@@ -60,4 +71,9 @@ private:
 	std::unique_ptr<Renderer> m_renderer;
 	QBasicTimer m_renderTimer;
 	bool m_renderLoopEnabled = false;
+	float m_rotX = 0.0f;
+	float m_rotY = 0.0f;
+	float m_zoom = 1.0f;
+	QPoint m_lastDragPos;
+	bool m_dragging = false;
 };

--- a/src/ui/widgets/SaveDetailsPanel.cpp
+++ b/src/ui/widgets/SaveDetailsPanel.cpp
@@ -4,6 +4,7 @@
 #include "SaveDetailsPanel.h"
 #include "IconWidget.h"
 #include "Config.h"
+#include <QStyle>
 #include "ps2mc.h"
 #include "ps2iconsys.h"
 #include "TranslationManager.h"
@@ -25,6 +26,31 @@ SaveDetailsPanel::SaveDetailsPanel(QWidget* parent)
 
 	connect(&TranslationManager::instance(), &TranslationManager::languageChanged, this, [this]() {
 		ui->retranslateUi(this);
+	});
+
+	connect(ui->playPauseButton, &QPushButton::clicked, this, [this]() {
+		if (!iconWidget)
+			return;
+		iconWidget->setAnimationEnabled(!iconWidget->isAnimationEnabled());
+		updatePlayPauseButton();
+	});
+
+	connect(ui->resetViewButton, &QPushButton::clicked, this, [this]() {
+		if (!iconWidget)
+			return;
+		iconWidget->resetCamera();
+	});
+
+	connect(ui->zoomInButton, &QPushButton::clicked, this, [this]() {
+		if (!iconWidget)
+			return;
+		iconWidget->zoomIn();
+	});
+
+	connect(ui->zoomOutButton, &QPushButton::clicked, this, [this]() {
+		if (!iconWidget)
+			return;
+		iconWidget->zoomOut();
 	});
 
 	this->hide();
@@ -139,6 +165,7 @@ void SaveDetailsPanel::setSave(PS2MemoryCard* card, const QString& savePath,
 
 				iconWidget->setRotation(0.0f, 0.0f, 0.0f);
 				iconWidget->setZoom(1.0f);
+				updatePlayPauseButton();
 				return;
 			}
 			else
@@ -147,7 +174,7 @@ void SaveDetailsPanel::setSave(PS2MemoryCard* card, const QString& savePath,
 			}
 		}
 	}
-	catch (const std::exception& e)
+	catch (const std::exception&)
 	{
 		if (iconWidget)
 			iconWidget->hide();
@@ -157,6 +184,7 @@ void SaveDetailsPanel::setSave(PS2MemoryCard* card, const QString& savePath,
 		if (iconWidget)
 			iconWidget->hide();
 	}
+	updatePlayPauseButton();
 }
 
 void SaveDetailsPanel::clear()
@@ -169,9 +197,28 @@ void SaveDetailsPanel::clear()
 		ui->detailsLabel->setText(tr("No details available"));
 	if (iconWidget)
 		iconWidget->hide();
+	updatePlayPauseButton();
 	currentCard = nullptr;
 	currentSavePath.clear();
 	this->hide();
+}
+
+void SaveDetailsPanel::updatePlayPauseButton()
+{
+	const bool visible = iconWidget && iconWidget->isVisible();
+	ui->playPauseButton->setVisible(visible);
+	ui->resetViewButton->setVisible(visible);
+	ui->zoomInButton->setVisible(visible);
+	ui->zoomOutButton->setVisible(visible);
+	if (!visible)
+		return;
+
+	const bool animating = iconWidget->isAnimationEnabled();
+	ui->playPauseButton->setIcon(
+		style()->standardIcon(animating ? QStyle::SP_MediaPause : QStyle::SP_MediaPlay));
+	ui->playPauseButton->setToolTip(
+		animating ? tr("Pause animation") : tr("Play animation"));
+	ui->resetViewButton->setIcon(style()->standardIcon(QStyle::SP_BrowserReload));
 }
 
 void SaveDetailsPanel::createIconWidget()
@@ -189,9 +236,11 @@ void SaveDetailsPanel::createIconWidget()
 	else
 		m_lastRendererType = "vulkan";
 
-	iconWidget->setMinimumSize(256, 256);
-	iconWidget->setMaximumSize(256, 256);
-	ui->iconLayout->addWidget(iconWidget);
+	iconWidget->setMinimumSize(128, 128);
+	QSizePolicy sp(QSizePolicy::Expanding, QSizePolicy::MinimumExpanding);
+	sp.setHeightForWidth(true);
+	iconWidget->setSizePolicy(sp);
+	ui->iconLayout->insertWidget(0, iconWidget);
 	iconWidget->hide();
 }
 

--- a/src/ui/widgets/SaveDetailsPanel.h
+++ b/src/ui/widgets/SaveDetailsPanel.h
@@ -28,6 +28,7 @@ public:
 
 private:
 	void createIconWidget();
+	void updatePlayPauseButton();
 
 	Config* m_config;
 	IconWidget* iconWidget;

--- a/src/ui/widgets/SaveDetailsPanel.ui
+++ b/src/ui/widgets/SaveDetailsPanel.ui
@@ -33,6 +33,118 @@
         </property>
        </widget>
       </item>
+      <item>
+       <layout class="QHBoxLayout" name="iconControlsLayout">
+        <item>
+         <spacer name="iconControlsLeftSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="playPauseButton">
+          <property name="visible">
+           <bool>false</bool>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>Pause animation</string>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>80</width>
+            <height>24</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="resetViewButton">
+          <property name="visible">
+           <bool>false</bool>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>Reset view</string>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>80</width>
+            <height>24</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="zoomInButton">
+          <property name="visible">
+           <bool>false</bool>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+          <property name="text">
+           <string>+</string>
+          </property>
+          <property name="toolTip">
+           <string>Zoom in</string>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>28</width>
+            <height>24</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="zoomOutButton">
+          <property name="visible">
+           <bool>false</bool>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+          <property name="text">
+           <string>−</string>
+          </property>
+          <property name="toolTip">
+           <string>Zoom out</string>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>28</width>
+            <height>24</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="iconControlsRightSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
### Description of Changes
Allows camera to be moved with mouse or buttons below the icon widget

### Rationale behind Changes
Because being able to move the camera with your mouse seems like a pretty good QoL improvement to me

### Did you use AI to help find, test, or implement this issue or feature?
No