### PR TITLE
Formats/Qt: Fix mass export remove dead code and add file names dialog

### DIFF
--- a/src/core/formats/ps2iconsys.cpp
+++ b/src/core/formats/ps2iconsys.cpp
@@ -6,32 +6,6 @@
 #include "sjis.h"
 #include <cstring>
 
-namespace
-{
-
-	uint32_t readLEu32(const uint8_t* ptr)
-	{
-		return (static_cast<uint32_t>(ptr[3]) << 24) |
-		       (static_cast<uint32_t>(ptr[2]) << 16) |
-		       (static_cast<uint32_t>(ptr[1]) << 8) |
-		       (static_cast<uint32_t>(ptr[0]));
-	}
-
-} // namespace
-
-struct IconSysHeader
-{
-	uint16_t unknown1;
-	uint16_t unknown2;
-	uint32_t animCount;
-	uint32_t animSpeed;
-	uint32_t animLoopCount;
-	uint32_t unknown3;
-	// Followed by animation speed entries (animCount * 2 bytes each)
-	// Then title entries
-	// Then icon data
-};
-
 class PS2IconSys::Impl
 {
 public:
@@ -76,16 +50,16 @@ public:
 		};
 
 		titleLineOffset = static_cast<uint16_t>((ptr[0x06] << 8) | ptr[0x07]);
-		bgTransparency = static_cast<float>(ptr[0x0C]) / 128.0f;
+		bgTransparency = static_cast<float>(ptr[0x0C]) / 255.0f;
 
 		for (int i = 0; i < 4; ++i)
 		{
 			size_t offset = 0x10 + (i * 16);
-			// Each color channel is stored as a uint32 (only low byte used), 0x00-0x80 range
-			bgColors[i].r = static_cast<float>(ptr[offset + 0]) / 128.0f;
-			bgColors[i].g = static_cast<float>(ptr[offset + 4]) / 128.0f;
-			bgColors[i].b = static_cast<float>(ptr[offset + 8]) / 128.0f;
-			bgColors[i].a = static_cast<float>(ptr[offset + 12]) / 128.0f;
+			// background colors stored as uint32[4] (RGBA), each channel 0–255 in low byte
+			bgColors[i].r = static_cast<float>(ptr[offset + 0]) / 255.0f;
+			bgColors[i].g = static_cast<float>(ptr[offset + 4]) / 255.0f;
+			bgColors[i].b = static_cast<float>(ptr[offset + 8]) / 255.0f;
+			bgColors[i].a = static_cast<float>(ptr[offset + 12]) / 255.0f;
 		}
 
 		for (int i = 0; i < 3; ++i)

--- a/src/core/formats/ps2mc.cpp
+++ b/src/core/formats/ps2mc.cpp
@@ -1636,17 +1636,18 @@ void PS2MemoryCard::exportSaveFile(const std::string& savePath, PS2SaveFile& sav
 				continue;
 			}
 
-			// Only export files, not subdirectories
-			if (entry.mode & DF_FILE)
+			if (entry.mode & DF_DIR)
 			{
-				PS2SaveEntry fileEntry;
-				fileEntry.dirEntry = entry;
-
-				std::string filePath = savePath + "/" + entry.name;
-				fileEntry.data = readFile(filePath);
-
-				entries.push_back(fileEntry);
+				continue;
 			}
+
+			PS2SaveEntry fileEntry;
+			fileEntry.dirEntry = entry;
+
+			std::string filePath = savePath + "/" + entry.name;
+			fileEntry.data = readFile(filePath);
+
+			entries.push_back(fileEntry);
 		}
 
 		// Set the save title from icon.sys if available

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -10,6 +10,7 @@ set(UI_SOURCES
     dialogs/NewCardDialog.cpp
     Settings/SettingsWidget.cpp
     dialogs/AboutDialog.cpp
+    dialogs/ExportSavesDialog.cpp
     Settings/GeneralSettingsWidget.cpp
     Settings/GraphicsSettingsWidget.cpp
     Settings/FilesSettingsWidget.cpp
@@ -29,6 +30,7 @@ set(UI_HEADERS
     dialogs/NewCardDialog.h
     Settings/SettingsWidget.h
     dialogs/AboutDialog.h
+    dialogs/ExportSavesDialog.h
     Settings/GeneralSettingsWidget.h
     Settings/GraphicsSettingsWidget.h
     Settings/FilesSettingsWidget.h

--- a/src/ui/CardActionHandler.cpp
+++ b/src/ui/CardActionHandler.cpp
@@ -143,12 +143,13 @@ void CardActionHandler::importSave(PS2MemoryCard* card, const QString& filename)
 	}
 }
 
-void CardActionHandler::exportSave(PS2MemoryCard* card, const QString& savePath, const QString& outputFilename)
+bool CardActionHandler::exportSave(PS2MemoryCard* card, const QString& savePath, const QString& outputFilename, bool showSuccessDialog)
 {
 	if (!card)
 	{
-		QMessageBox::warning(parentWidget, tr("Warning"), tr("No memory card open"));
-		return;
+		if (showSuccessDialog)
+			QMessageBox::warning(parentWidget, tr("Warning"), tr("No memory card open"));
+		return false;
 	}
 
 	try
@@ -158,24 +159,24 @@ void CardActionHandler::exportSave(PS2MemoryCard* card, const QString& savePath,
 
 		SaveFormat format = PS2SaveFile::detectFormat(outputFilename.toStdString());
 		if (format == SaveFormat::UNKNOWN)
-		{
-			format = SaveFormat::EMS; // Default to .psu
-		}
+			format = SaveFormat::EMS;
 
 		saveFile.save(outputFilename.toStdString(), format);
 
-		QMessageBox::information(parentWidget, tr("Success"),
-			tr("Successfully exported save to:\n%1").arg(outputFilename));
-
-		if (statusBar)
+		if (showSuccessDialog)
 		{
-			statusBar->showMessage(tr("Exported: %1").arg(savePath), 3000);
+			QMessageBox::information(parentWidget, tr("Success"),
+				tr("Successfully exported save to:\n%1").arg(outputFilename));
 		}
+		if (statusBar && showSuccessDialog)
+			statusBar->showMessage(tr("Exported: %1").arg(savePath), 3000);
+		return true;
 	}
 	catch (const std::exception& e)
 	{
-		QMessageBox::critical(parentWidget, tr("Error"),
-			tr("Failed to export save: %1").arg(e.what()));
+		if (showSuccessDialog)
+			QMessageBox::critical(parentWidget, tr("Error"), tr("Failed to export save: %1").arg(e.what()));
+		return false;
 	}
 }
 

--- a/src/ui/CardActionHandler.h
+++ b/src/ui/CardActionHandler.h
@@ -22,7 +22,7 @@ public:
 	void closeCard();
 
 	void importSave(PS2MemoryCard* card, const QString& filename);
-	void exportSave(PS2MemoryCard* card, const QString& savePath, const QString& filename);
+	bool exportSave(PS2MemoryCard* card, const QString& savePath, const QString& filename, bool showSuccessDialog = true);
 	void deleteSave(PS2MemoryCard* card, const QString& savePath);
 	void formatCard(PS2MemoryCard* card, const QString& cardPath, int sizeMB = 8);
 

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -7,6 +7,7 @@
 #include "CardActionHandler.h"
 #include "NewCardDialog.h"
 #include "dialogs/AboutDialog.h"
+#include "dialogs/ExportSavesDialog.h"
 #include "ps2mc.h"
 #include "Settings/SettingsWindow.h"
 #include "DiscordRPCManager.h"
@@ -151,16 +152,19 @@ MainWindow::MainWindow(Config* config, QWidget* parent)
 		if (!memoryCard)
 			return;
 
-		QString filename = QFileDialog::getSaveFileName(
-			this,
-			tr("Export Save"),
-			"",
-			tr("EMS/PSU Format (*.psu);;MAX Drive Format (*.max);;All Files (*.*)"));
+		ExportSavesDialog nameDialog({savePath}, this);
+		if (nameDialog.exec() != QDialog::Accepted)
+			return;
 
-		if (!filename.isEmpty())
-		{
-			actionHandler->exportSave(memoryCard.get(), savePath, filename);
-		}
+		QStringList filenames = nameDialog.getFilenames();
+		if (filenames.isEmpty())
+			return;
+		QString suggestedName = filenames[0];
+		QString filter = suggestedName.endsWith(QLatin1String(".max"), Qt::CaseInsensitive) ? tr("MAX Drive Format (*.max);;EMS/PSU Format (*.psu);;All Files (*.*)") : tr("EMS/PSU Format (*.psu);;MAX Drive Format (*.max);;All Files (*.*)");
+		QString path = QFileDialog::getSaveFileName(this, tr("Export Save"),
+			QDir::homePath() + QLatin1Char('/') + suggestedName, filter);
+		if (!path.isEmpty())
+			actionHandler->exportSave(memoryCard.get(), savePath, path);
 	});
 
 	connect(ui->cardBrowser, &MemoryCardBrowser::exportFileRequested, this, [this](const QString& savePath, const QString& fileName) {
@@ -258,6 +262,11 @@ MainWindow::MainWindow(Config* config, QWidget* parent)
 		if (!memoryCard || savePaths.isEmpty())
 			return;
 
+		ExportSavesDialog nameDialog(savePaths, this);
+		if (nameDialog.exec() != QDialog::Accepted)
+			return;
+
+		QStringList filenames = nameDialog.getFilenames();
 		QString targetDir = QFileDialog::getExistingDirectory(
 			this,
 			tr("Export Selected Saves"),
@@ -267,17 +276,40 @@ MainWindow::MainWindow(Config* config, QWidget* parent)
 			return;
 
 		QDir dir(targetDir);
-		for (const QString& savePath : savePaths)
+		QStringList existing;
+		for (int i = 0; i < savePaths.size() && i < filenames.size(); ++i)
 		{
-			QString baseName = QFileInfo(savePath).fileName();
-			if (baseName.isEmpty())
-				continue;
-
-			QString outputPath = dir.filePath(baseName + ".psu");
-			actionHandler->exportSave(memoryCard.get(), savePath, outputPath);
+			if (!filenames[i].isEmpty() && QFileInfo(dir, filenames[i]).exists())
+				existing.append(filenames[i]);
+		}
+		if (!existing.isEmpty())
+		{
+			QMessageBox::StandardButton reply = QMessageBox::question(this, tr("Overwrite Files"),
+				tr("%1 file(s) already exist in the folder. Overwrite?").arg(existing.size()),
+				QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+			if (reply == QMessageBox::No)
+				return;
 		}
 
-		ui->statusBar->showMessage(tr("Exported %1 saves").arg(savePaths.size()), 5000);
+		int ok = 0, failed = 0;
+		QStringList failedNames;
+		for (int i = 0; i < savePaths.size() && i < filenames.size(); ++i)
+		{
+			if (filenames[i].isEmpty())
+				continue;
+			QString outputPath = dir.filePath(filenames[i]);
+			if (actionHandler->exportSave(memoryCard.get(), savePaths[i], outputPath, false))
+				++ok;
+			else
+			{
+				++failed;
+				failedNames.append(filenames[i]);
+			}
+		}
+
+		if (failed > 0)
+			QMessageBox::warning(this, tr("Export"), tr("Exported %1 save(s); %2 failed:\n%3").arg(ok).arg(failed).arg(failedNames.join("\n")));
+		ui->statusBar->showMessage(failed == 0 ? tr("Exported %1 saves").arg(ok) : tr("Exported %1, %2 failed").arg(ok).arg(failed), 5000);
 	});
 
 	connect(ui->cardBrowser, &MemoryCardBrowser::deleteMultipleSavesRequested, this, [this](const QStringList& savePaths) {

--- a/src/ui/dialogs/ExportSavesDialog.cpp
+++ b/src/ui/dialogs/ExportSavesDialog.cpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2025-2026 SternXD
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "ExportSavesDialog.h"
+#include "ui_ExportSavesDialog.h"
+#include <QFileInfo>
+#include <QMessageBox>
+
+static const char* const PSU_EXT = ".psu";
+static const char* const MAX_EXT = ".max";
+
+ExportSavesDialog::ExportSavesDialog(const QStringList& savePaths, QWidget* parent)
+	: QDialog(parent)
+	, ui(new Ui::ExportSavesDialog)
+{
+	ui->setupUi(this);
+	ui->formatCombo->addItem(tr("PSU (.psu)"), QVariant(QLatin1String(PSU_EXT)));
+	ui->formatCombo->addItem(tr("MAX (.max)"), QVariant(QLatin1String(MAX_EXT)));
+	connect(ui->formatCombo, &QComboBox::currentIndexChanged, this, [this]() {
+		QString ext = ui->formatCombo->currentData().toString();
+		for (int i = 0; i < ui->tableWidget->rowCount(); ++i)
+		{
+			QTableWidgetItem* item = ui->tableWidget->item(i, 1);
+			if (!item)
+				continue;
+			QString name = item->text();
+			if (name.endsWith(QLatin1String(PSU_EXT), Qt::CaseInsensitive) || name.endsWith(QLatin1String(MAX_EXT), Qt::CaseInsensitive))
+			{
+				QString base = name.left(name.lastIndexOf(QLatin1Char('.')));
+				if (base.isEmpty())
+					base = ui->tableWidget->item(i, 0)->text();
+				item->setText(base + ext);
+			}
+		}
+	});
+
+	ui->tableWidget->horizontalHeader()->setStretchLastSection(true);
+	ui->tableWidget->setRowCount(savePaths.size());
+	QString ext = ui->formatCombo->currentData().toString();
+
+	for (int i = 0; i < savePaths.size(); ++i)
+	{
+		QString path = savePaths[i];
+		QString displayName = path;
+		if (displayName.startsWith('/'))
+			displayName.remove(0, 1);
+		QString defaultName = QFileInfo(path).fileName() + ext;
+
+		QTableWidgetItem* pathItem = new QTableWidgetItem(displayName);
+		pathItem->setFlags(pathItem->flags() & ~Qt::ItemIsEditable);
+		ui->tableWidget->setItem(i, 0, pathItem);
+
+		QTableWidgetItem* nameItem = new QTableWidgetItem(defaultName);
+		ui->tableWidget->setItem(i, 1, nameItem);
+	}
+
+	ui->tableWidget->resizeColumnsToContents();
+}
+
+ExportSavesDialog::~ExportSavesDialog() = default;
+
+QStringList ExportSavesDialog::getFilenames() const
+{
+	QString ext = ui->formatCombo->currentData().toString();
+	QStringList out;
+	for (int i = 0; i < ui->tableWidget->rowCount(); ++i)
+	{
+		QString name = ui->tableWidget->item(i, 1)->text().trimmed();
+		if (name.isEmpty())
+			name = ui->tableWidget->item(i, 0)->text() + ext;
+		else if (!name.contains(QLatin1Char('.')))
+			name += ext;
+		out.append(QFileInfo(name).fileName());
+	}
+	return out;
+}
+
+void ExportSavesDialog::accept()
+{
+	QStringList names = getFilenames();
+	QSet<QString> seen;
+	QStringList dups;
+	for (const QString& n : names)
+	{
+		if (seen.contains(n))
+			dups.append(n);
+		else
+			seen.insert(n);
+	}
+	if (!dups.isEmpty())
+	{
+		QString list = dups.join(QStringLiteral(", "));
+		QMessageBox::StandardButton reply = QMessageBox::question(this, tr("Duplicate Filenames"),
+			tr("Some filenames are used more than once. Later files will overwrite earlier ones:\n\n%1\n\nContinue?").arg(list),
+			QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+		if (reply != QMessageBox::Yes)
+			return;
+	}
+	QDialog::accept();
+}
+
+void ExportSavesDialog::retranslateFormatCombo()
+{
+	int idx = ui->formatCombo->currentIndex();
+	ui->formatCombo->clear();
+	ui->formatCombo->addItem(tr("PSU (.psu)"), QVariant(QLatin1String(PSU_EXT)));
+	ui->formatCombo->addItem(tr("MAX (.max)"), QVariant(QLatin1String(MAX_EXT)));
+	ui->formatCombo->setCurrentIndex(idx == 1 ? 1 : 0);
+}
+
+void ExportSavesDialog::changeEvent(QEvent* event)
+{
+	if (event->type() == QEvent::LanguageChange && ui)
+	{
+		ui->retranslateUi(this);
+		retranslateFormatCombo();
+	}
+	QDialog::changeEvent(event);
+}

--- a/src/ui/dialogs/ExportSavesDialog.h
+++ b/src/ui/dialogs/ExportSavesDialog.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025-2026 SternXD
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include <QDialog>
+
+namespace Ui
+{
+	class ExportSavesDialog;
+}
+
+class ExportSavesDialog : public QDialog
+{
+	Q_OBJECT
+
+public:
+	explicit ExportSavesDialog(const QStringList& savePaths, QWidget* parent = nullptr);
+	~ExportSavesDialog();
+	QStringList getFilenames() const;
+
+protected:
+	void changeEvent(QEvent* event) override;
+	void accept() override;
+
+private:
+	void retranslateFormatCombo();
+	std::unique_ptr<Ui::ExportSavesDialog> ui;
+};

--- a/src/ui/dialogs/ExportSavesDialog.ui
+++ b/src/ui/dialogs/ExportSavesDialog.ui
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ExportSavesDialog</class>
+ <widget class="QDialog" name="ExportSavesDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>520</width>
+    <height>360</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>500</width>
+    <height>300</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Export File Names</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="introLabel">
+     <property name="text">
+      <string>Edit export filenames (folder name by default):</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="formatLayout">
+     <item>
+      <widget class="QLabel" name="formatLabel">
+       <property name="text">
+        <string>Export format:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="formatCombo"/>
+     </item>
+     <item>
+      <spacer name="formatSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="tableWidget">
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectItems</enum>
+     </property>
+     <column>
+      <property name="text">
+       <string>Save</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Export filename</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ExportSavesDialog</receiver>
+   <slot>accept()</slot>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ExportSavesDialog</receiver>
+   <slot>reject()</slot>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/ui.vcxproj
+++ b/src/ui/ui.vcxproj
@@ -212,6 +212,7 @@
     <ClCompile Include="dialogs\NewCardDialog.cpp" />
     <ClCompile Include="Settings\SettingsWidget.cpp" />
     <ClCompile Include="dialogs\AboutDialog.cpp" />
+    <ClCompile Include="dialogs\ExportSavesDialog.cpp" />
     <ClCompile Include="Settings\GeneralSettingsWidget.cpp" />
     <ClCompile Include="Settings\GraphicsSettingsWidget.cpp" />
     <ClCompile Include="Settings\FilesSettingsWidget.cpp" />
@@ -230,6 +231,7 @@
     <QtMoc Include="dialogs\NewCardDialog.h" />
     <QtMoc Include="Settings\SettingsWidget.h" />
     <QtMoc Include="dialogs\AboutDialog.h" />
+    <QtMoc Include="dialogs\ExportSavesDialog.h" />
     <QtMoc Include="Settings\GeneralSettingsWidget.h" />
     <QtMoc Include="Settings\GraphicsSettingsWidget.h" />
     <QtMoc Include="Settings\FilesSettingsWidget.h" />
@@ -244,6 +246,7 @@
     <QtUic Include="Settings\GraphicsSettingsWidget.ui" />
     <QtUic Include="Settings\SettingsWindow.ui" />
     <QtUic Include="dialogs\AboutDialog.ui" />
+    <QtUic Include="dialogs\ExportSavesDialog.ui" />
     <QtUic Include="dialogs\NewCardDialog.ui" />
     <QtUic Include="widgets\MemoryCardBrowser.ui" />
     <QtUic Include="widgets\SaveDetailsPanel.ui" />

--- a/src/ui/ui.vcxproj.filters
+++ b/src/ui/ui.vcxproj.filters
@@ -62,6 +62,9 @@
     <ClCompile Include="dialogs\AboutDialog.cpp">
       <Filter>src\dialogs</Filter>
     </ClCompile>
+    <ClCompile Include="dialogs\ExportSavesDialog.cpp">
+      <Filter>src\dialogs</Filter>
+    </ClCompile>
     <ClCompile Include="Settings\GeneralSettingsWidget.cpp">
       <Filter>src\Settings</Filter>
     </ClCompile>
@@ -110,6 +113,9 @@
       <Filter>headers\Settings</Filter>
     </QtMoc>
     <QtMoc Include="dialogs\AboutDialog.h">
+      <Filter>headers\dialogs</Filter>
+    </QtMoc>
+    <QtMoc Include="dialogs\ExportSavesDialog.h">
       <Filter>headers\dialogs</Filter>
     </QtMoc>
     <QtMoc Include="Settings\GeneralSettingsWidget.h">
@@ -162,6 +168,9 @@
       <Filter>ui\Settings</Filter>
     </QtUic>
     <QtUic Include="dialogs\AboutDialog.ui">
+      <Filter>ui\dialogs</Filter>
+    </QtUic>
+    <QtUic Include="dialogs\ExportSavesDialog.ui">
       <Filter>ui\dialogs</Filter>
     </QtUic>
     <QtUic Include="dialogs\NewCardDialog.ui">


### PR DESCRIPTION
### Description of Changes
- Drops some dead code normalize bg colors 0-255 
- Fix in export some dirs were treated as files
- Add dedicated dialog to let the user pick psu/max and names etc

### Rationale behind Changes
Bug fixes and QoL fixes 

### Suggested Testing Steps
See if in export dirs are still being treated as files

### Related Issues / Links
Fixes #32 
Fixes #33 

### Did you use AI to help find, test, or implement this issue or feature?
No