### PR TITLE
Formats: Fix import crashes and parsing issues for MAX, SharkPort, CBS, and PSV saves

### DIFF
--- a/src/cli/ps2mc_cli.cpp
+++ b/src/cli/ps2mc_cli.cpp
@@ -436,11 +436,12 @@ int PS2McCommandLine::cmdImport(const std::vector<std::string>& args)
 			std::string saveName = save.getTitle();
 			if (saveName.empty())
 			{
-				// Get directory name from first entry
+				// Get directory name from first entry if it's a directory
 				const auto& entries = save.getEntries();
 				if (!entries.empty())
 				{
-					saveName = entries[0].dirEntry.name;
+					const bool hasDir = (entries[0].dirEntry.mode & DF_DIR) != 0;
+					saveName = hasDir ? entries[0].dirEntry.name : "";
 				}
 				if (saveName.empty())
 				{

--- a/src/common/lzari.cpp
+++ b/src/common/lzari.cpp
@@ -6,6 +6,7 @@
 #include <array>
 
 const int ARITH_BITS = 15;
+const int CODE_BITS = ARITH_BITS + 2;
 const int QUADRANT1 = 1 << ARITH_BITS;
 const int QUADRANT2 = QUADRANT1 * 2;
 const int QUADRANT3 = QUADRANT1 * 3;
@@ -101,10 +102,12 @@ void LzariCodec::Impl::flush_bits()
 
 int LzariCodec::Impl::input_bit()
 {
-	if (bitin_pos >= bitin_size)
-		return 0; // padding with zeros
 	if (bitcnt == 0)
 	{
+		if (bitin_pos >= bitin_size)
+		{
+			return 0; // padding with zeros
+		}
 		bitbuf = bitin[bitin_pos++];
 		bitcnt = 8;
 	}
@@ -224,10 +227,10 @@ void LzariCodec::Impl::update_model_decode(int symbol)
 
 void LzariCodec::Impl::encode_symbol(int symbol)
 {
-	int range = high - low;
-	int total = sym_cum[0];
-	high = low + (range * sym_cum[symbol - 1]) / total;
-	low = low + (range * sym_cum[symbol]) / total;
+	int64_t range = high - low;
+	int64_t total = sym_cum[0];
+	high = static_cast<int>(low + (range * sym_cum[symbol - 1]) / total);
+	low = static_cast<int>(low + (range * sym_cum[symbol]) / total);
 
 	for (;;)
 	{
@@ -263,16 +266,16 @@ void LzariCodec::Impl::encode_symbol(int symbol)
 
 int LzariCodec::Impl::decode_symbol()
 {
-	int range = high - low;
-	int total = sym_cum[MAX_CHAR];
-	int n = ((code - low + 1) * total - 1) / range;
+	int64_t range = high - low;
+	int64_t total = sym_cum[MAX_CHAR];
+	int n = static_cast<int>(((static_cast<int64_t>(code - low + 1) * total) - 1) / range);
 
 	int i = 1;
 	while (sym_cum[i] <= n)
 		++i; // sym_cum is ascending in decode mode
 	int symbol = MAX_CHAR + 1 - i;
-	high = low + (range * sym_cum[i]) / total;
-	low = low + (range * sym_cum[i - 1]) / total;
+	high = static_cast<int>(low + (range * sym_cum[i]) / total);
+	low = static_cast<int>(low + (range * sym_cum[i - 1]) / total);
 
 	for (;;)
 	{
@@ -300,17 +303,18 @@ int LzariCodec::Impl::decode_symbol()
 		high <<= 1;
 		code = (code << 1) + input_bit();
 	}
+	int ret = sym_to_char[symbol];
 	update_model_decode(symbol);
-	return sym_to_char[symbol];
+	return ret;
 }
 
 void LzariCodec::Impl::encode_position(int position)
 {
 	// position is 0..N-1 representing distance-1
-	int range = high - low;
-	int total = position_cum[0];
-	high = low + (range * position_cum[position]) / total;
-	low = low + (range * position_cum[position + 1]) / total;
+	int64_t range = high - low;
+	int64_t total = position_cum[0];
+	high = static_cast<int>(low + (range * position_cum[position]) / total);
+	low = static_cast<int>(low + (range * position_cum[position + 1]) / total);
 
 	for (;;)
 	{
@@ -345,9 +349,9 @@ void LzariCodec::Impl::encode_position(int position)
 
 int LzariCodec::Impl::decode_position()
 {
-	int range = high - low;
-	int total = position_cum[0];
-	int n = ((code - low + 1) * total - 1) / range;
+	int64_t range = high - low;
+	int64_t total = position_cum[0];
+	int n = static_cast<int>(((static_cast<int64_t>(code - low + 1) * total) - 1) / range);
 
 	// binary search position_cum.
 	int c = 1, s = N;
@@ -366,8 +370,8 @@ int LzariCodec::Impl::decode_position()
 			break;
 	}
 	int position = s - 1;
-	high = low + (range * position_cum[position]) / total;
-	low = low + (range * position_cum[position + 1]) / total;
+	high = static_cast<int>(low + (range * position_cum[position]) / total);
+	low = static_cast<int>(low + (range * position_cum[position + 1]) / total);
 
 	for (;;)
 	{
@@ -504,7 +508,7 @@ std::vector<uint8_t> LzariCodec::Impl::decompress(const std::vector<uint8_t>& in
 	low = 0;
 	high = QUADRANT4;
 	code = 0;
-	for (int i = 0; i < ARITH_BITS; ++i)
+	for (int i = 0; i < CODE_BITS; ++i)
 	{
 		code = (code << 1) + input_bit();
 	}

--- a/src/core/formats/ps2mc.cpp
+++ b/src/core/formats/ps2mc.cpp
@@ -1607,7 +1607,26 @@ bool PS2MemoryCard::importSaveFile(PS2SaveFile& save, bool ignoreExisting, const
 			throw PS2McError("Save file contains no entries");
 		}
 
-		const auto& dirEntry = entries[0].dirEntry;
+		const bool hasDirHeader = (entries[0].dirEntry.mode & DF_DIR) != 0;
+		PS2McDirEntry dirEntry{};
+		if (hasDirHeader)
+		{
+			dirEntry = entries[0].dirEntry;
+		}
+		else
+		{
+			dirEntry.name = save.getTitle();
+			if (dirEntry.name.empty())
+			{
+				dirEntry.name = entries[0].dirEntry.name;
+			}
+			dirEntry.mode = DF_DIR | DF_EXISTS | DF_RWX | DF_0400;
+			dirEntry.created = entries[0].dirEntry.created;
+			dirEntry.modified = dirEntry.created;
+			dirEntry.unused = 0;
+			dirEntry.attr = 0;
+		}
+
 		std::string saveDirName = targetDir.empty() ? dirEntry.name : targetDir;
 
 		if (!saveDirName.empty() && saveDirName[0] == '/')
@@ -1635,7 +1654,8 @@ bool PS2MemoryCard::importSaveFile(PS2SaveFile& save, bool ignoreExisting, const
 
 		makeDir(savePath);
 
-		for (size_t i = 1; i < entries.size(); ++i)
+		const size_t firstFileIdx = hasDirHeader ? 1 : 0;
+		for (size_t i = firstFileIdx; i < entries.size(); ++i)
 		{
 			const auto& entry = entries[i];
 			std::string filePath = savePath + "/" + entry.dirEntry.name;
@@ -1677,21 +1697,20 @@ bool PS2MemoryCard::importSaveFile(PS2SaveFile& save, bool ignoreExisting, const
 			(void)pImpl->find_entry(savePath, saveParentCluster);
 
 			auto parentRows = pImpl->read_dirents(saveParentCluster);
-			const auto& hdr = entries[0].dirEntry;
 			constexpr uint16_t typeMask = DF_FILE | DF_DIR | DF_EXISTS;
 			for (auto& row : parentRows)
 			{
 				if (row.name == saveDirName && (row.mode & DF_DIR))
 				{
-					row.mode = static_cast<uint16_t>((hdr.mode & ~typeMask) | (row.mode & typeMask));
+					row.mode = static_cast<uint16_t>((dirEntry.mode & ~typeMask) | (row.mode & typeMask));
 					if ((row.mode & DF_EXISTS) && (row.mode & DF_DIR) && !(row.mode & DF_PSX))
 					{
 						row.mode |= DF_0400;
 					}
-					row.unused = hdr.unused;
-					row.created = hdr.created;
-					row.modified = hdr.modified;
-					row.attr = hdr.attr;
+					row.unused = dirEntry.unused;
+					row.created = dirEntry.created;
+					row.modified = dirEntry.modified;
+					row.attr = dirEntry.attr;
 					break;
 				}
 			}

--- a/src/core/formats/ps2save.cpp
+++ b/src/core/formats/ps2save.cpp
@@ -508,20 +508,20 @@ void PS2SaveFile::Impl::loadCodeBreaker(std::ifstream& file)
 	std::vector<uint8_t> header = readFixed(file, hlen - 12);
 
 	uint32_t dlen = 0, flen = 0;
-	std::memcpy(&dlen, header.data(), 4);
+	std::memcpy(&dlen, header.data() + 0, 4);
 	std::memcpy(&flen, header.data() + 4, 4);
 
 	char dirname[32];
 	std::memcpy(dirname, header.data() + 8, 32);
 
-	auto created_data = readFixed(file, 8);
+	std::vector<uint8_t> created_data(header.begin() + 40, header.begin() + 48);
 	PS2McTod created = unpackTod(created_data);
 
-	auto modified_data = readFixed(file, 8);
+	std::vector<uint8_t> modified_data(header.begin() + 48, header.begin() + 56);
 	PS2McTod modified = unpackTod(modified_data);
 
 	uint32_t dirmode = 0;
-	std::memcpy(&dirmode, header.data() + 44, 4);
+	std::memcpy(&dirmode, header.data() + 64, 4);
 
 	if (!(dirmode & DF_DIR))
 	{
@@ -533,7 +533,25 @@ void PS2SaveFile::Impl::loadCodeBreaker(std::ifstream& file)
 	if (todToTime(modified) == 0)
 		modified = timeToTod(std::time(nullptr));
 
-	auto body = readFixed(file, flen);
+	size_t remaining = 0;
+	{
+		auto cur = file.tellg();
+		file.seekg(0, std::ios::end);
+		remaining = static_cast<size_t>(file.tellg() - cur);
+		file.seekg(cur, std::ios::beg);
+	}
+
+	size_t body_len = flen;
+	if (body_len > remaining)
+	{
+		body_len = remaining;
+	}
+	if (body_len != flen && body_len != flen - hlen)
+	{
+		throw PS2SaveError("Unexpected EOF");
+	}
+
+	auto body = readFixed(file, body_len);
 
 	std::vector<uint8_t> rc4_key(std::begin(PS2SAVE_CBS_RC4S), std::end(PS2SAVE_CBS_RC4S));
 	auto decrypted = rc4_crypt(rc4_key, body);
@@ -560,14 +578,14 @@ void PS2SaveFile::Impl::loadCodeBreaker(std::ifstream& file)
 			break;
 
 		uint32_t fsize = 0;
-		std::memcpy(&fsize, decompressed.data() + off + 8, 4);
+		std::memcpy(&fsize, decompressed.data() + off + 16, 4);
 		uint16_t fmode = 0;
-		std::memcpy(&fmode, decompressed.data() + off + 12, 2);
+		std::memcpy(&fmode, decompressed.data() + off + 20, 2);
 
-		auto fcreated_data = std::vector<uint8_t>(decompressed.data() + off + 14,
-			decompressed.data() + off + 18);
-		auto fmodified_data = std::vector<uint8_t>(decompressed.data() + off + 18,
-			decompressed.data() + off + 22);
+		std::vector<uint8_t> fcreated_data(decompressed.begin() + off + 0,
+			decompressed.begin() + off + 8);
+		std::vector<uint8_t> fmodified_data(decompressed.begin() + off + 8,
+			decompressed.begin() + off + 16);
 
 		char fname[32];
 		std::memcpy(fname, decompressed.data() + off + 32, 32);
@@ -590,14 +608,14 @@ void PS2SaveFile::Impl::loadCodeBreaker(std::ifstream& file)
 		PS2McDirEntry ent;
 		ent.mode = fmode | DF_EXISTS;
 		ent.length = fsize;
-		ent.name = zeroTerminate(std::string(fname));
+		ent.name = zeroTerminate(std::string(fname, 32));
 		ent.created = fcreated;
 		ent.modified = fmodified;
 
 		entries.push_back({ent, std::move(fdata)});
 	}
 
-	title = zeroTerminate(std::string(dirname));
+	title = zeroTerminate(std::string(dirname, 32));
 	format = SaveFormat::CODEBREAKER;
 }
 

--- a/src/core/formats/ps2save.cpp
+++ b/src/core/formats/ps2save.cpp
@@ -290,7 +290,8 @@ void PS2SaveFile::Impl::loadMaxDrive(std::ifstream& file)
 		if (off + l > decompressed.size())
 			throw PS2SaveError("MAX file truncated");
 		std::vector<uint8_t> data(decompressed.begin() + off, decompressed.begin() + off + l);
-		off += roundUp(static_cast<int>(l) + 8, 16) - 8;
+		off += l;
+		off = roundUp(static_cast<int>(off) + 8, 16) - 8;
 
 		PS2McDirEntry ent{};
 		ent.mode = DF_RWX | DF_FILE | DF_0400 | DF_EXISTS;
@@ -716,8 +717,12 @@ void PS2SaveFile::Impl::loadPsv(std::ifstream& file)
 void PS2SaveFile::Impl::saveMaxDrive(std::ofstream& file)
 {
 	std::vector<uint8_t> blob;
-	for (auto& e : entries)
+	const bool hasDirHeader = !entries.empty() && (entries[0].dirEntry.mode & DF_DIR);
+	const size_t firstFileIdx = hasDirHeader ? 1 : 0;
+
+	for (size_t i = firstFileIdx; i < entries.size(); ++i)
 	{
+		const auto& e = entries[i];
 		const auto& ent = e.dirEntry;
 		const auto& data = e.data;
 		uint32_t len = static_cast<uint32_t>(data.size());
@@ -730,8 +735,7 @@ void PS2SaveFile::Impl::saveMaxDrive(std::ofstream& file)
 		std::memcpy(blob.data() + cur, &len, 4);
 		std::memcpy(blob.data() + cur + 4, name, 32);
 		std::memcpy(blob.data() + cur + 36, data.data(), len);
-		size_t padded = roundUp(static_cast<int>(len) + 8, 16) - 8;
-		blob.resize(cur + 36 + padded);
+		blob.resize(roundUp(static_cast<int>(cur + 36 + len) + 8, 16) - 8);
 	}
 	uint32_t length = static_cast<uint32_t>(blob.size());
 	auto compressed = lzariCompress(blob);
@@ -739,13 +743,18 @@ void PS2SaveFile::Impl::saveMaxDrive(std::ofstream& file)
 	char dirname[32] = {0};
 	if (!entries.empty())
 	{
-		const size_t copyLen = std::min(entries[0].dirEntry.name.size(), sizeof(dirname) - 1);
-		std::memcpy(dirname, entries[0].dirEntry.name.c_str(), copyLen);
+		std::string dName = hasDirHeader ? entries[0].dirEntry.name : title;
+		if (dName.empty())
+		{
+			dName = entries[0].dirEntry.name;
+		}
+		const size_t copyLen = std::min(dName.size(), sizeof(dirname) - 1);
+		std::memcpy(dirname, dName.c_str(), copyLen);
 		dirname[copyLen] = '\0';
 	}
 	char iconsys[32] = {0};
 	uint32_t clen = static_cast<uint32_t>(compressed.size()) + 4; // include CRC field itself
-	uint32_t dirlen = static_cast<uint32_t>(entries.size());
+	uint32_t dirlen = static_cast<uint32_t>(hasDirHeader ? entries.size() - 1 : entries.size());
 	uint32_t crc = 0; // omitted
 	file.write(PS2SAVE_MAX_MAGIC, 12);
 	file.write(reinterpret_cast<const char*>(&crc), 4);
@@ -888,9 +897,12 @@ std::string makeLongname(const std::string& dirname, const PS2SaveFile& save)
 	std::string title = save.getTitle();
 
 	uint32_t crc = 0xFFFFFFFF;
-	for (const auto& entry : save.getEntries())
+	const auto& entries = save.getEntries();
+	const bool hasDirHeader = !entries.empty() && (entries[0].dirEntry.mode & DF_DIR);
+	const size_t firstFileIdx = hasDirHeader ? 1 : 0;
+	for (size_t i = firstFileIdx; i < entries.size(); ++i)
 	{
-		for (uint8_t byte : entry.data)
+		for (uint8_t byte : entries[i].data)
 		{
 			crc ^= byte;
 			for (int bit = 0; bit < 8; ++bit)

--- a/src/core/formats/ps2save.cpp
+++ b/src/core/formats/ps2save.cpp
@@ -159,6 +159,16 @@ SaveFormat PS2SaveFile::detectFormat(const std::string& filename)
 	}
 	if (std::memcmp(magic, PS2SAVE_SPS_MAGIC, 13) == 0)
 	{
+		size_t dotPos = filename.find_last_of('.');
+		if (dotPos != std::string::npos)
+		{
+			std::string ext = filename.substr(dotPos);
+			std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+			if (ext == ".xps")
+			{
+				return SaveFormat::XPORT;
+			}
+		}
 		return SaveFormat::SHARKPORT;
 	}
 	if (std::memcmp(magic, PS2SAVE_CBS_MAGIC, 4) == 0)
@@ -311,10 +321,12 @@ void PS2SaveFile::Impl::loadMaxDrive(std::ifstream& file)
 
 void PS2SaveFile::Impl::loadSharkPort(std::ifstream& file)
 {
+	const std::string fmtName = (format == SaveFormat::XPORT) ? "X-Port" : "SharkPort";
+
 	auto magic = readFixed(file, 17);
 	if (std::memcmp(magic.data(), PS2SAVE_SPS_MAGIC, 13) != 0)
 	{
-		throw PS2SaveError("Not a SharkPort save");
+		throw PS2SaveError("Not a " + fmtName + " save");
 	}
 
 	uint32_t savetype = 0;
@@ -345,12 +357,14 @@ void PS2SaveFile::Impl::loadSharkPort(std::ifstream& file)
 	uint32_t dirlen = 0;
 	file.read(reinterpret_cast<char*>(&dirlen), 4);
 
-	uint16_t dirmode = 0;
-	file.read(reinterpret_cast<char*>(&dirmode), 2);
 	readFixed(file, 8); // skip 8 bytes
 
-	auto created_data = readFixed(file, 8);
+	uint16_t dirmode = 0;
+	file.read(reinterpret_cast<char*>(&dirmode), 2);
 
+	readFixed(file, 2); // skip 2 bytes
+
+	auto created_data = readFixed(file, 8);
 
 	auto modified_data = readFixed(file, 8);
 
@@ -361,7 +375,7 @@ void PS2SaveFile::Impl::loadSharkPort(std::ifstream& file)
 
 	if (!(dirmode & DF_DIR) || dirlen < 2)
 	{
-		throw PS2SaveError("Invalid SharkPort directory header");
+		throw PS2SaveError("Invalid " + fmtName + " directory header");
 	}
 
 	entries.clear();
@@ -398,7 +412,7 @@ void PS2SaveFile::Impl::loadSharkPort(std::ifstream& file)
 
 		if (!(fmode & DF_FILE))
 		{
-			throw PS2SaveError("Non-file in SharkPort directory");
+			throw PS2SaveError("Non-file in " + fmtName + " directory");
 		}
 
 		auto fdata = readFixed(file, fsize);
@@ -414,7 +428,10 @@ void PS2SaveFile::Impl::loadSharkPort(std::ifstream& file)
 	}
 
 	title = dirname;
-	format = SaveFormat::SHARKPORT;
+	if (format != SaveFormat::XPORT)
+	{
+		format = SaveFormat::SHARKPORT;
+	}
 }
 
 namespace

--- a/src/core/formats/ps2save.cpp
+++ b/src/core/formats/ps2save.cpp
@@ -627,10 +627,11 @@ void PS2SaveFile::Impl::loadPsv(std::ifstream& file)
 		throw PS2SaveError("Not a PSV file");
 	}
 
-	uint32_t version = 0, savetype = 0;
+	uint32_t version = 0, next_section_size = 0, savetype = 0;
 	file.read(reinterpret_cast<char*>(&version), 4);
 	readFixed(file, 40); // signature
 	readFixed(file, 8); // reserved
+	file.read(reinterpret_cast<char*>(&next_section_size), 4);
 	file.read(reinterpret_cast<char*>(&savetype), 4);
 
 	if (version != 0)
@@ -663,7 +664,7 @@ void PS2SaveFile::Impl::loadPsv(std::ifstream& file)
 		auto root_created_data = readFixed(file, 8);
 		auto root_modified_data = readFixed(file, 8);
 		uint32_t root_size = 0;
-		uint16_t root_mode = 0;
+		uint32_t root_mode = 0;
 		file.read(reinterpret_cast<char*>(&root_size), 4);
 		file.read(reinterpret_cast<char*>(&root_mode), 4);
 
@@ -675,9 +676,7 @@ void PS2SaveFile::Impl::loadPsv(std::ifstream& file)
 			throw PS2SaveError("PSV root is not a directory");
 		}
 
-
-
-		title = zeroTerminate(std::string(reinterpret_cast<const char*>(root_filename.data())));
+		title = zeroTerminate(std::string(reinterpret_cast<const char*>(root_filename.data()), 32));
 
 		entries.clear();
 		entries.reserve(files_count);
@@ -688,7 +687,7 @@ void PS2SaveFile::Impl::loadPsv(std::ifstream& file)
 			auto file_created_data = readFixed(file, 8);
 			auto file_modified_data = readFixed(file, 8);
 			uint32_t file_size = 0;
-			uint16_t file_mode = 0;
+			uint32_t file_mode = 0;
 			file.read(reinterpret_cast<char*>(&file_size), 4);
 			file.read(reinterpret_cast<char*>(&file_mode), 4);
 
@@ -699,9 +698,9 @@ void PS2SaveFile::Impl::loadPsv(std::ifstream& file)
 			file.read(reinterpret_cast<char*>(&file_offset), 4);
 
 			PS2McDirEntry ent;
-			ent.mode = file_mode | DF_EXISTS;
+			ent.mode = static_cast<uint16_t>(file_mode | DF_EXISTS);
 			ent.length = file_size;
-			ent.name = zeroTerminate(std::string(reinterpret_cast<const char*>(filename_buf.data())));
+			ent.name = zeroTerminate(std::string(reinterpret_cast<const char*>(filename_buf.data()), 32));
 			ent.created = unpackTod(file_created_data);
 			ent.modified = unpackTod(file_modified_data);
 
@@ -724,13 +723,14 @@ void PS2SaveFile::Impl::loadPsv(std::ifstream& file)
 		file.read(reinterpret_cast<char*>(&save_size), 4);
 		file.read(reinterpret_cast<char*>(&save_offset), 4);
 		readFixed(file, 20); // reserved
-		file.read(reinterpret_cast<char*>(&save_offset), 4); // actual offset
+		uint32_t unused_next = 0;
+		file.read(reinterpret_cast<char*>(&unused_next), 4);
 		readFixed(file, 4); // reserved
 
 		std::vector<uint8_t> prod_code(20);
 		file.read(reinterpret_cast<char*>(prod_code.data()), 20);
 
-		title = zeroTerminate(std::string(reinterpret_cast<const char*>(prod_code.data())));
+		title = zeroTerminate(std::string(reinterpret_cast<const char*>(prod_code.data()), 20));
 
 		entries.clear();
 		uint16_t mode = DF_RWX | DF_FILE | DF_0080 | DF_0400 | DF_EXISTS;

--- a/src/ui/CardActionHandler.cpp
+++ b/src/ui/CardActionHandler.cpp
@@ -95,7 +95,12 @@ void CardActionHandler::importSave(PS2MemoryCard* card, const QString& filename)
 			return;
 		}
 
-		std::string saveName = entries[0].dirEntry.name;
+		const bool hasDirHeader = !entries.empty() && (entries[0].dirEntry.mode & DF_DIR);
+		std::string saveName = hasDirHeader ? entries[0].dirEntry.name : saveFile.getTitle();
+		if (saveName.empty())
+		{
+			saveName = entries[0].dirEntry.name;
+		}
 
 		bool result = card->importSaveFile(saveFile, false, "");
 


### PR DESCRIPTION
### Description of Changes
Fixes issues that caused/not allowing imports:
* **MAX / SharkPort**: Fixed import crashes and incorrect directory name loading.
* **CodeBreaker (CBS)**: Fixed file truncation issues that caused "Unexpected EOF" errors during import.
* **PSV**: Fixed "Unsupported PSV save type" errors

### Rationale behind Changes
Allows the application to import MAX, SharkPort, CodeBreaker, and PSV format saves without crashing or showing error dialogs.

### Suggested Testing Steps
Import `.max`, `.sps`, `.xps,` `.cbs`, and `.psv` saves to a memory card in the UI.

### Related Issues / Links
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No