### PR TITLE
Renderer: Fix icon texture OOB crash when switching saves

### DIFF
--- a/src/core/formats/ps2icon.cpp
+++ b/src/core/formats/ps2icon.cpp
@@ -242,20 +242,21 @@ namespace PS2Icon
 
 	size_t Icon::loadTexture(const uint8_t* data, size_t length, size_t offset)
 	{
+		constexpr uint16_t DEFAULT_TEXEL = 0xFFFF;
+		const size_t texturePixelCount = static_cast<size_t>(TEXTURE_WIDTH) * static_cast<size_t>(TEXTURE_HEIGHT);
+
 		// Check if texture data exists (bit 2 = 0x04)
 		if (!(textureFlags & 0x04))
 		{
 			Logger::info("PS2Icon: No texture data (textureFlags=0x{:02X})", textureFlags);
-			texture.resize(1);
-			texture[0] = 0xFFFF;
+			texture.assign(texturePixelCount, DEFAULT_TEXEL);
 			return offset;
 		}
 
 		if (offset >= length)
 		{
 			Logger::warn("PS2Icon: Texture flag set but no data remaining");
-			texture.resize(1);
-			texture[0] = 0xFFFF;
+			texture.assign(texturePixelCount, DEFAULT_TEXEL);
 			return offset;
 		}
 

--- a/src/core/renderer/Common/RendererCommon.cpp
+++ b/src/core/renderer/Common/RendererCommon.cpp
@@ -352,9 +352,22 @@ namespace TextureUtils
 
 	std::vector<uint8_t> convertPS2TextureToRGBA(const uint16_t* textureData, uint32_t width, uint32_t height)
 	{
-		std::vector<uint8_t> rgba(width * height * 4);
+		if (!textureData || width == 0 || height == 0)
+		{
+			Logger::warn("TextureUtils: Invalid texture input (ptr={}, width={}, height={})", (const void*)textureData, width, height);
+			return {};
+		}
 
-		for (size_t i = 0; i < width * height; ++i)
+		const size_t pixelCount = static_cast<size_t>(width) * static_cast<size_t>(height);
+		if (pixelCount > std::numeric_limits<size_t>::max() / 4)
+		{
+			Logger::error("TextureUtils: Texture size overflow (width={}, height={})", width, height);
+			return {};
+		}
+
+		std::vector<uint8_t> rgba(pixelCount * 4);
+
+		for (size_t i = 0; i < pixelCount; ++i)
 		{
 			uint16_t pixel = textureData[i];
 			uint8_t r5 = static_cast<uint8_t>((pixel >> 0) & 0x1F); // Red (bits 0-4)

--- a/src/core/renderer/Metal/MetalRenderer.mm
+++ b/src/core/renderer/Metal/MetalRenderer.mm
@@ -236,7 +236,14 @@ void MetalRenderer::render()
 		uint32_t width = m_icon->getTextureWidth();
 		uint32_t height = m_icon->getTextureHeight();
 		auto rgbaData = TextureUtils::convertPS2TextureToRGBA(m_icon->getTextureData(), width, height);
-		m_impl->resources.uploadTexture(m_impl->device.getDevice(), rgbaData.data(), width, height);
+		if (!rgbaData.empty())
+		{
+			m_impl->resources.uploadTexture(m_impl->device.getDevice(), rgbaData.data(), width, height);
+		}
+		else
+		{
+			Logger::warn("MTL: Texture conversion returned empty data");
+		}
 		m_iconChanged = false;
 	}
 

--- a/src/core/renderer/OpenGL/OpenGLRenderer.cpp
+++ b/src/core/renderer/OpenGL/OpenGLRenderer.cpp
@@ -301,6 +301,12 @@ void OpenGLRenderer::setupTexture()
 		}
 
 		auto rgba = TextureUtils::convertPS2TextureToRGBA(textureData, texWidth, texHeight);
+		if (rgba.empty())
+		{
+			Logger::error("GL: Texture conversion returned empty data");
+			m_context->releaseCurrent();
+			return;
+		}
 
 		m_resources.uploadTexture(rgba.data(), texWidth, texHeight);
 

--- a/src/core/renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/core/renderer/Vulkan/VulkanRenderer.cpp
@@ -695,6 +695,12 @@ bool VulkanRenderer::uploadTexture()
 	}
 
 	auto rgba = TextureUtils::convertPS2TextureToRGBA(textureData, texWidth, texHeight);
+	if (rgba.empty())
+	{
+		Logger::warn("VK: Texture conversion returned empty data");
+		return false;
+	}
+
 	Logger::debug("VK: Texture converted to RGBA, size={} bytes", rgba.size());
 	VkDeviceSize imageSize = rgba.size();
 


### PR DESCRIPTION
### Description of Changes
Fixed icon switch crash caused by texture OOB reads.

### Rationale behind Changes
Some icons can have missing/invalid texture data so switching to them could crash during RGBA conversion.

### Suggested Testing Steps
Switch icons repeatedly in all of the renderers

### Did you use AI to help find, test, or implement this issue or feature?
No.