### PR TITLE
Qt: Allow locking toolbar to not move

### DIFF
--- a/src/common/Config.cpp
+++ b/src/common/Config.cpp
@@ -380,6 +380,23 @@ void Config::setAsciiMode(bool enabled)
 	m_config["ui"]["ascii_mode"] = enabled;
 }
 
+bool Config::getToolbarLocked() const
+{
+	try
+	{
+		return m_config["ui"]["toolbar_locked"].get<bool>();
+	}
+	catch (...)
+	{
+		return false;
+	}
+}
+
+void Config::setToolbarLocked(bool locked)
+{
+	m_config["ui"]["toolbar_locked"] = locked;
+}
+
 bool Config::getForceImport() const
 {
 	try
@@ -585,6 +602,7 @@ void Config::createDefaults()
 		{"ui", {{"theme", "dark"},
 				   {"thumbnail_size", 64},
 				   {"ascii_mode", false},
+				   {"toolbar_locked", false},
 				   {"language", "en"}}},
 		{"behavior", {{"warn_on_delete", true},
 						 {"hide_to_tray", false},
@@ -644,6 +662,8 @@ void Config::ensureKeys()
 		m_config["ui"]["thumbnail_size"] = 64;
 	if (!m_config["ui"].contains("ascii_mode"))
 		m_config["ui"]["ascii_mode"] = false;
+	if (!m_config["ui"].contains("toolbar_locked"))
+		m_config["ui"]["toolbar_locked"] = false;
 	if (!m_config["ui"].contains("language"))
 		m_config["ui"]["language"] = "en";
 

--- a/src/common/Config.h
+++ b/src/common/Config.h
@@ -70,6 +70,9 @@ public:
 	bool getAsciiMode() const;
 	void setAsciiMode(bool enabled);
 
+	bool getToolbarLocked() const;
+	void setToolbarLocked(bool locked);
+
 	bool getForceImport() const;
 	void setForceImport(bool enabled);
 	bool getDiscordRPCEnabled() const;

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -81,6 +81,21 @@ MainWindow::MainWindow(Config* config, QWidget* parent)
 	ui->actionForceImport->setChecked(m_config ? m_config->getForceImport() : false);
 	connect(ui->actionForceImport, &QAction::triggered, this, &MainWindow::onToggleForceImport);
 
+	if (m_config)
+	{
+		const bool toolbarLocked = m_config->getToolbarLocked();
+		ui->actionLockToolbar->setChecked(toolbarLocked);
+		ui->mainToolBar->setMovable(!toolbarLocked);
+		ui->mainToolBar->setFloatable(!toolbarLocked);
+	}
+	else
+	{
+		ui->mainToolBar->setMovable(true);
+		ui->mainToolBar->setFloatable(true);
+	}
+
+	connect(ui->actionLockToolbar, &QAction::triggered, this, &MainWindow::onToggleToolbarLock);
+
 	ui->actionAbout->setMenuRole(QAction::AboutRole);
 	ui->actionPreferences->setText(tr("Settings..."));
 	ui->actionPreferences->setMenuRole(QAction::PreferencesRole);
@@ -1025,6 +1040,24 @@ void MainWindow::onToggleForceImport()
 		m_config->save();
 		updateForceImportWarning();
 	}
+}
+
+void MainWindow::onToggleToolbarLock()
+{
+	if (!m_config)
+		return;
+
+	const bool newValue = !m_config->getToolbarLocked();
+	m_config->setToolbarLocked(newValue);
+	ui->actionLockToolbar->setChecked(newValue);
+
+	if (ui->mainToolBar)
+	{
+		ui->mainToolBar->setMovable(!newValue);
+		ui->mainToolBar->setFloatable(!newValue);
+	}
+
+	m_config->save();
 }
 
 void MainWindow::importFileToCard(const QString& savePath, const QString& hostFilePath)

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -42,6 +42,7 @@ private slots:
 	void onEccTool();
 	void onToggleAscii();
 	void onToggleForceImport();
+	void onToggleToolbarLock();
 	void onPreferences();
 	void onAbout();
 	void onGitHubRepository();

--- a/src/ui/MainWindow.ui
+++ b/src/ui/MainWindow.ui
@@ -88,6 +88,8 @@
     <addaction name="actionAscii"/>
     <addaction name="actionForceImport"/>
     <addaction name="separator"/>
+    <addaction name="actionLockToolbar"/>
+    <addaction name="separator"/>
     <addaction name="actionPreferences"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
@@ -348,6 +350,17 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+F</string>
+   </property>
+  </action>
+  <action name="actionLockToolbar">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Lock Toolbar</string>
+   </property>
+   <property name="statusTip">
+    <string>Prevent the main toolbar from being moved or floated</string>
    </property>
   </action>
   <action name="actionPreferences">


### PR DESCRIPTION
### Description of Changes
Adds option to lock the toolbar 

### Rationale behind Changes
Because some people don't want to let their toolbar be moved

### Did you use AI to help find, test, or implement this issue or feature?
Yes