### PR TITLE
Qt/Vulkan: Keep Qt usage only in ui project and make Vulkan validation optional

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -114,12 +114,13 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4.3.1
         with:
-          version: '6.10.2'
+          version: '6.11.0'
           host: 'linux'
           target: 'desktop'
           arch: 'linux_gcc_64'
           modules: 'qtimageformats'
           cache: true
+          use-official: true
 
       - name: Configure CMake (Clang)
         if: inputs.compiler == 'clang'

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -90,12 +90,13 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4.3.1
         with:
-          version: '6.10.2'
+          version: '6.11.0'
           host: 'mac'
           target: 'desktop'
           arch: 'clang_64'
           modules: 'qtimageformats'
           cache: true
+          use-official: true
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -80,24 +80,27 @@ jobs:
         if: inputs.platform == 'x64'
         uses: jurplel/install-qt-action@v4.3.1
         with:
-          version: '6.10.2'
+          version: '6.11.0'
           host: 'windows'
           target: 'desktop'
           arch: 'win64_msvc2022_64'
           modules: 'qtimageformats'
           cache: true
+          aqtsource: 'git+https://github.com/miurahr/aqtinstall.git'
+          use-official: true
 
       - name: Install Qt (ARM64)
         if: inputs.platform == 'ARM64'
         uses: jurplel/install-qt-action@v4.3.1
         with:
-          version: '6.10.2'
+          version: '6.11.0'
           host: 'windows_arm64'
           target: 'desktop'
           arch: 'win64_msvc2022_arm64'
           modules: 'qtimageformats'
           cache: true
           aqtsource: 'git+https://github.com/miurahr/aqtinstall.git'
+          use-official: true
 
       - name: Configure CMake (MSVC)
         if: inputs.compiler == 'msvc'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,13 +13,8 @@ if(WIN32)
 endif()
 
 target_link_libraries(myMCpp PRIVATE
-    myMCpp-core
     myMCpp-qt
     myMCpp-cli
-    Qt6::Core
-    Qt6::Gui
-    Qt6::GuiPrivate
-    Qt6::Widgets
 )
 
 # Took inspiration from https://github.com/PCSX2/pcsx2/blob/master/pcsx2-qt/CMakeLists.txt for the translation generation
@@ -52,14 +47,6 @@ else()
             COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${QM_FILE}" "${QM_OUTPUT_DIR}/${QM_FILE_NAME}")
     endforeach()
 endif()
-
-target_include_directories(myMCpp PRIVATE
-    ${Qt6Gui_PRIVATE_INCLUDE_DIRS}
-    ${CMAKE_SOURCE_DIR}/src/core
-    ${CMAKE_SOURCE_DIR}/src/core/formats
-    ${CMAKE_SOURCE_DIR}/src/common
-    ${CMAKE_SOURCE_DIR}/src/cli
-)
 
 if(ENABLE_VULKAN)
     target_include_directories(myMCpp PRIVATE ${vulkan-headers_SOURCE_DIR}/include)
@@ -145,7 +132,6 @@ if(APPLE)
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 ${CMAKE_BINARY_DIR}/default.metallib
                 $<TARGET_FILE_DIR:myMCpp>/../Resources/shaders/Metal/default.metallib
-            COMMENT "Copying Metal library to bundle..."
         )
     endif()
     
@@ -167,7 +153,6 @@ if(APPLE)
         COMMAND ${CMAKE_COMMAND} -E copy_directory
             ${CMAKE_SOURCE_DIR}/resources
             $<TARGET_FILE_DIR:myMCpp>/../Resources
-        COMMENT "Copying resources to app bundle..."
     )
 endif()
 

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -15,7 +15,6 @@ target_include_directories(myMCpp-cli PUBLIC
 target_link_libraries(myMCpp-cli PUBLIC
     myMCpp-common
     myMCpp-core
-    Qt6::Core
 )
 
 if(MSVC)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -79,8 +79,6 @@ target_include_directories(myMCpp-core PUBLIC
 
 target_link_libraries(myMCpp-core PUBLIC
     myMCpp-common
-    Qt6::Core
-    Qt6::Widgets
     nlohmann_json::nlohmann_json
     OpenGL::GL
     glfw

--- a/src/core/renderer/Vulkan/VulkanDevice.cpp
+++ b/src/core/renderer/Vulkan/VulkanDevice.cpp
@@ -21,10 +21,9 @@
 #endif
 
 #include "Logger.h"
-#include <vector>
 
 #ifndef NDEBUG
-static VKAPI_ATTR VkBool32 VKAPI_CALL vulkanDebugCallback(VkDebugUtilsMessageSeverityFlagEXT severity,
+static VKAPI_ATTR VkBool32 VKAPI_CALL vulkanDebugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity,
 	VkDebugUtilsMessageTypeFlagsEXT /*type*/, const VkDebugUtilsMessengerCallbackDataEXT* data, void* /*ud*/)
 {
 	if (data && data->pMessage)
@@ -120,10 +119,6 @@ bool VulkanDevice::createInstance()
 		VK_KHR_XLIB_SURFACE_EXTENSION_NAME,
 		VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME,
 #endif
-#ifndef NDEBUG
-		,
-		VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
-#endif
 	};
 
 	VkInstanceCreateInfo createInfo{};
@@ -133,19 +128,58 @@ bool VulkanDevice::createInstance()
 	createInfo.ppEnabledExtensionNames = extensions.data();
 
 #ifndef NDEBUG
-	const char* layers[] = {"VK_LAYER_KHRONOS_validation"};
-	createInfo.enabledLayerCount = 1;
-	createInfo.ppEnabledLayerNames = layers;
+	bool enableDebugValidation = false;
+	uint32_t extensionCount = 0;
+	vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, nullptr);
+	std::vector<VkExtensionProperties> availableExtensions(extensionCount);
+	if (extensionCount > 0)
+		vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, availableExtensions.data());
 
-	VkDebugUtilsMessengerCreateInfoEXT dbgInfo{};
-	dbgInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
-	dbgInfo.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
-	                          VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-	dbgInfo.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
-	                      VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
-	                      VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
-	dbgInfo.pfnUserCallback = vulkanDebugCallback;
-	createInfo.pNext = &dbgInfo;
+	const bool hasDebugUtilsExtension = std::any_of(availableExtensions.begin(), availableExtensions.end(),
+		[](const VkExtensionProperties& extension) {
+			return std::strcmp(extension.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0;
+		});
+
+	uint32_t layerCount = 0;
+	vkEnumerateInstanceLayerProperties(&layerCount, nullptr);
+	std::vector<VkLayerProperties> availableLayers(layerCount);
+	if (layerCount > 0)
+		vkEnumerateInstanceLayerProperties(&layerCount, availableLayers.data());
+
+	const bool hasValidationLayer = std::any_of(availableLayers.begin(), availableLayers.end(),
+		[](const VkLayerProperties& layer) {
+			return std::strcmp(layer.layerName, "VK_LAYER_KHRONOS_validation") == 0;
+		});
+
+	if (hasValidationLayer && hasDebugUtilsExtension)
+	{
+		enableDebugValidation = true;
+		extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+		createInfo.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
+		createInfo.ppEnabledExtensionNames = extensions.data();
+
+		const char* layers[] = {"VK_LAYER_KHRONOS_validation"};
+		createInfo.enabledLayerCount = 1;
+		createInfo.ppEnabledLayerNames = layers;
+
+		VkDebugUtilsMessengerCreateInfoEXT dbgInfo{};
+		dbgInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+		dbgInfo.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+		                          VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+		dbgInfo.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
+		                      VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
+		                      VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+		dbgInfo.pfnUserCallback = vulkanDebugCallback;
+		createInfo.pNext = &dbgInfo;
+	}
+	else if (!hasValidationLayer)
+	{
+		Logger::warn("VK: Validation layer VK_LAYER_KHRONOS_validation not available, continuing without validation");
+	}
+	else
+	{
+		Logger::warn("VK: Extension VK_EXT_debug_utils not available, continuing without validation");
+	}
 #endif
 
 	if (vkCreateInstance(&createInfo, nullptr, &m_instance) != VK_SUCCESS)
@@ -155,6 +189,7 @@ bool VulkanDevice::createInstance()
 	}
 
 #ifndef NDEBUG
+	if (enableDebugValidation)
 	{
 		auto createFn = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(
 			vkGetInstanceProcAddr(m_instance, "vkCreateDebugUtilsMessengerEXT"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,23 +1,17 @@
 // SPDX-FileCopyrightText: 2025-2026 SternXD
 // SPDX-License-Identifier: GPL-3.0+
 
-#include "MainWindow.h"
 #include "ps2mc_cli.h"
 #include "Config.h"
 #include "version.h"
 #include "BuildVersion.h"
-#if !defined(__APPLE__)
-#include <QVulkanInstance>
-#endif
+#include "QtMain.h"
 #include <filesystem>
 #include "Logger.h"
 #include "ResourcePath.h"
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>
-#include <QTranslator>
-#include <QLibraryInfo>
-#include "TranslationManager.h"
 
 #if defined(_WIN32)
 #include <Windows.h>
@@ -28,6 +22,35 @@
 #endif
 
 namespace fs = std::filesystem;
+
+#if !defined(__APPLE__)
+static fs::path getExecutableDir(const char* argv0)
+{
+#if defined(_WIN32)
+	char modulePath[MAX_PATH] = {};
+	const DWORD length = GetModuleFileNameA(nullptr, modulePath, MAX_PATH);
+	if (length > 0)
+	{
+		return fs::path(modulePath).parent_path();
+	}
+#endif
+	if (argv0 != nullptr && argv0[0] != '\0')
+	{
+		std::error_code ec;
+		fs::path resolved = fs::weakly_canonical(fs::path(argv0), ec);
+		if (!ec && !resolved.empty())
+		{
+			if (resolved.has_parent_path())
+				return resolved.parent_path();
+			return resolved;
+		}
+	}
+
+	std::error_code ec;
+	fs::path current = fs::current_path(ec);
+	return ec ? fs::path(".") : current;
+}
+#endif
 
 static int appMain(int argc, char* argv[])
 {
@@ -83,17 +106,11 @@ static int appMain(int argc, char* argv[])
 		return cli.execute(argc, argv);
 	}
 
-	QApplication app(argc, argv);
-
 	Logger::info("Main: myMCpp version {} ({}, hash {}, date {})",
 		myMCpp_VERSION_STRING,
 		BuildVersion::GitRev,
 		BuildVersion::GitHash,
 		BuildVersion::GitDate);
-
-	app.setApplicationName(MYMCpp_APP_NAME);
-	app.setApplicationVersion(myMCpp_VERSION_STRING);
-	app.setOrganizationName("myMCpp");
 
 	Config config;
 	fs::path config_path;
@@ -151,37 +168,12 @@ static int appMain(int argc, char* argv[])
 		config.setResourcesPath("resources");
 	}
 #else
-	config.setResourcesPath((fs::path(QCoreApplication::applicationDirPath().toStdString()) / "resources").string());
+	config.setResourcesPath((getExecutableDir(argc > 0 ? argv[0] : nullptr) / "resources").string());
 #endif
 	ResourcePath::set(config.getResourcesPath());
 	Logger::info("Main: Resources path: {}", ResourcePath::get().string());
 
-#if !defined(__APPLE__)
-	QVulkanInstance vulkanInstance;
-#if defined(QT_DEBUG)
-	vulkanInstance.setLayers({"VK_LAYER_KHRONOS_validation"});
-#endif
-	if (!vulkanInstance.create())
-	{
-		Logger::info("Main: Failed to create Vulkan instance");
-	}
-#endif
-
-	// Load translations
-	TranslationManager::instance().init(&app, &config);
-	TranslationManager::instance().loadLanguage(config.getLanguage());
-
-	QTranslator qtTranslator;
-	if (qtTranslator.load("qt_" + QLocale::system().name(), QLibraryInfo::path(QLibraryInfo::TranslationsPath)))
-	{
-		app.installTranslator(&qtTranslator);
-	}
-
-
-	MainWindow window(&config);
-	window.show();
-
-	return app.exec();
+	return runQtMainApp(argc, argv, config);
 }
 
 #if defined(_WIN32)

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(UI_SOURCES
+    QtMain.cpp
     MainWindow.cpp
     DiscordRPCManager.cpp
     Themes.cpp
@@ -19,6 +20,7 @@ set(UI_SOURCES
 )
 
 set(UI_HEADERS
+    QtMain.h
     MainWindow.h
     DiscordRPCManager.h
     Themes.h

--- a/src/ui/QtMain.cpp
+++ b/src/ui/QtMain.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025-2026 SternXD
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "QtMain.h"
+
+#include "Config.h"
+#include "MainWindow.h"
+#include "TranslationManager.h"
+#include "version.h"
+#include "Logger.h"
+
+#include <QLibraryInfo>
+
+int runQtMainApp(int argc, char* argv[], Config& config)
+{
+	QApplication app(argc, argv);
+	app.setApplicationName(MYMCpp_APP_NAME);
+	app.setApplicationVersion(myMCpp_VERSION_STRING);
+	app.setOrganizationName("myMCpp");
+
+	// Load translations
+	TranslationManager::instance().init(&app, &config);
+	TranslationManager::instance().loadLanguage(config.getLanguage());
+
+	QTranslator qtTranslator;
+	if (qtTranslator.load("qt_" + QLocale::system().name(), QLibraryInfo::path(QLibraryInfo::TranslationsPath)))
+	{
+		app.installTranslator(&qtTranslator);
+	}
+
+	MainWindow window(&config);
+	window.show();
+
+	return app.exec();
+}

--- a/src/ui/QtMain.h
+++ b/src/ui/QtMain.h
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2025-2026 SternXD
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+class Config;
+
+int runQtMainApp(int argc, char* argv[], Config& config);


### PR DESCRIPTION
## Description of Changes
- Kept Qt dependencies limited to the UI target.
- Updated Vulkan debug init so validation is only enabled when it’s actually available.
- Update Qt to 6.11.0 in CI

## Rationale behind Changes
Keeps Qt usage only in ui project

## Suggested Testing Steps
Start the app and make sure UI launches.

## Related Issues / Links
N/A

## Did you use AI to help find, test, or implement this issue or feature?
No.