### PR TITLE
ci: Add ARM64 Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,21 +8,45 @@ on:
       - master
 
 jobs:
-  build_linux_clang:
-    name: "🐧 Linux (Clang)"
+  build_linux_x64_clang:
+    name: "🐧 Linux x64 (Clang)"
     uses: ./.github/workflows/linux_build.yml
     with:
-      jobName: "Linux Clang Build"
+      jobName: "Linux x64 Clang Build"
       artifactPrefixName: "myMCpp-linux-x64-clang"
+      platform: x64
       compiler: clang
     secrets: inherit
 
-  build_linux_gcc:
-    name: "🐧 Linux (GCC)"
+  build_linux_x64_gcc:
+    name: "🐧 Linux x64 (GCC)"
     uses: ./.github/workflows/linux_build.yml
     with:
-      jobName: "Linux GCC Build"
+      jobName: "Linux x64 GCC Build"
       artifactPrefixName: "myMCpp-linux-x64-gcc"
+      platform: x64
+      compiler: gcc
+    secrets: inherit
+
+  build_linux_arm64_clang:
+    name: "🐧 Linux ARM64 (Clang)"
+    uses: ./.github/workflows/linux_build.yml
+    with:
+      jobName: "Linux ARM64 Clang Build"
+      artifactPrefixName: "myMCpp-linux-arm64-clang"
+      os: ubuntu-24.04-arm
+      platform: arm64
+      compiler: clang
+    secrets: inherit
+
+  build_linux_arm64_gcc:
+    name: "🐧 Linux ARM64 (GCC)"
+    uses: ./.github/workflows/linux_build.yml
+    with:
+      jobName: "Linux ARM64 GCC Build"
+      artifactPrefixName: "myMCpp-linux-arm64-gcc"
+      os: ubuntu-24.04-arm
+      platform: arm64
       compiler: gcc
     secrets: inherit
 

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -31,6 +31,10 @@ on:
         required: false
         type: boolean
         default: false
+      platform:
+        required: false
+        type: string
+        default: x64
 
 jobs:
   build_linux:
@@ -111,7 +115,8 @@ jobs:
             imagemagick \
             wget
 
-      - name: Install Qt
+      - name: Install Qt (x64)
+        if: inputs.platform != 'arm64'
         uses: jurplel/install-qt-action@v4.3.1
         with:
           version: '6.11.0'
@@ -122,13 +127,33 @@ jobs:
           cache: true
           use-official: true
 
+      - name: Install Qt (ARM64)
+        if: inputs.platform == 'arm64'
+        uses: jurplel/install-qt-action@v4.3.1
+        with:
+          version: '6.11.0'
+          host: 'linux_arm64'
+          target: 'desktop'
+          arch: 'linux_gcc_arm64'
+          modules: 'qtimageformats'
+          cache: true
+          use-official: true
+
       - name: Configure CMake (Clang)
         if: inputs.compiler == 'clang'
         run: |
           if [ "${{ inputs.buildType }}" = "Debug" ]; then
-            PRESET="linux-dbg"
+            if [ "${{ inputs.platform }}" = "arm64" ]; then
+              PRESET="linux-arm64-dbg"
+            else
+              PRESET="linux-x64-dbg"
+            fi
           else
-            PRESET="linux-rel"
+            if [ "${{ inputs.platform }}" = "arm64" ]; then
+              PRESET="linux-arm64-rel"
+            else
+              PRESET="linux-x64-rel"
+            fi
           fi
           echo "PRESET=$PRESET" >> $GITHUB_ENV
           cmake --preset $PRESET \
@@ -142,9 +167,17 @@ jobs:
         if: inputs.compiler == 'gcc'
         run: |
           if [ "${{ inputs.buildType }}" = "Debug" ]; then
-            PRESET="linux-gcc-dbg"
+            if [ "${{ inputs.platform }}" = "arm64" ]; then
+              PRESET="linux-arm64-gcc-dbg"
+            else
+              PRESET="linux-x64-gcc-dbg"
+            fi
           else
-            PRESET="linux-gcc-rel"
+            if [ "${{ inputs.platform }}" = "arm64" ]; then
+              PRESET="linux-arm64-gcc-rel"
+            else
+              PRESET="linux-x64-gcc-rel"
+            fi
           fi
           echo "PRESET=$PRESET" >> $GITHUB_ENV
           cmake --preset $PRESET \

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -66,26 +66,56 @@ jobs:
           echo "new_tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "release_name=${NAME}" >> "$GITHUB_OUTPUT"
 
-  build_linux_clang:
+  build_linux_x64_clang:
     if: github.repository == 'PCSX2/myMCpp'
-    name: '🐧 Linux (Clang, Nightly)'
+    name: '🐧 Linux x64 (Clang, Nightly)'
     needs: cut_release
     uses: ./.github/workflows/linux_build.yml
     with:
-      jobName: 'Linux Clang Nightly Build'
+      jobName: 'Linux x64 Clang Nightly Build'
       artifactPrefixName: 'myMCpp-nightly-linux-x64-clang'
+      platform: x64
       compiler: clang
       fetchTags: true
     secrets: inherit
 
-  build_linux_gcc:
+  build_linux_x64_gcc:
     if: github.repository == 'PCSX2/myMCpp'
-    name: '🐧 Linux (GCC, Nightly)'
+    name: '🐧 Linux x64 (GCC, Nightly)'
     needs: cut_release
     uses: ./.github/workflows/linux_build.yml
     with:
-      jobName: 'Linux GCC Nightly Build'
+      jobName: 'Linux x64 GCC Nightly Build'
       artifactPrefixName: 'myMCpp-nightly-linux-x64-gcc'
+      platform: x64
+      compiler: gcc
+      fetchTags: true
+    secrets: inherit
+
+  build_linux_arm64_clang:
+    if: github.repository == 'PCSX2/myMCpp'
+    name: '🐧 Linux ARM64 (Clang, Nightly)'
+    needs: cut_release
+    uses: ./.github/workflows/linux_build.yml
+    with:
+      jobName: 'Linux ARM64 Clang Nightly Build'
+      artifactPrefixName: 'myMCpp-nightly-linux-arm64-clang'
+      os: ubuntu-24.04-arm
+      platform: arm64
+      compiler: clang
+      fetchTags: true
+    secrets: inherit
+
+  build_linux_arm64_gcc:
+    if: github.repository == 'PCSX2/myMCpp'
+    name: '🐧 Linux ARM64 (GCC, Nightly)'
+    needs: cut_release
+    uses: ./.github/workflows/linux_build.yml
+    with:
+      jobName: 'Linux ARM64 GCC Nightly Build'
+      artifactPrefixName: 'myMCpp-nightly-linux-arm64-gcc'
+      os: ubuntu-24.04-arm
+      platform: arm64
       compiler: gcc
       fetchTags: true
     secrets: inherit
@@ -161,8 +191,10 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - cut_release
-      - build_linux_clang
-      - build_linux_gcc
+      - build_linux_x64_clang
+      - build_linux_x64_gcc
+      - build_linux_arm64_clang
+      - build_linux_arm64_gcc
       - build_macos
       - build_windows_x64_clang
       - build_windows_x64_msvc

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -72,11 +72,11 @@
             }
         },
         {
-            "name": "linux-rel",
-            "displayName": "Linux Release",
-            "description": "Release build for Linux with Clang and Ninja",
+            "name": "linux-x64-rel",
+            "displayName": "Linux x64 Release",
+            "description": "Release build for Linux x64 with Clang and Ninja",
             "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/linux-rel",
+            "binaryDir": "${sourceDir}/build/linux-x64-rel",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "MinSizeRel",
                 "CMAKE_C_COMPILER": "clang",
@@ -85,11 +85,11 @@
             }
         },
         {
-            "name": "linux-dbg",
-            "displayName": "Linux Debug",
-            "description": "Debug build for Linux with Clang and Ninja",
+            "name": "linux-x64-dbg",
+            "displayName": "Linux x64 Debug",
+            "description": "Debug build for Linux x64 with Clang and Ninja",
             "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/linux-dbg",
+            "binaryDir": "${sourceDir}/build/linux-x64-dbg",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_C_COMPILER": "clang",
@@ -98,11 +98,11 @@
             }
         },
         {
-            "name": "linux-gcc-rel",
-            "displayName": "Linux GCC Release",
-            "description": "Release build for Linux with GCC and Ninja",
+            "name": "linux-x64-gcc-rel",
+            "displayName": "Linux x64 GCC Release",
+            "description": "Release build for Linux x64 with GCC and Ninja",
             "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/linux-gcc-rel",
+            "binaryDir": "${sourceDir}/build/linux-x64-gcc-rel",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "MinSizeRel",
                 "CMAKE_C_COMPILER": "gcc",
@@ -111,11 +111,63 @@
             }
         },
         {
-            "name": "linux-gcc-dbg",
-            "displayName": "Linux GCC Debug",
-            "description": "Debug build for Linux with GCC and Ninja",
+            "name": "linux-x64-gcc-dbg",
+            "displayName": "Linux x64 GCC Debug",
+            "description": "Debug build for Linux x64 with GCC and Ninja",
             "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/linux-gcc-dbg",
+            "binaryDir": "${sourceDir}/build/linux-x64-gcc-dbg",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++",
+                "ENABLE_VULKAN": "ON"
+            }
+        },
+        {
+            "name": "linux-arm64-rel",
+            "displayName": "Linux ARM64 Release",
+            "description": "Release build for Linux ARM64 with Clang and Ninja",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/linux-arm64-rel",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "MinSizeRel",
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "ENABLE_VULKAN": "ON"
+            }
+        },
+        {
+            "name": "linux-arm64-dbg",
+            "displayName": "Linux ARM64 Debug",
+            "description": "Debug build for Linux ARM64 with Clang and Ninja",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/linux-arm64-dbg",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "ENABLE_VULKAN": "ON"
+            }
+        },
+        {
+            "name": "linux-arm64-gcc-rel",
+            "displayName": "Linux ARM64 GCC Release",
+            "description": "Release build for Linux ARM64 with GCC and Ninja",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/linux-arm64-gcc-rel",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "MinSizeRel",
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++",
+                "ENABLE_VULKAN": "ON"
+            }
+        },
+        {
+            "name": "linux-arm64-gcc-dbg",
+            "displayName": "Linux ARM64 GCC Debug",
+            "description": "Debug build for Linux ARM64 with GCC and Ninja",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/linux-arm64-gcc-dbg",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_C_COMPILER": "gcc",
@@ -182,23 +234,43 @@
             "jobs": 0
         },
         {
-            "name": "linux-rel",
-            "configurePreset": "linux-rel",
+            "name": "linux-x64-rel",
+            "configurePreset": "linux-x64-rel",
             "jobs": 0
         },
         {
-            "name": "linux-dbg",
-            "configurePreset": "linux-dbg",
+            "name": "linux-x64-dbg",
+            "configurePreset": "linux-x64-dbg",
             "jobs": 0
         },
         {
-            "name": "linux-gcc-rel",
-            "configurePreset": "linux-gcc-rel",
+            "name": "linux-x64-gcc-rel",
+            "configurePreset": "linux-x64-gcc-rel",
             "jobs": 0
         },
         {
-            "name": "linux-gcc-dbg",
-            "configurePreset": "linux-gcc-dbg",
+            "name": "linux-x64-gcc-dbg",
+            "configurePreset": "linux-x64-gcc-dbg",
+            "jobs": 0
+        },
+        {
+            "name": "linux-arm64-rel",
+            "configurePreset": "linux-arm64-rel",
+            "jobs": 0
+        },
+        {
+            "name": "linux-arm64-dbg",
+            "configurePreset": "linux-arm64-dbg",
+            "jobs": 0
+        },
+        {
+            "name": "linux-arm64-gcc-rel",
+            "configurePreset": "linux-arm64-gcc-rel",
+            "jobs": 0
+        },
+        {
+            "name": "linux-arm64-gcc-dbg",
+            "configurePreset": "linux-arm64-gcc-dbg",
             "jobs": 0
         },
         {


### PR DESCRIPTION
### Description of Changes
Adds linux arm64 builds 

### Rationale behind Changes
ARM64 Linux devices are getting a little more common so decided to do this

### Suggested Testing Steps
See if CI passes/build launches on arm64 Linux (ex: macOS parallels/Asahi)

### Did you use AI to help find, test, or implement this issue or feature?
No