### PR TITLE
Formats: Treat .psu as EMS and tolerate PSU subdirs

### DIFF
--- a/src/core/formats/ps2save.cpp
+++ b/src/core/formats/ps2save.cpp
@@ -3,6 +3,7 @@
 // PS2 save container handling (MAX/EMS/SharkPort/CodeBreaker/PSV) follows the mymc++ / mymc implementations and PS2 save format documentation.
 
 #include "ps2save.h"
+#include "Logger.h"
 #include "round.h"
 #include "lzari.h"
 #include "sjis.h"
@@ -179,7 +180,11 @@ SaveFormat PS2SaveFile::detectFormat(const std::string& filename)
 		std::string ext = filename.substr(dotPos);
 		std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
 
-		if (ext == ".psu" || ext == ".max")
+		if (ext == ".psu")
+		{
+			return SaveFormat::EMS;
+		}
+		if (ext == ".max")
 		{
 			return SaveFormat::MAX_DRIVE;
 		}
@@ -773,7 +778,11 @@ void PS2SaveFile::Impl::loadEms(std::ifstream& file)
 		auto entRaw = readFixed(file, PS2MC_DIRENT_LENGTH);
 		auto ent = unpackDirEntry(entRaw);
 		if (!modeIsFile(ent.mode))
-			throw PS2SaveError("Subdir in PSU");
+		{
+			const std::string name = ent.name.empty() ? std::string("<unnamed>") : ent.name;
+			Logger::warn("Skipping subdir (entry {}): {}", i, name);
+			continue;
+		}
 		auto data = readFixed(file, ent.length);
 		size_t pad = roundUp(static_cast<int>(ent.length), 1024) - ent.length;
 		if (pad)


### PR DESCRIPTION
### Description of Changes
- Treat .psu as EMS/PSU instead of MAX.
- Allow PSU import to skip subdir entries, logging which ones were skipped.

### Rationale behind Changes
Fixes PSU imports that previously failed or misdetected.

### Suggested Testing Steps
Import wLE/psuPaste PSU.
Export a PSU from a save, then re-import it.

### Related Issues / Links
Fixes #36
Fixes #37

### Did you use AI to help find, test, or implement this issue or feature?
No 