### PR TITLE
Renderer/Vulkan: fix validation errors and modernize API usage

### DIFF
--- a/src/core/renderer/Vulkan/VulkanDevice.cpp
+++ b/src/core/renderer/Vulkan/VulkanDevice.cpp
@@ -23,6 +23,21 @@
 #include "Logger.h"
 #include <vector>
 
+#ifndef NDEBUG
+static VKAPI_ATTR VkBool32 VKAPI_CALL vulkanDebugCallback(VkDebugUtilsMessageSeverityFlagEXT severity,
+	VkDebugUtilsMessageTypeFlagsEXT /*type*/, const VkDebugUtilsMessengerCallbackDataEXT* data, void* /*ud*/)
+{
+	if (data && data->pMessage)
+	{
+		if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
+			Logger::error("VK validation: {}", data->pMessage);
+		else if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
+			Logger::warn("VK validation: {}", data->pMessage);
+	}
+	return VK_FALSE;
+}
+#endif
+
 VulkanDevice::VulkanDevice() = default;
 
 VulkanDevice::~VulkanDevice()
@@ -62,6 +77,16 @@ void VulkanDevice::destroy()
 	}
 	if (m_instance != VK_NULL_HANDLE)
 	{
+#ifndef NDEBUG
+		if (m_debugMessenger != VK_NULL_HANDLE)
+		{
+			auto destroyFn = reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(
+				vkGetInstanceProcAddr(m_instance, "vkDestroyDebugUtilsMessengerEXT"));
+			if (destroyFn)
+				destroyFn(m_instance, m_debugMessenger, nullptr);
+			m_debugMessenger = VK_NULL_HANDLE;
+		}
+#endif
 		vkDestroyInstance(m_instance, nullptr);
 		m_instance = VK_NULL_HANDLE;
 	}
@@ -95,6 +120,10 @@ bool VulkanDevice::createInstance()
 		VK_KHR_XLIB_SURFACE_EXTENSION_NAME,
 		VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME,
 #endif
+#ifndef NDEBUG
+		,
+		VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
+#endif
 	};
 
 	VkInstanceCreateInfo createInfo{};
@@ -103,11 +132,46 @@ bool VulkanDevice::createInstance()
 	createInfo.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
 	createInfo.ppEnabledExtensionNames = extensions.data();
 
+#ifndef NDEBUG
+	const char* layers[] = {"VK_LAYER_KHRONOS_validation"};
+	createInfo.enabledLayerCount = 1;
+	createInfo.ppEnabledLayerNames = layers;
+
+	VkDebugUtilsMessengerCreateInfoEXT dbgInfo{};
+	dbgInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+	dbgInfo.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+	                          VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+	dbgInfo.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
+	                      VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
+	                      VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+	dbgInfo.pfnUserCallback = vulkanDebugCallback;
+	createInfo.pNext = &dbgInfo;
+#endif
+
 	if (vkCreateInstance(&createInfo, nullptr, &m_instance) != VK_SUCCESS)
 	{
 		Logger::error("VK: Failed to create Vulkan instance");
 		return false;
 	}
+
+#ifndef NDEBUG
+	{
+		auto createFn = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(
+			vkGetInstanceProcAddr(m_instance, "vkCreateDebugUtilsMessengerEXT"));
+		if (createFn)
+		{
+			VkDebugUtilsMessengerCreateInfoEXT dbgCreate{};
+			dbgCreate.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+			dbgCreate.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+			                            VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+			dbgCreate.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
+			                        VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
+			                        VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+			dbgCreate.pfnUserCallback = vulkanDebugCallback;
+			createFn(m_instance, &dbgCreate, nullptr, &m_debugMessenger);
+		}
+	}
+#endif
 
 	return true;
 }
@@ -255,18 +319,25 @@ bool VulkanDevice::selectPhysicalDevice()
 
 	for (const auto& device : devices)
 	{
-		VkPhysicalDeviceProperties props;
-		vkGetPhysicalDeviceProperties(device, &props);
+		VkPhysicalDeviceProperties2 props2{};
+		props2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+		vkGetPhysicalDeviceProperties2(device, &props2);
+		const VkPhysicalDeviceProperties& props = props2.properties;
 
 		uint32_t queueFamilyCount = 0;
-		vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
+		vkGetPhysicalDeviceQueueFamilyProperties2(device, &queueFamilyCount, nullptr);
 
-		std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
-		vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
+		std::vector<VkQueueFamilyProperties2> queueFamilies(queueFamilyCount);
+		for (uint32_t q = 0; q < queueFamilyCount; ++q)
+		{
+			queueFamilies[q].sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2;
+			queueFamilies[q].pNext = nullptr;
+		}
+		vkGetPhysicalDeviceQueueFamilyProperties2(device, &queueFamilyCount, queueFamilies.data());
 
 		for (uint32_t i = 0; i < queueFamilyCount; ++i)
 		{
-			if (queueFamilies[i].queueFlags & VK_QUEUE_GRAPHICS_BIT)
+			if (queueFamilies[i].queueFamilyProperties.queueFlags & VK_QUEUE_GRAPHICS_BIT)
 			{
 				VkBool32 presentSupport = false;
 				vkGetPhysicalDeviceSurfaceSupportKHR(device, i, m_surface, &presentSupport);
@@ -295,16 +366,18 @@ bool VulkanDevice::createLogicalDevice()
 	float queuePriority = 1.0f;
 	queueCreateInfo.pQueuePriorities = &queuePriority;
 
-	VkPhysicalDeviceFeatures deviceFeatures{};
+	VkPhysicalDeviceFeatures2 features2{};
+	features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+	vkGetPhysicalDeviceFeatures2(m_physicalDevice, &features2);
 
 	std::vector<const char*> extensions = {
 		VK_KHR_SWAPCHAIN_EXTENSION_NAME};
 
 	VkDeviceCreateInfo createInfo{};
 	createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+	createInfo.pNext = &features2;
 	createInfo.queueCreateInfoCount = 1;
 	createInfo.pQueueCreateInfos = &queueCreateInfo;
-	createInfo.pEnabledFeatures = &deviceFeatures;
 	createInfo.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
 	createInfo.ppEnabledExtensionNames = extensions.data();
 
@@ -334,8 +407,10 @@ bool VulkanDevice::createLogicalDevice()
 
 uint32_t VulkanDevice::findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties) const
 {
-	VkPhysicalDeviceMemoryProperties memProperties;
-	vkGetPhysicalDeviceMemoryProperties(m_physicalDevice, &memProperties);
+	VkPhysicalDeviceMemoryProperties2 memProperties2{};
+	memProperties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
+	vkGetPhysicalDeviceMemoryProperties2(m_physicalDevice, &memProperties2);
+	const VkPhysicalDeviceMemoryProperties& memProperties = memProperties2.memoryProperties;
 
 	for (uint32_t i = 0; i < memProperties.memoryTypeCount; ++i)
 	{

--- a/src/core/renderer/Vulkan/VulkanDevice.h
+++ b/src/core/renderer/Vulkan/VulkanDevice.h
@@ -47,4 +47,7 @@ private:
 #ifdef __linux__
 	void* m_platformDisplay = nullptr; // Display* on Linux/X11
 #endif
+#ifndef NDEBUG
+	VkDebugUtilsMessengerEXT m_debugMessenger = VK_NULL_HANDLE;
+#endif
 };

--- a/src/core/renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/core/renderer/Vulkan/VulkanRenderer.cpp
@@ -100,7 +100,8 @@ bool VulkanRenderer::initialize()
 	if (!m_vulkanResources.createBackgroundVertexBuffer(m_vulkanDevice))
 		return false;
 
-	if (!m_vulkanResources.createSyncObjects(m_vulkanDevice.getDevice()))
+	if (!m_vulkanResources.createSyncObjects(m_vulkanDevice.getDevice(),
+			static_cast<uint32_t>(m_vulkanSwapchain.getImages().size())))
 		return false;
 
 	if (!createCommandBuffers())
@@ -325,6 +326,13 @@ void VulkanRenderer::resize(uint32_t width, uint32_t height)
 	m_imagesInFlight.clear();
 	m_imagesInFlight.resize(m_vulkanSwapchain.getImages().size(), VK_NULL_HANDLE);
 
+	if (!m_vulkanResources.recreateRenderFinishedSemaphores(m_vulkanDevice.getDevice(),
+			static_cast<uint32_t>(m_vulkanSwapchain.getImages().size())))
+	{
+		Logger::error("VK: Failed to recreate render-finished semaphores after resize");
+		return;
+	}
+
 	if (!createCommandBuffers())
 	{
 		Logger::error("VK: Failed to recreate command buffers");
@@ -429,6 +437,44 @@ void VulkanRenderer::prepareVertexData()
 	vkUnmapMemory(device, m_vertexMemory);
 
 	Logger::debug("VK: Vertex buffer created (host-visible) for animation updates");
+}
+
+void VulkanRenderer::writeDescriptorSets()
+{
+	if (m_descriptorSet == VK_NULL_HANDLE || m_uniformBuffer == VK_NULL_HANDLE || m_textureView == VK_NULL_HANDLE)
+		return;
+
+	VkDevice device = m_vulkanDevice.getDevice();
+	const VkDeviceSize uboSize = 320;
+
+	VkDescriptorBufferInfo bufferDescInfo{};
+	bufferDescInfo.buffer = m_uniformBuffer;
+	bufferDescInfo.offset = 0;
+	bufferDescInfo.range = uboSize;
+
+	VkDescriptorImageInfo imageDescInfo{};
+	imageDescInfo.sampler = m_textureSampler;
+	imageDescInfo.imageView = m_textureView;
+	imageDescInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+	VkWriteDescriptorSet descriptorWrites[2]{};
+	descriptorWrites[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+	descriptorWrites[0].dstSet = m_descriptorSet;
+	descriptorWrites[0].dstBinding = 0;
+	descriptorWrites[0].dstArrayElement = 0;
+	descriptorWrites[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+	descriptorWrites[0].descriptorCount = 1;
+	descriptorWrites[0].pBufferInfo = &bufferDescInfo;
+
+	descriptorWrites[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+	descriptorWrites[1].dstSet = m_descriptorSet;
+	descriptorWrites[1].dstBinding = 1;
+	descriptorWrites[1].dstArrayElement = 0;
+	descriptorWrites[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+	descriptorWrites[1].descriptorCount = 1;
+	descriptorWrites[1].pImageInfo = &imageDescInfo;
+
+	vkUpdateDescriptorSets(device, 2, descriptorWrites, 0, nullptr);
 }
 
 void VulkanRenderer::updateUniformBuffer()
@@ -603,38 +649,7 @@ void VulkanRenderer::updateUniformBuffer()
 		descriptorWrites[1].descriptorCount = 1;
 		descriptorWrites[1].pImageInfo = &imageDescInfo;
 
-		vkUpdateDescriptorSets(device, 2, descriptorWrites, 0, nullptr);
-	}
-	else if (m_descriptorSet != VK_NULL_HANDLE && m_textureView != VK_NULL_HANDLE)
-	{
-		VkDescriptorBufferInfo bufferDescInfo{};
-		bufferDescInfo.buffer = m_uniformBuffer;
-		bufferDescInfo.offset = 0;
-		bufferDescInfo.range = uboSize;
-
-		VkDescriptorImageInfo imageDescInfo{};
-		imageDescInfo.sampler = m_textureSampler;
-		imageDescInfo.imageView = m_textureView;
-		imageDescInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-
-		VkWriteDescriptorSet descriptorWrites[2]{};
-		descriptorWrites[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-		descriptorWrites[0].dstSet = m_descriptorSet;
-		descriptorWrites[0].dstBinding = 0;
-		descriptorWrites[0].dstArrayElement = 0;
-		descriptorWrites[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-		descriptorWrites[0].descriptorCount = 1;
-		descriptorWrites[0].pBufferInfo = &bufferDescInfo;
-
-		descriptorWrites[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-		descriptorWrites[1].dstSet = m_descriptorSet;
-		descriptorWrites[1].dstBinding = 1;
-		descriptorWrites[1].dstArrayElement = 0;
-		descriptorWrites[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-		descriptorWrites[1].descriptorCount = 1;
-		descriptorWrites[1].pImageInfo = &imageDescInfo;
-
-		vkUpdateDescriptorSets(device, 2, descriptorWrites, 0, nullptr);
+		writeDescriptorSets();
 	}
 
 	void* data;
@@ -773,6 +788,7 @@ bool VulkanRenderer::uploadTexture()
 	}
 	Logger::debug("VK: Texture image view created, calling updateUniformBuffer");
 
+	writeDescriptorSets();
 	updateUniformBuffer();
 
 	vkDestroyBuffer(device, stagingBuffer, nullptr);
@@ -874,7 +890,10 @@ bool VulkanRenderer::createCommandBuffers()
 		renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());
 		renderPassInfo.pClearValues = clearValues.data();
 
-		vkCmdBeginRenderPass(m_commandBuffers[i], &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+		VkSubpassBeginInfo subpassBegin{};
+		subpassBegin.sType = VK_STRUCTURE_TYPE_SUBPASS_BEGIN_INFO;
+		subpassBegin.contents = VK_SUBPASS_CONTENTS_INLINE;
+		vkCmdBeginRenderPass2(m_commandBuffers[i], &renderPassInfo, &subpassBegin);
 
 		VkBuffer bgBuffer = m_vulkanResources.getBackgroundVertexBuffer();
 		if (m_background.shouldRender && m_vulkanPipeline.getBackgroundPipeline() != VK_NULL_HANDLE && bgBuffer != VK_NULL_HANDLE)
@@ -919,7 +938,9 @@ bool VulkanRenderer::createCommandBuffers()
 			vkCmdDraw(m_commandBuffers[i], m_vertexCount, 1, 0, 0);
 		}
 
-		vkCmdEndRenderPass(m_commandBuffers[i]);
+		VkSubpassEndInfo subpassEnd{};
+		subpassEnd.sType = VK_STRUCTURE_TYPE_SUBPASS_END_INFO;
+		vkCmdEndRenderPass2(m_commandBuffers[i], &subpassEnd);
 
 		if (vkEndCommandBuffer(m_commandBuffers[i]) != VK_SUCCESS)
 		{
@@ -948,7 +969,6 @@ void VulkanRenderer::submitFrame()
 
 		VkFence fence = m_vulkanResources.getInFlightFence(m_currentFrame);
 		VkSemaphore imageAvailable = m_vulkanResources.getImageAvailableSemaphore(m_currentFrame);
-		VkSemaphore renderFinished = m_vulkanResources.getRenderFinishedSemaphore(m_currentFrame);
 		vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
 
 		uint32_t imageIndex;
@@ -965,6 +985,8 @@ void VulkanRenderer::submitFrame()
 			Logger::error("VK: Failed to acquire next image: {}", static_cast<int>(result));
 			return;
 		}
+
+		VkSemaphore renderFinished = m_vulkanResources.getRenderFinishedSemaphore(imageIndex);
 
 		if (m_imagesInFlight[imageIndex] != VK_NULL_HANDLE)
 		{
@@ -1023,13 +1045,31 @@ void VulkanRenderer::submitFrame()
 
 void VulkanRenderer::setVSync(bool enabled)
 {
-	if (m_vulkanDevice.getDevice() != VK_NULL_HANDLE)
-	{
-		m_vulkanSwapchain.setVSync(m_vulkanDevice, enabled);
+	if (m_vulkanDevice.getDevice() == VK_NULL_HANDLE || !m_initialized)
+		return;
 
-		if (m_config)
+	VkDevice device = m_vulkanDevice.getDevice();
+	if (m_vulkanSwapchain.setVSync(m_vulkanDevice, enabled))
+	{
+		vkDeviceWaitIdle(device);
+		m_imagesInFlight.clear();
+		m_imagesInFlight.resize(m_vulkanSwapchain.getImages().size(), VK_NULL_HANDLE);
+		if (!m_vulkanResources.recreateRenderFinishedSemaphores(device,
+				static_cast<uint32_t>(m_vulkanSwapchain.getImages().size())))
 		{
-			m_config->setVSync(enabled);
+			Logger::error("VK: Failed to recreate render-finished semaphores after VSync change");
 		}
+		if (!m_commandBuffers.empty())
+		{
+			vkFreeCommandBuffers(device, m_vulkanResources.getCommandPool(),
+				static_cast<uint32_t>(m_commandBuffers.size()), m_commandBuffers.data());
+			m_commandBuffers.clear();
+		}
+		if (!createCommandBuffers())
+			Logger::error("VK: Failed to recreate command buffers after VSync change");
+		m_iconChanged = true;
 	}
+
+	if (m_config)
+		m_config->setVSync(enabled);
 }

--- a/src/core/renderer/Vulkan/VulkanRenderer.h
+++ b/src/core/renderer/Vulkan/VulkanRenderer.h
@@ -105,6 +105,7 @@ private:
 
 	bool createCommandBuffers();
 	bool uploadTexture();
+	void writeDescriptorSets();
 	void updateBackgroundVertexData();
 
 	void prepareVertexData();

--- a/src/core/renderer/Vulkan/VulkanResources.cpp
+++ b/src/core/renderer/Vulkan/VulkanResources.cpp
@@ -28,7 +28,37 @@ bool VulkanResources::createCommandPool(VkDevice device, uint32_t queueFamily)
 	return true;
 }
 
-bool VulkanResources::createSyncObjects(VkDevice device)
+bool VulkanResources::recreateRenderFinishedSemaphores(VkDevice device, uint32_t swapchainImageCount)
+{
+	for (VkSemaphore s : m_renderFinishedSemaphores)
+	{
+		if (s != VK_NULL_HANDLE)
+			vkDestroySemaphore(device, s, nullptr);
+	}
+	m_renderFinishedSemaphores.clear();
+	m_renderFinishedSemaphores.resize(swapchainImageCount);
+
+	VkSemaphoreCreateInfo semaphoreInfo{};
+	semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+
+	for (uint32_t i = 0; i < swapchainImageCount; ++i)
+	{
+		if (vkCreateSemaphore(device, &semaphoreInfo, nullptr, &m_renderFinishedSemaphores[i]) != VK_SUCCESS)
+		{
+			Logger::error("VK: Failed to create render-finished semaphore {}", i);
+			for (uint32_t j = 0; j < i; ++j)
+			{
+				vkDestroySemaphore(device, m_renderFinishedSemaphores[j], nullptr);
+				m_renderFinishedSemaphores[j] = VK_NULL_HANDLE;
+			}
+			m_renderFinishedSemaphores.clear();
+			return false;
+		}
+	}
+	return true;
+}
+
+bool VulkanResources::createSyncObjects(VkDevice device, uint32_t swapchainImageCount)
 {
 	VkSemaphoreCreateInfo semaphoreInfo{};
 	semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
@@ -40,13 +70,15 @@ bool VulkanResources::createSyncObjects(VkDevice device)
 	for (uint32_t i = 0; i < MAX_FRAMES_IN_FLIGHT; ++i)
 	{
 		if (vkCreateSemaphore(device, &semaphoreInfo, nullptr, &m_imageAvailableSemaphores[i]) != VK_SUCCESS ||
-			vkCreateSemaphore(device, &semaphoreInfo, nullptr, &m_renderFinishedSemaphores[i]) != VK_SUCCESS ||
 			vkCreateFence(device, &fenceInfo, nullptr, &m_inFlightFences[i]) != VK_SUCCESS)
 		{
 			Logger::error("VK: Failed to create synchronization objects for frame {}", i);
 			return false;
 		}
 	}
+
+	if (!recreateRenderFinishedSemaphores(device, swapchainImageCount))
+		return false;
 
 	VkFenceCreateInfo singleTimeFenceInfo{};
 	singleTimeFenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
@@ -72,17 +104,19 @@ void VulkanResources::destroy(VkDevice device)
 		m_singleTimeFence = VK_NULL_HANDLE;
 	}
 
+	for (VkSemaphore s : m_renderFinishedSemaphores)
+	{
+		if (s != VK_NULL_HANDLE)
+			vkDestroySemaphore(device, s, nullptr);
+	}
+	m_renderFinishedSemaphores.clear();
+
 	for (uint32_t i = 0; i < MAX_FRAMES_IN_FLIGHT; ++i)
 	{
 		if (m_inFlightFences[i] != VK_NULL_HANDLE)
 		{
 			vkDestroyFence(device, m_inFlightFences[i], nullptr);
 			m_inFlightFences[i] = VK_NULL_HANDLE;
-		}
-		if (m_renderFinishedSemaphores[i] != VK_NULL_HANDLE)
-		{
-			vkDestroySemaphore(device, m_renderFinishedSemaphores[i], nullptr);
-			m_renderFinishedSemaphores[i] = VK_NULL_HANDLE;
 		}
 		if (m_imageAvailableSemaphores[i] != VK_NULL_HANDLE)
 		{

--- a/src/core/renderer/Vulkan/VulkanResources.h
+++ b/src/core/renderer/Vulkan/VulkanResources.h
@@ -6,6 +6,7 @@
 #include <vulkan/vulkan.h>
 #include <cstdint>
 #include <array>
+#include <vector>
 #include "Logger.h"
 
 class VulkanDevice;
@@ -44,7 +45,8 @@ public:
 	VulkanResources& operator=(const VulkanResources&) = delete;
 
 	bool createCommandPool(VkDevice device, uint32_t queueFamily);
-	bool createSyncObjects(VkDevice device);
+	bool createSyncObjects(VkDevice device, uint32_t swapchainImageCount);
+	bool recreateRenderFinishedSemaphores(VkDevice device, uint32_t swapchainImageCount);
 	void destroy(VkDevice device);
 
 	VkCommandBuffer beginSingleTimeCommands(VkDevice device);
@@ -64,14 +66,14 @@ public:
 
 	VkCommandPool getCommandPool() const { return m_commandPool; }
 	VkSemaphore getImageAvailableSemaphore(uint32_t frameIndex) const { return m_imageAvailableSemaphores[frameIndex]; }
-	VkSemaphore getRenderFinishedSemaphore(uint32_t frameIndex) const { return m_renderFinishedSemaphores[frameIndex]; }
+	VkSemaphore getRenderFinishedSemaphore(uint32_t imageIndex) const { return m_renderFinishedSemaphores[imageIndex]; }
 	VkFence getInFlightFence(uint32_t frameIndex) const { return m_inFlightFences[frameIndex]; }
 	VkBuffer getBackgroundVertexBuffer() const { return m_bgVertexBuffer; }
 
 private:
 	VkCommandPool m_commandPool = VK_NULL_HANDLE;
 	std::array<VkSemaphore, MAX_FRAMES_IN_FLIGHT> m_imageAvailableSemaphores{};
-	std::array<VkSemaphore, MAX_FRAMES_IN_FLIGHT> m_renderFinishedSemaphores{};
+	std::vector<VkSemaphore> m_renderFinishedSemaphores;
 	std::array<VkFence, MAX_FRAMES_IN_FLIGHT> m_inFlightFences{};
 	VkFence m_singleTimeFence = VK_NULL_HANDLE;
 

--- a/src/core/renderer/Vulkan/VulkanSwapchain.cpp
+++ b/src/core/renderer/Vulkan/VulkanSwapchain.cpp
@@ -44,21 +44,7 @@ void VulkanSwapchain::destroy(VkDevice device)
 		m_renderPass = VK_NULL_HANDLE;
 	}
 
-	if (m_depthImageView != VK_NULL_HANDLE)
-	{
-		vkDestroyImageView(device, m_depthImageView, nullptr);
-		m_depthImageView = VK_NULL_HANDLE;
-	}
-	if (m_depthImage != VK_NULL_HANDLE)
-	{
-		vkDestroyImage(device, m_depthImage, nullptr);
-		m_depthImage = VK_NULL_HANDLE;
-	}
-	if (m_depthMemory != VK_NULL_HANDLE)
-	{
-		vkFreeMemory(device, m_depthMemory, nullptr);
-		m_depthMemory = VK_NULL_HANDLE;
-	}
+	destroyDepthResources(device);
 
 	for (auto imageView : m_imageViews)
 	{
@@ -111,7 +97,7 @@ bool VulkanSwapchain::createSwapchain(VulkanDevice& device, uint32_t width, uint
 	VkPresentModeKHR presentMode = VK_PRESENT_MODE_FIFO_KHR;
 	for (const auto& mode : presentModes)
 	{
-		if (mode == VK_PRESENT_MODE_MAILBOX_KHR)
+		if (mode == VK_PRESENT_MODE_FIFO_KHR)
 		{
 			presentMode = mode;
 			break;
@@ -200,9 +186,10 @@ VkFormat VulkanSwapchain::findDepthFormat(VkPhysicalDevice physicalDevice)
 
 	for (VkFormat format : candidates)
 	{
-		VkFormatProperties props;
-		vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &props);
-		if (props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
+		VkFormatProperties2 props{};
+		props.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
+		vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, &props);
+		if (props.formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
 		{
 			return format;
 		}
@@ -210,68 +197,110 @@ VkFormat VulkanSwapchain::findDepthFormat(VkPhysicalDevice physicalDevice)
 	return VK_FORMAT_D32_SFLOAT;
 }
 
+void VulkanSwapchain::destroyDepthResources(VkDevice device)
+{
+	for (auto v : m_depthImageViews)
+	{
+		if (v != VK_NULL_HANDLE)
+			vkDestroyImageView(device, v, nullptr);
+	}
+	m_depthImageViews.clear();
+
+	for (auto img : m_depthImages)
+	{
+		if (img != VK_NULL_HANDLE)
+			vkDestroyImage(device, img, nullptr);
+	}
+	m_depthImages.clear();
+
+	for (auto mem : m_depthMemories)
+	{
+		if (mem != VK_NULL_HANDLE)
+			vkFreeMemory(device, mem, nullptr);
+	}
+	m_depthMemories.clear();
+}
+
 bool VulkanSwapchain::createDepthResources(VulkanDevice& device)
 {
+	destroyDepthResources(device.getDevice());
+
 	m_depthFormat = findDepthFormat(device.getPhysicalDevice());
 
-	VkImageCreateInfo imageInfo{};
-	imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-	imageInfo.imageType = VK_IMAGE_TYPE_2D;
-	imageInfo.extent.width = m_extent.width;
-	imageInfo.extent.height = m_extent.height;
-	imageInfo.extent.depth = 1;
-	imageInfo.mipLevels = 1;
-	imageInfo.arrayLayers = 1;
-	imageInfo.format = m_depthFormat;
-	imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
-	imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-	imageInfo.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-	imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-	imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+	const size_t n = m_images.size();
+	m_depthImages.resize(n);
+	m_depthMemories.resize(n);
+	m_depthImageViews.resize(n);
 
-	if (vkCreateImage(device.getDevice(), &imageInfo, nullptr, &m_depthImage) != VK_SUCCESS)
+	for (size_t i = 0; i < n; ++i)
 	{
-		Logger::error("VK: Failed to create depth image");
-		return false;
-	}
+		m_depthImages[i] = VK_NULL_HANDLE;
+		m_depthMemories[i] = VK_NULL_HANDLE;
+		m_depthImageViews[i] = VK_NULL_HANDLE;
 
-	VkMemoryRequirements memRequirements;
-	vkGetImageMemoryRequirements(device.getDevice(), m_depthImage, &memRequirements);
+		VkImageCreateInfo imageInfo{};
+		imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+		imageInfo.imageType = VK_IMAGE_TYPE_2D;
+		imageInfo.extent.width = m_extent.width;
+		imageInfo.extent.height = m_extent.height;
+		imageInfo.extent.depth = 1;
+		imageInfo.mipLevels = 1;
+		imageInfo.arrayLayers = 1;
+		imageInfo.format = m_depthFormat;
+		imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+		imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+		imageInfo.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+		imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+		imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-	VkMemoryAllocateInfo allocInfo{};
-	allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-	allocInfo.allocationSize = memRequirements.size;
-	allocInfo.memoryTypeIndex = device.findMemoryType(memRequirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+		if (vkCreateImage(device.getDevice(), &imageInfo, nullptr, &m_depthImages[i]) != VK_SUCCESS)
+		{
+			Logger::error("VK: Failed to create depth image");
+			destroyDepthResources(device.getDevice());
+			return false;
+		}
 
-	if (allocInfo.memoryTypeIndex == UINT32_MAX)
-	{
-		Logger::error("VK: Failed to find suitable memory type for depth buffer");
-		return false;
-	}
+		VkMemoryRequirements memRequirements;
+		vkGetImageMemoryRequirements(device.getDevice(), m_depthImages[i], &memRequirements);
 
-	if (vkAllocateMemory(device.getDevice(), &allocInfo, nullptr, &m_depthMemory) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to allocate depth image memory");
-		return false;
-	}
+		VkMemoryAllocateInfo allocInfo{};
+		allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+		allocInfo.allocationSize = memRequirements.size;
+		allocInfo.memoryTypeIndex = device.findMemoryType(memRequirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-	vkBindImageMemory(device.getDevice(), m_depthImage, m_depthMemory, 0);
+		if (allocInfo.memoryTypeIndex == UINT32_MAX)
+		{
+			Logger::error("VK: Failed to find suitable memory type for depth buffer");
+			destroyDepthResources(device.getDevice());
+			return false;
+		}
 
-	VkImageViewCreateInfo viewInfo{};
-	viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-	viewInfo.image = m_depthImage;
-	viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-	viewInfo.format = m_depthFormat;
-	viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-	viewInfo.subresourceRange.baseMipLevel = 0;
-	viewInfo.subresourceRange.levelCount = 1;
-	viewInfo.subresourceRange.baseArrayLayer = 0;
-	viewInfo.subresourceRange.layerCount = 1;
+		if (vkAllocateMemory(device.getDevice(), &allocInfo, nullptr, &m_depthMemories[i]) != VK_SUCCESS)
+		{
+			Logger::error("VK: Failed to allocate depth image memory");
+			destroyDepthResources(device.getDevice());
+			return false;
+		}
 
-	if (vkCreateImageView(device.getDevice(), &viewInfo, nullptr, &m_depthImageView) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create depth image view");
-		return false;
+		vkBindImageMemory(device.getDevice(), m_depthImages[i], m_depthMemories[i], 0);
+
+		VkImageViewCreateInfo viewInfo{};
+		viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+		viewInfo.image = m_depthImages[i];
+		viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+		viewInfo.format = m_depthFormat;
+		viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+		viewInfo.subresourceRange.baseMipLevel = 0;
+		viewInfo.subresourceRange.levelCount = 1;
+		viewInfo.subresourceRange.baseArrayLayer = 0;
+		viewInfo.subresourceRange.layerCount = 1;
+
+		if (vkCreateImageView(device.getDevice(), &viewInfo, nullptr, &m_depthImageViews[i]) != VK_SUCCESS)
+		{
+			Logger::error("VK: Failed to create depth image view");
+			destroyDepthResources(device.getDevice());
+			return false;
+		}
 	}
 
 	Logger::info("VK: Depth buffer created successfully");
@@ -280,52 +309,58 @@ bool VulkanSwapchain::createDepthResources(VulkanDevice& device)
 
 bool VulkanSwapchain::createRenderPass(VkDevice device)
 {
-	VkAttachmentDescription colorAttachment{};
-	colorAttachment.format = m_format;
-	colorAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
-	colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-	colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-	colorAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-	colorAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	colorAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-	colorAttachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+	std::array<VkAttachmentDescription2, 2> attachments{};
+	attachments[0].sType = VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2;
+	attachments[0].format = m_format;
+	attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
+	attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+	attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+	attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+	attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+	attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+	attachments[0].finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
-	VkAttachmentReference colorAttachmentRef{};
-	colorAttachmentRef.attachment = 0;
-	colorAttachmentRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+	attachments[1].sType = VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2;
+	attachments[1].format = m_depthFormat;
+	attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
+	attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+	attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+	attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+	attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+	attachments[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+	attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
-	VkAttachmentDescription depthAttachment{};
-	depthAttachment.format = m_depthFormat;
-	depthAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
-	depthAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-	depthAttachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	depthAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-	depthAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	depthAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-	depthAttachment.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+	VkAttachmentReference2 colorRef{};
+	colorRef.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
+	colorRef.attachment = 0;
+	colorRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+	colorRef.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-	VkAttachmentReference depthAttachmentRef{};
-	depthAttachmentRef.attachment = 1;
-	depthAttachmentRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+	VkAttachmentReference2 depthRef{};
+	depthRef.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
+	depthRef.attachment = 1;
+	depthRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+	depthRef.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
 
-	VkSubpassDescription subpass{};
+	VkSubpassDescription2 subpass{};
+	subpass.sType = VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2;
 	subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
 	subpass.colorAttachmentCount = 1;
-	subpass.pColorAttachments = &colorAttachmentRef;
-	subpass.pDepthStencilAttachment = &depthAttachmentRef;
+	subpass.pColorAttachments = &colorRef;
+	subpass.pDepthStencilAttachment = &depthRef;
 
-	VkSubpassDependency dependency{};
+	VkSubpassDependency2 dependency{};
+	dependency.sType = VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2;
 	dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
 	dependency.dstSubpass = 0;
 	dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
-	dependency.srcAccessMask = 0;
 	dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
 	dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+	dependency.dependencyFlags = 0;
+	dependency.viewOffset = 0;
 
-	std::array<VkAttachmentDescription, 2> attachments = {colorAttachment, depthAttachment};
-
-	VkRenderPassCreateInfo renderPassInfo{};
-	renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+	VkRenderPassCreateInfo2 renderPassInfo{};
+	renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2;
 	renderPassInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
 	renderPassInfo.pAttachments = attachments.data();
 	renderPassInfo.subpassCount = 1;
@@ -333,7 +368,7 @@ bool VulkanSwapchain::createRenderPass(VkDevice device)
 	renderPassInfo.dependencyCount = 1;
 	renderPassInfo.pDependencies = &dependency;
 
-	if (vkCreateRenderPass(device, &renderPassInfo, nullptr, &m_renderPass) != VK_SUCCESS)
+	if (vkCreateRenderPass2(device, &renderPassInfo, nullptr, &m_renderPass) != VK_SUCCESS)
 	{
 		Logger::error("VK: Failed to create render pass");
 		return false;
@@ -350,7 +385,7 @@ bool VulkanSwapchain::createFramebuffers(VkDevice device)
 	{
 		std::array<VkImageView, 2> attachments = {
 			m_imageViews[i],
-			m_depthImageView};
+			m_depthImageViews[i]};
 
 		VkFramebufferCreateInfo framebufferInfo{};
 		framebufferInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
@@ -371,73 +406,76 @@ bool VulkanSwapchain::createFramebuffers(VkDevice device)
 	return true;
 }
 
-void VulkanSwapchain::setVSync(VulkanDevice& device, bool enabled)
+bool VulkanSwapchain::setVSync(VulkanDevice& device, bool enabled)
 {
 	VkPresentModeKHR newPresentMode = enabled ? VK_PRESENT_MODE_FIFO_KHR : VK_PRESENT_MODE_MAILBOX_KHR;
 
-	if (newPresentMode != m_presentMode && m_swapchain != VK_NULL_HANDLE)
+	if (newPresentMode == m_presentMode || m_swapchain == VK_NULL_HANDLE)
+		return false;
+
+	Logger::info("VK: Recreating swapchain with VSync {}", enabled ? "enabled" : "disabled");
+
+	vkDeviceWaitIdle(device.getDevice());
+
+	VkSwapchainKHR oldSwapchain = m_swapchain;
+
+	VkSurfaceCapabilitiesKHR capabilities;
+	vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device.getPhysicalDevice(), device.getSurface(), &capabilities);
+
+	VkSwapchainCreateInfoKHR createInfo{};
+	createInfo.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+	createInfo.pNext = nullptr;
+	createInfo.surface = device.getSurface();
+	createInfo.minImageCount = capabilities.minImageCount + 1;
+	createInfo.imageFormat = m_format;
+	createInfo.imageColorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+	createInfo.imageExtent = m_extent;
+	createInfo.imageArrayLayers = 1;
+	createInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+	createInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+	createInfo.preTransform = capabilities.currentTransform;
+	createInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+	createInfo.presentMode = newPresentMode;
+	createInfo.clipped = VK_TRUE;
+	createInfo.oldSwapchain = oldSwapchain;
+
+	VkSwapchainKHR newSwapchain;
+	if (vkCreateSwapchainKHR(device.getDevice(), &createInfo, nullptr, &newSwapchain) != VK_SUCCESS)
 	{
-		Logger::info("VK: Recreating swapchain with VSync {}", enabled ? "enabled" : "disabled");
-
-		vkDeviceWaitIdle(device.getDevice());
-
-		VkSwapchainKHR oldSwapchain = m_swapchain;
-
-		VkSurfaceCapabilitiesKHR capabilities;
-		vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device.getPhysicalDevice(), device.getSurface(), &capabilities);
-
-		VkSwapchainCreateInfoKHR createInfo{};
-		createInfo.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
-		createInfo.pNext = nullptr;
-		createInfo.surface = device.getSurface();
-		createInfo.minImageCount = capabilities.minImageCount + 1;
-		createInfo.imageFormat = m_format;
-		createInfo.imageColorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-		createInfo.imageExtent = m_extent;
-		createInfo.imageArrayLayers = 1;
-		createInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-		createInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
-		createInfo.preTransform = capabilities.currentTransform;
-		createInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
-		createInfo.presentMode = newPresentMode;
-		createInfo.clipped = VK_TRUE;
-		createInfo.oldSwapchain = oldSwapchain;
-
-		VkSwapchainKHR newSwapchain;
-		if (vkCreateSwapchainKHR(device.getDevice(), &createInfo, nullptr, &newSwapchain) != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to recreate swapchain for VSync change");
-			return;
-		}
-
-		m_swapchain = newSwapchain;
-		m_presentMode = newPresentMode;
-
-		for (auto imageView : m_imageViews)
-		{
-			vkDestroyImageView(device.getDevice(), imageView, nullptr);
-		}
-		m_imageViews.clear();
-
-		for (auto framebuffer : m_framebuffers)
-		{
-			vkDestroyFramebuffer(device.getDevice(), framebuffer, nullptr);
-		}
-		m_framebuffers.clear();
-
-		uint32_t imageCount;
-		vkGetSwapchainImagesKHR(device.getDevice(), m_swapchain, &imageCount, nullptr);
-		m_images.resize(imageCount);
-		vkGetSwapchainImagesKHR(device.getDevice(), m_swapchain, &imageCount, m_images.data());
-		if (!createImageViews(device.getDevice()) || !createFramebuffers(device.getDevice()))
-		{
-			Logger::error("VK: Failed to recreate swapchain resources for VSync change");
-			return;
-		}
-
-		if (oldSwapchain != VK_NULL_HANDLE)
-		{
-			vkDestroySwapchainKHR(device.getDevice(), oldSwapchain, nullptr);
-		}
+		Logger::error("VK: Failed to recreate swapchain for VSync change");
+		return false;
 	}
+
+	m_swapchain = newSwapchain;
+	m_presentMode = newPresentMode;
+
+	for (auto imageView : m_imageViews)
+	{
+		vkDestroyImageView(device.getDevice(), imageView, nullptr);
+	}
+	m_imageViews.clear();
+
+	for (auto framebuffer : m_framebuffers)
+	{
+		vkDestroyFramebuffer(device.getDevice(), framebuffer, nullptr);
+	}
+	m_framebuffers.clear();
+
+	destroyDepthResources(device.getDevice());
+
+	uint32_t imageCount;
+	vkGetSwapchainImagesKHR(device.getDevice(), m_swapchain, &imageCount, nullptr);
+	m_images.resize(imageCount);
+	vkGetSwapchainImagesKHR(device.getDevice(), m_swapchain, &imageCount, m_images.data());
+	if (!createImageViews(device.getDevice()) || !createDepthResources(device) || !createFramebuffers(device.getDevice()))
+	{
+		Logger::error("VK: Failed to recreate swapchain resources for VSync change");
+		return false;
+	}
+
+	if (oldSwapchain != VK_NULL_HANDLE)
+	{
+		vkDestroySwapchainKHR(device.getDevice(), oldSwapchain, nullptr);
+	}
+	return true;
 }

--- a/src/core/renderer/Vulkan/VulkanSwapchain.h
+++ b/src/core/renderer/Vulkan/VulkanSwapchain.h
@@ -31,7 +31,7 @@ public:
 	const std::vector<VkFramebuffer>& getFramebuffers() const { return m_framebuffers; }
 	VkFormat getDepthFormat() const { return m_depthFormat; }
 
-	void setVSync(VulkanDevice& device, bool enabled);
+	bool setVSync(VulkanDevice& device, bool enabled);
 
 private:
 	bool createSwapchain(VulkanDevice& device, uint32_t width, uint32_t height);
@@ -39,6 +39,7 @@ private:
 	bool createDepthResources(VulkanDevice& device);
 	bool createRenderPass(VkDevice device);
 	bool createFramebuffers(VkDevice device);
+	void destroyDepthResources(VkDevice device);
 	VkFormat findDepthFormat(VkPhysicalDevice physicalDevice);
 
 	VkSwapchainKHR m_swapchain = VK_NULL_HANDLE;
@@ -47,9 +48,9 @@ private:
 	VkFormat m_format = VK_FORMAT_UNDEFINED;
 	VkExtent2D m_extent = {0, 0};
 
-	VkImage m_depthImage = VK_NULL_HANDLE;
-	VkDeviceMemory m_depthMemory = VK_NULL_HANDLE;
-	VkImageView m_depthImageView = VK_NULL_HANDLE;
+	std::vector<VkImage> m_depthImages;
+	std::vector<VkDeviceMemory> m_depthMemories;
+	std::vector<VkImageView> m_depthImageViews;
 	VkFormat m_depthFormat = VK_FORMAT_UNDEFINED;
 
 	VkRenderPass m_renderPass = VK_NULL_HANDLE;


### PR DESCRIPTION
### Description of Changes
- Fixed the Vulkan validation errors in the icon renderer.
- Cleaned up sync/resource handling around descriptors, depth, and semaphores.
- Switched a few Vulkan calls to newer API variants.

### Rationale behind Changes
The validator was reporting API misuse issues during icon updates/resize.

### Suggested Testing Steps
- Run with validation layers on.
- Load icons, resize the view a lot, and switch icons repeatedly.
- Make sure the old queue submit/sync errors no longer appear.

### Related Issues / Links
- Vulkan validation logs from local repro.

### Did you use AI to help find, test, or implement this issue or feature?
No