### PR TITLE
Core/Renderer/VK: Finish VMA migration, validation fixes, smoother resize, and various fixes

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -123,7 +123,7 @@ jobs:
           host: 'linux'
           target: 'desktop'
           arch: 'linux_gcc_64'
-          modules: 'qtimageformats'
+          modules: 'qtimageformats qtwaylandcompositor'
           cache: true
           use-official: true
 
@@ -135,7 +135,7 @@ jobs:
           host: 'linux_arm64'
           target: 'desktop'
           arch: 'linux_gcc_arm64'
-          modules: 'qtimageformats'
+          modules: 'qtimageformats qtwaylandcompositor'
           cache: true
           use-official: true
 
@@ -273,7 +273,8 @@ jobs:
           echo "Using QMAKE: $QMAKE_PATH"
           
           echo "Running linuxdeploy to create AppDir..."
-          EXTRA_QT_MODULES="core;gui;widgets;xcbqpa" \
+          EXTRA_QT_MODULES="core;gui;widgets;waylandclient;waylandcompositor;xcbqpa" \
+          EXTRA_PLATFORM_PLUGINS="libqwayland.so" \
           DEPLOY_PLATFORM_THEMES="1" \
           QMAKE="$QMAKE_PATH" \
           NO_STRIP="1" \
@@ -283,6 +284,12 @@ jobs:
           echo "Copying resources into AppDir..."
           if [ -d "${BUILD_DIR}/resources" ]; then
             cp -a "${BUILD_DIR}/resources" "$OUTDIR/usr/bin"
+          fi
+
+          echo "Copying translations into AppDir..."
+          if [ -d "${BUILD_DIR}/translations" ]; then
+            rm -fr "$OUTDIR/usr/bin/translations" "$OUTDIR/usr/translations"
+            cp -a "${BUILD_DIR}/translations" "$OUTDIR/usr/bin"
           fi
           
           echo "Generating AppImage..."

--- a/resources/Info.plist.in
+++ b/resources/Info.plist.in
@@ -7,7 +7,7 @@
 	<string>myMCpp</string>
 
 	<key>CFBundleIdentifier</key>
-	<string>xyz.sternserv.myMCpp</string>
+	<string>net.mymcpp.myMCpp</string>
 
 	<key>CFBundleName</key>
 	<string>myMCpp</string>
@@ -60,7 +60,7 @@
 	<array>
 		<dict>
 			<key>UTTypeIdentifier</key>
-			<string>net.pcsx2.memcard</string>
+			<string>net.mymcpp.memcard</string>
 			<key>UTTypeDescription</key>
 			<string>PlayStation 2 Memory Card</string>
 			<key>UTTypeConformsTo</key>

--- a/src/core/formats/ps2iconsys.h
+++ b/src/core/formats/ps2iconsys.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <memory>
 #include <array>
+#include <cstdint>
 
 // PS2 icon.sys structure
 struct IconSysColor

--- a/src/core/renderer/Vulkan/VulkanDevice.cpp
+++ b/src/core/renderer/Vulkan/VulkanDevice.cpp
@@ -107,7 +107,7 @@ bool VulkanDevice::createInstance()
 	appInfo.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
 	appInfo.pEngineName = "myMCpp";
 	appInfo.engineVersion = VK_MAKE_VERSION(1, 0, 0);
-	appInfo.apiVersion = VK_API_VERSION_1_3;
+	appInfo.apiVersion = VK_API_VERSION_1_1;
 
 	std::vector<const char*> extensions = {
 		VK_KHR_SURFACE_EXTENSION_NAME,
@@ -401,12 +401,55 @@ bool VulkanDevice::createLogicalDevice()
 	float queuePriority = 1.0f;
 	queueCreateInfo.pQueuePriorities = &queuePriority;
 
+	uint32_t extensionCount = 0;
+	vkEnumerateDeviceExtensionProperties(m_physicalDevice, nullptr, &extensionCount, nullptr);
+	std::vector<VkExtensionProperties> availableExtensions(extensionCount);
+	if (extensionCount > 0)
+		vkEnumerateDeviceExtensionProperties(m_physicalDevice, nullptr, &extensionCount, availableExtensions.data());
+
+	auto hasExtension = [&](const char* name) {
+		for (const auto& ext : availableExtensions)
+		{
+			if (std::strcmp(ext.extensionName, name) == 0)
+				return true;
+		}
+		return false;
+	};
+
+	VkPhysicalDeviceMemoryPriorityFeaturesEXT memPriorityFeatures{};
+	memPriorityFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT;
+
+	VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT pageableFeatures{};
+	pageableFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PAGEABLE_DEVICE_LOCAL_MEMORY_FEATURES_EXT;
+
 	VkPhysicalDeviceFeatures2 features2{};
 	features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+
+	void** chain = &features2.pNext;
+	if (hasExtension(VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME))
+	{
+		*chain = &memPriorityFeatures;
+		chain = &memPriorityFeatures.pNext;
+	}
+	if (hasExtension(VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME))
+		*chain = &pageableFeatures;
+
 	vkGetPhysicalDeviceFeatures2(m_physicalDevice, &features2);
 
-	std::vector<const char*> extensions = {
-		VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+	const bool supportsMemoryPriority = hasExtension(VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME) && memPriorityFeatures.memoryPriority == VK_TRUE;
+	const bool supportsPageable = hasExtension(VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME) && pageableFeatures.pageableDeviceLocalMemory == VK_TRUE && supportsMemoryPriority;
+
+	std::vector<const char*> extensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+	if (supportsMemoryPriority)
+	{
+		memPriorityFeatures.memoryPriority = VK_TRUE;
+		extensions.push_back(VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME);
+	}
+	if (supportsPageable)
+	{
+		pageableFeatures.pageableDeviceLocalMemory = VK_TRUE;
+		extensions.push_back(VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME);
+	}
 
 	VkDeviceCreateInfo createInfo{};
 	createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
@@ -422,13 +465,17 @@ bool VulkanDevice::createLogicalDevice()
 		return false;
 	}
 
+	m_supportsMemoryPriority = supportsMemoryPriority;
+
 	vkGetDeviceQueue(m_device, m_graphicsQueueFamily, 0, &m_graphicsQueue);
 
 	VmaAllocatorCreateInfo allocatorInfo{};
 	allocatorInfo.physicalDevice = m_physicalDevice;
 	allocatorInfo.device = m_device;
 	allocatorInfo.instance = m_instance;
-	allocatorInfo.vulkanApiVersion = VK_API_VERSION_1_3;
+	allocatorInfo.vulkanApiVersion = VK_API_VERSION_1_1;
+	if (m_supportsMemoryPriority)
+		allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT;
 
 	if (vmaCreateAllocator(&allocatorInfo, &m_allocator) != VK_SUCCESS)
 	{
@@ -440,19 +487,8 @@ bool VulkanDevice::createLogicalDevice()
 	return true;
 }
 
-uint32_t VulkanDevice::findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties) const
+void VulkanDevice::setAllocationPriority(VmaAllocationCreateInfo& allocInfo, float priority) const
 {
-	VkPhysicalDeviceMemoryProperties2 memProperties2{};
-	memProperties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
-	vkGetPhysicalDeviceMemoryProperties2(m_physicalDevice, &memProperties2);
-	const VkPhysicalDeviceMemoryProperties& memProperties = memProperties2.memoryProperties;
-
-	for (uint32_t i = 0; i < memProperties.memoryTypeCount; ++i)
-	{
-		if ((typeFilter & (1 << i)) && (memProperties.memoryTypes[i].propertyFlags & properties) == properties)
-			return i;
-	}
-
-	Logger::error("VK: Failed to find suitable memory type");
-	return UINT32_MAX;
+	if (m_supportsMemoryPriority)
+		allocInfo.priority = priority;
 }

--- a/src/core/renderer/Vulkan/VulkanDevice.h
+++ b/src/core/renderer/Vulkan/VulkanDevice.h
@@ -28,8 +28,9 @@ public:
 	VkQueue getGraphicsQueue() const { return m_graphicsQueue; }
 	uint32_t getGraphicsQueueFamily() const { return m_graphicsQueueFamily; }
 	VmaAllocator getAllocator() const { return m_allocator; }
+	bool supportsMemoryPriority() const { return m_supportsMemoryPriority; }
 
-	uint32_t findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties) const;
+	void setAllocationPriority(VmaAllocationCreateInfo& allocInfo, float priority) const;
 
 private:
 	bool createInstance();
@@ -44,6 +45,7 @@ private:
 	VkQueue m_graphicsQueue = VK_NULL_HANDLE;
 	uint32_t m_graphicsQueueFamily = 0;
 	VmaAllocator m_allocator = VK_NULL_HANDLE;
+	bool m_supportsMemoryPriority = false;
 #ifdef __linux__
 	void* m_platformDisplay = nullptr; // Display* on Linux/X11
 #endif

--- a/src/core/renderer/Vulkan/VulkanPipeline.cpp
+++ b/src/core/renderer/Vulkan/VulkanPipeline.cpp
@@ -159,7 +159,6 @@ bool VulkanPipeline::createPipelineCache(VkDevice device)
 		return false;
 	}
 
-	Logger::info("VK: Pipeline cache created");
 	return true;
 }
 
@@ -385,7 +384,6 @@ bool VulkanPipeline::createMainPipeline(VkDevice device, VkRenderPass renderPass
 		return false;
 	}
 
-	Logger::info("VK: Graphics pipeline created with dynamic viewport/scissor");
 	return true;
 }
 
@@ -550,6 +548,5 @@ bool VulkanPipeline::createBackgroundPipeline(VkDevice device, VkRenderPass rend
 
 	vkDestroyShaderModule(device, bgVert, nullptr);
 	vkDestroyShaderModule(device, bgFrag, nullptr);
-	Logger::info("VK: Background pipeline created with dynamic viewport/scissor");
 	return true;
 }

--- a/src/core/renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/core/renderer/Vulkan/VulkanRenderer.cpp
@@ -6,11 +6,9 @@
 #include "ps2iconsys.h"
 #include "Logger.h"
 #include "../../../common/Config.h"
+#include <vk_mem_alloc.h>
 #include <cstring>
 #include <algorithm>
-#include <chrono>
-#include <unordered_map>
-#include <array>
 #include <glm/glm.hpp>
 
 #ifdef _WIN32
@@ -29,11 +27,8 @@ VulkanRenderer::VulkanRenderer(const WindowInfo& windowInfo, Config* config)
 	, m_height(windowInfo.surface_height)
 	, m_initialized(false)
 	, m_vertexBuffer(VK_NULL_HANDLE)
-	, m_vertexMemory(VK_NULL_HANDLE)
 	, m_uniformBuffer(VK_NULL_HANDLE)
-	, m_uniformMemory(VK_NULL_HANDLE)
 	, m_textureImage(VK_NULL_HANDLE)
-	, m_textureMemory(VK_NULL_HANDLE)
 	, m_textureView(VK_NULL_HANDLE)
 	, m_textureSampler(VK_NULL_HANDLE)
 	, m_descriptorPool(VK_NULL_HANDLE)
@@ -57,8 +52,6 @@ VulkanRenderer::~VulkanRenderer()
 
 bool VulkanRenderer::initialize()
 {
-	Logger::info("VK: VulkanRenderer::initialize() - Size: {}x{} Ptr: {}", m_width, m_height, (void*)this);
-
 	if (m_width < 100 || m_height < 100)
 	{
 		Logger::warn("VK: Window too small: {}x{}", m_width, m_height);
@@ -94,6 +87,9 @@ bool VulkanRenderer::initialize()
 	if (!m_vulkanPipeline.createBackgroundPipeline(m_vulkanDevice.getDevice(), renderPass))
 		return false;
 
+	if (!createDescriptorResources())
+		return false;
+
 	if (!m_vulkanResources.createCommandPool(m_vulkanDevice.getDevice(), m_vulkanDevice.getGraphicsQueueFamily()))
 		return false;
 
@@ -104,13 +100,13 @@ bool VulkanRenderer::initialize()
 			static_cast<uint32_t>(m_vulkanSwapchain.getImages().size())))
 		return false;
 
-	if (!createCommandBuffers())
+	if (!allocateCommandBuffers())
 		return false;
 
 	m_imagesInFlight.resize(m_vulkanSwapchain.getImages().size(), VK_NULL_HANDLE);
 
 	m_initialized = true;
-	Logger::info("VK: VulkanRenderer initialized successfully");
+	Logger::info("VK: Renderer initialized successfully");
 	return true;
 }
 
@@ -120,6 +116,7 @@ void VulkanRenderer::shutdown()
 		return;
 
 	VkDevice device = m_vulkanDevice.getDevice();
+	VmaAllocator allocator = m_vulkanDevice.getAllocator();
 	if (device != VK_NULL_HANDLE)
 	{
 		vkDeviceWaitIdle(device);
@@ -132,37 +129,35 @@ void VulkanRenderer::shutdown()
 		}
 
 		if (m_vertexBuffer != VK_NULL_HANDLE)
-			vkDestroyBuffer(device, m_vertexBuffer, nullptr);
-		if (m_vertexMemory != VK_NULL_HANDLE)
-			vkFreeMemory(device, m_vertexMemory, nullptr);
+			vmaDestroyBuffer(allocator, m_vertexBuffer, m_vertexAllocation);
 		if (m_uniformBuffer != VK_NULL_HANDLE)
-			vkDestroyBuffer(device, m_uniformBuffer, nullptr);
-		if (m_uniformMemory != VK_NULL_HANDLE)
-			vkFreeMemory(device, m_uniformMemory, nullptr);
+			vmaDestroyBuffer(allocator, m_uniformBuffer, m_uniformAllocation);
 		if (m_textureSampler != VK_NULL_HANDLE)
 			vkDestroySampler(device, m_textureSampler, nullptr);
 		if (m_textureView != VK_NULL_HANDLE)
 			vkDestroyImageView(device, m_textureView, nullptr);
 		if (m_textureImage != VK_NULL_HANDLE)
-			vkDestroyImage(device, m_textureImage, nullptr);
-		if (m_textureMemory != VK_NULL_HANDLE)
-			vkFreeMemory(device, m_textureMemory, nullptr);
+			vmaDestroyImage(allocator, m_textureImage, m_textureAllocation);
+		if (m_stagingBuffer != VK_NULL_HANDLE)
+			vmaDestroyBuffer(allocator, m_stagingBuffer, m_stagingAllocation);
 		if (m_descriptorPool != VK_NULL_HANDLE)
 			vkDestroyDescriptorPool(device, m_descriptorPool, nullptr);
 
-		m_vulkanResources.destroy(device);
+		m_vulkanResources.destroy(device, allocator);
 		m_vulkanPipeline.destroy(device);
-		m_vulkanSwapchain.destroy(device);
+		m_vulkanSwapchain.destroy(device, allocator);
 	}
 	m_initialized = false;
 }
 
 void VulkanRenderer::setIcon(std::shared_ptr<PS2Icon::Icon> icon)
 {
+	if (m_icon == icon)
+		return;
+
 	m_icon = icon;
 	m_animStart = std::chrono::steady_clock::now();
 	m_iconChanged = true;
-	Logger::info("VK: Icon set");
 }
 
 bool VulkanRenderer::hasValidIcon() const
@@ -174,10 +169,7 @@ void VulkanRenderer::setAnimationEnabled(bool enabled)
 {
 	m_animationEnabled = enabled;
 	if (!enabled)
-	{
 		prepareVertexData();
-		m_iconChanged = true;
-	}
 }
 
 void VulkanRenderer::setRotation(float x, float y, float z)
@@ -220,10 +212,7 @@ void VulkanRenderer::setLightingMode(LightingMode mode)
 void VulkanRenderer::setBackgroundFromIconSys(PS2IconSys* iconSys)
 {
 	if (m_background.loadFromIconSys(iconSys))
-	{
 		updateBackgroundVertexData();
-		m_iconChanged = true;
-	}
 }
 
 void VulkanRenderer::setBackgroundColor(float r, float g, float b, float a)
@@ -247,14 +236,11 @@ void VulkanRenderer::render()
 
 	if (m_iconChanged)
 	{
-		Logger::debug("VK: Processing icon change");
-		// Wait for GPU to finish using old resources before destroying them
 		vkDeviceWaitIdle(device);
 		prepareVertexData();
 		uploadTexture();
-		createCommandBuffers();
 		m_iconChanged = false;
-		Logger::debug("VK: Icon prepared with {} vertices", m_vertexCount);
+		Logger::info("VK: Icon loaded successfully");
 	}
 
 	if (m_animationEnabled && m_icon && m_icon->getAnimationShapes() > 1 && m_icon->getFrameCount() > 0 && m_vertexBuffer != VK_NULL_HANDLE)
@@ -284,17 +270,10 @@ void VulkanRenderer::render()
 		}
 
 		VkDeviceSize size = vertices.size() * sizeof(VulkanVertex);
-		void* mapped = nullptr;
-		if (vkMapMemory(device, m_vertexMemory, 0, size, 0, &mapped) == VK_SUCCESS)
-		{
-			std::memcpy(mapped, vertices.data(), size);
-			vkUnmapMemory(device, m_vertexMemory);
-		}
+		std::memcpy(m_vertexAllocInfo.pMappedData, vertices.data(), static_cast<size_t>(size));
 	}
 
 	updateUniformBuffer();
-	// this spams logs so if you need it uncomment it
-	// Logger::debug("VK: Uniform buffer updated, submitting frame...");
 	submitFrame();
 }
 
@@ -305,10 +284,33 @@ void VulkanRenderer::resize(uint32_t width, uint32_t height)
 
 	m_width = width;
 	m_height = height;
-	Logger::info("VK: Resizing to {}x{}", width, height);
+}
 
+bool VulkanRenderer::swapchainNeedsRecreate() const
+{
+	if (m_width == 0 || m_height == 0)
+		return false;
+
+	VkExtent2D extent = m_vulkanSwapchain.getExtent();
+	return m_width != extent.width || m_height != extent.height;
+}
+
+bool VulkanRenderer::recreateSwapchain()
+{
 	VkDevice device = m_vulkanDevice.getDevice();
-	vkDeviceWaitIdle(device);
+
+	for (VkFence fence : m_imagesInFlight)
+	{
+		if (fence != VK_NULL_HANDLE)
+			vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
+	}
+
+	for (uint32_t i = 0; i < VulkanResources::frameCount; ++i)
+	{
+		VkFence fence = m_vulkanResources.getInFlightFence(i);
+		if (fence != VK_NULL_HANDLE)
+			vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
+	}
 
 	if (!m_commandBuffers.empty())
 	{
@@ -317,30 +319,41 @@ void VulkanRenderer::resize(uint32_t width, uint32_t height)
 		m_commandBuffers.clear();
 	}
 
-	if (!m_vulkanSwapchain.recreate(m_vulkanDevice, width, height))
+	VkExtent2D extent = m_vulkanSwapchain.getExtent();
+	if (m_width != extent.width || m_height != extent.height)
+		Logger::info("VK: Resizing to {}x{}", m_width, m_height);
+
+	if (!m_vulkanSwapchain.recreate(m_vulkanDevice, m_width, m_height))
 	{
 		Logger::error("VK: Failed to recreate swapchain");
-		return;
+		return false;
 	}
+
+	if (!rebuildPerImageResources())
+	{
+		Logger::error("VK: Failed to rebuild per-image resources after resize");
+		return false;
+	}
+
+	VkExtent2D actualExtent = m_vulkanSwapchain.getExtent();
+	m_width = actualExtent.width;
+	m_height = actualExtent.height;
+
+	return true;
+}
+
+bool VulkanRenderer::rebuildPerImageResources()
+{
+	VkDevice device = m_vulkanDevice.getDevice();
 
 	m_imagesInFlight.clear();
 	m_imagesInFlight.resize(m_vulkanSwapchain.getImages().size(), VK_NULL_HANDLE);
 
-	if (!m_vulkanResources.recreateRenderFinishedSemaphores(m_vulkanDevice.getDevice(),
+	if (!m_vulkanResources.recreateRenderFinishedSemaphores(device,
 			static_cast<uint32_t>(m_vulkanSwapchain.getImages().size())))
-	{
-		Logger::error("VK: Failed to recreate render-finished semaphores after resize");
-		return;
-	}
+		return false;
 
-	if (!createCommandBuffers())
-	{
-		Logger::error("VK: Failed to recreate command buffers");
-		return;
-	}
-
-	m_iconChanged = true;
-	Logger::info("VK: Resize complete (pipelines preserved with dynamic state)");
+	return allocateCommandBuffers();
 }
 
 uint32_t VulkanRenderer::getVertexCount() const
@@ -360,9 +373,7 @@ void VulkanRenderer::prepareVertexData()
 	if (!m_icon || !m_icon->isValid())
 		return;
 
-	VkDevice device = m_vulkanDevice.getDevice();
 	m_vertexCount = m_icon->getVertexCount();
-	Logger::debug("VK: Preparing {} vertices", m_vertexCount);
 
 	std::vector<VulkanVertex> vertices;
 	vertices.reserve(m_vertexCount);
@@ -389,54 +400,33 @@ void VulkanRenderer::prepareVertexData()
 		vertices.push_back(v);
 	}
 
-	if (m_vertexBuffer != VK_NULL_HANDLE)
-		vkDestroyBuffer(device, m_vertexBuffer, nullptr);
-	if (m_vertexMemory != VK_NULL_HANDLE)
-		vkFreeMemory(device, m_vertexMemory, nullptr);
+	const VkDeviceSize requiredSize = vertices.size() * sizeof(VulkanVertex);
 
-	VkBufferCreateInfo vertexBufferInfo{};
-	vertexBufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-	vertexBufferInfo.size = vertices.size() * sizeof(VulkanVertex);
-	vertexBufferInfo.usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
-	vertexBufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-	if (vkCreateBuffer(device, &vertexBufferInfo, nullptr, &m_vertexBuffer) != VK_SUCCESS)
+	if (m_vertexBuffer != VK_NULL_HANDLE && m_vertexBufferSize >= requiredSize)
 	{
-		Logger::error("VK: Failed to create vertex buffer");
-		return;
+		std::memcpy(m_vertexAllocInfo.pMappedData, vertices.data(), static_cast<size_t>(requiredSize));
+	}
+	else
+	{
+		VmaAllocator allocator = m_vulkanDevice.getAllocator();
+		if (m_vertexBuffer != VK_NULL_HANDLE)
+			vmaDestroyBuffer(allocator, m_vertexBuffer, m_vertexAllocation);
+		m_vertexBuffer = VK_NULL_HANDLE;
+		m_vertexAllocation = VK_NULL_HANDLE;
+		m_vertexBufferSize = 0;
+
+		if (!m_vulkanResources.createMappedBuffer(m_vulkanDevice, requiredSize, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, 0.5f,
+				m_vertexBuffer, m_vertexAllocation, m_vertexAllocInfo))
+		{
+			Logger::error("VK: Failed to create vertex buffer");
+			return;
+		}
+
+		std::memcpy(m_vertexAllocInfo.pMappedData, vertices.data(), static_cast<size_t>(requiredSize));
+		m_vertexBufferSize = requiredSize;
 	}
 
-	VkMemoryRequirements memRequirements;
-	vkGetBufferMemoryRequirements(device, m_vertexBuffer, &memRequirements);
-
-	VkMemoryAllocateInfo allocInfo{};
-	allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-	allocInfo.allocationSize = memRequirements.size;
-	allocInfo.memoryTypeIndex = m_vulkanDevice.findMemoryType(memRequirements.memoryTypeBits,
-		VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-
-	if (allocInfo.memoryTypeIndex == UINT32_MAX)
-	{
-		Logger::error("VK: Failed to find memory type for vertex buffer");
-		vkDestroyBuffer(device, m_vertexBuffer, nullptr);
-		return;
-	}
-
-	if (vkAllocateMemory(device, &allocInfo, nullptr, &m_vertexMemory) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to allocate vertex memory");
-		vkDestroyBuffer(device, m_vertexBuffer, nullptr);
-		return;
-	}
-
-	vkBindBufferMemory(device, m_vertexBuffer, m_vertexMemory, 0);
-
-	void* data;
-	vkMapMemory(device, m_vertexMemory, 0, vertexBufferInfo.size, 0, &data);
-	std::memcpy(data, vertices.data(), vertexBufferInfo.size);
-	vkUnmapMemory(device, m_vertexMemory);
-
-	Logger::debug("VK: Vertex buffer created (host-visible) for animation updates");
+	Logger::info("VK: Prepared {} vertices", m_vertexCount);
 }
 
 void VulkanRenderer::writeDescriptorSets()
@@ -477,184 +467,106 @@ void VulkanRenderer::writeDescriptorSets()
 	vkUpdateDescriptorSets(device, 2, descriptorWrites, 0, nullptr);
 }
 
-void VulkanRenderer::updateUniformBuffer()
+bool VulkanRenderer::createDescriptorResources()
 {
 	VkDevice device = m_vulkanDevice.getDevice();
 	const VkDeviceSize uboSize = 320;
 
-	if (m_uniformBuffer == VK_NULL_HANDLE)
+	if (!m_vulkanResources.createMappedBuffer(m_vulkanDevice, uboSize, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, 0.5f,
+			m_uniformBuffer, m_uniformAllocation, m_uniformAllocInfo))
 	{
-		VkBufferCreateInfo bufferInfo{};
-		bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-		bufferInfo.size = uboSize;
-		bufferInfo.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-		bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-		if (vkCreateBuffer(device, &bufferInfo, nullptr, &m_uniformBuffer) != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to create uniform buffer");
-			return;
-		}
-
-		VkMemoryRequirements memRequirements;
-		vkGetBufferMemoryRequirements(device, m_uniformBuffer, &memRequirements);
-
-		VkMemoryAllocateInfo allocInfo{};
-		allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-		allocInfo.allocationSize = memRequirements.size;
-		allocInfo.memoryTypeIndex = m_vulkanDevice.findMemoryType(memRequirements.memoryTypeBits,
-			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-
-		if (allocInfo.memoryTypeIndex == UINT32_MAX)
-		{
-			Logger::error("VK: Failed to find memory type for uniform buffer");
-			vkDestroyBuffer(device, m_uniformBuffer, nullptr);
-			m_uniformBuffer = VK_NULL_HANDLE;
-			return;
-		}
-
-		if (vkAllocateMemory(device, &allocInfo, nullptr, &m_uniformMemory) != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to allocate uniform memory");
-			vkDestroyBuffer(device, m_uniformBuffer, nullptr);
-			m_uniformBuffer = VK_NULL_HANDLE;
-			return;
-		}
-
-		vkBindBufferMemory(device, m_uniformBuffer, m_uniformMemory, 0);
-
-		VkSamplerCreateInfo samplerInfo{};
-		samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-		samplerInfo.magFilter = VK_FILTER_LINEAR;
-		samplerInfo.minFilter = VK_FILTER_LINEAR;
-		samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-		samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-		samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-		samplerInfo.anisotropyEnable = VK_FALSE;
-		samplerInfo.maxAnisotropy = 1.0f;
-		samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
-		samplerInfo.unnormalizedCoordinates = VK_FALSE;
-		samplerInfo.compareEnable = VK_FALSE;
-		samplerInfo.compareOp = VK_COMPARE_OP_ALWAYS;
-		samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-
-		if (vkCreateSampler(device, &samplerInfo, nullptr, &m_textureSampler) != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to create texture sampler");
-		}
-
-		if (m_textureView == VK_NULL_HANDLE)
-		{
-			VkImageCreateInfo imageInfo{};
-			imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-			imageInfo.imageType = VK_IMAGE_TYPE_2D;
-			imageInfo.extent.width = 1;
-			imageInfo.extent.height = 1;
-			imageInfo.extent.depth = 1;
-			imageInfo.mipLevels = 1;
-			imageInfo.arrayLayers = 1;
-			imageInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
-			imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
-			imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-			imageInfo.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
-			imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-			imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-
-			if (vkCreateImage(device, &imageInfo, nullptr, &m_textureImage) == VK_SUCCESS)
-			{
-				VkMemoryRequirements imgMemReq;
-				vkGetImageMemoryRequirements(device, m_textureImage, &imgMemReq);
-
-				VkMemoryAllocateInfo imgAllocInfo{};
-				imgAllocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-				imgAllocInfo.allocationSize = imgMemReq.size;
-				imgAllocInfo.memoryTypeIndex = m_vulkanDevice.findMemoryType(imgMemReq.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-
-				if (imgAllocInfo.memoryTypeIndex != UINT32_MAX)
-				{
-					vkAllocateMemory(device, &imgAllocInfo, nullptr, &m_textureMemory);
-					vkBindImageMemory(device, m_textureImage, m_textureMemory, 0);
-
-					VkImageViewCreateInfo viewInfo{};
-					viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-					viewInfo.image = m_textureImage;
-					viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-					viewInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
-					viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-					viewInfo.subresourceRange.baseMipLevel = 0;
-					viewInfo.subresourceRange.levelCount = 1;
-					viewInfo.subresourceRange.baseArrayLayer = 0;
-					viewInfo.subresourceRange.layerCount = 1;
-
-					vkCreateImageView(device, &viewInfo, nullptr, &m_textureView);
-				}
-			}
-		}
-
-		VkDescriptorPoolSize poolSizes[2]{};
-		poolSizes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-		poolSizes[0].descriptorCount = 1;
-		poolSizes[1].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-		poolSizes[1].descriptorCount = 1;
-
-		VkDescriptorPoolCreateInfo poolInfo{};
-		poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-		poolInfo.poolSizeCount = 2;
-		poolInfo.pPoolSizes = poolSizes;
-		poolInfo.maxSets = 1;
-
-		if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &m_descriptorPool) != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to create descriptor pool");
-			return;
-		}
-
-		VkDescriptorSetLayout layout = m_vulkanPipeline.getDescriptorSetLayout();
-		VkDescriptorSetAllocateInfo allocInfoDesc{};
-		allocInfoDesc.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-		allocInfoDesc.descriptorPool = m_descriptorPool;
-		allocInfoDesc.descriptorSetCount = 1;
-		allocInfoDesc.pSetLayouts = &layout;
-
-		if (vkAllocateDescriptorSets(device, &allocInfoDesc, &m_descriptorSet) != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to allocate descriptor set");
-			return;
-		}
-
-		VkDescriptorBufferInfo bufferDescInfo{};
-		bufferDescInfo.buffer = m_uniformBuffer;
-		bufferDescInfo.offset = 0;
-		bufferDescInfo.range = uboSize;
-
-		VkDescriptorImageInfo imageDescInfo{};
-		imageDescInfo.sampler = m_textureSampler;
-		imageDescInfo.imageView = m_textureView;
-		imageDescInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-
-		VkWriteDescriptorSet descriptorWrites[2]{};
-		descriptorWrites[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-		descriptorWrites[0].dstSet = m_descriptorSet;
-		descriptorWrites[0].dstBinding = 0;
-		descriptorWrites[0].dstArrayElement = 0;
-		descriptorWrites[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-		descriptorWrites[0].descriptorCount = 1;
-		descriptorWrites[0].pBufferInfo = &bufferDescInfo;
-
-		descriptorWrites[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-		descriptorWrites[1].dstSet = m_descriptorSet;
-		descriptorWrites[1].dstBinding = 1;
-		descriptorWrites[1].dstArrayElement = 0;
-		descriptorWrites[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-		descriptorWrites[1].descriptorCount = 1;
-		descriptorWrites[1].pImageInfo = &imageDescInfo;
-
-		writeDescriptorSets();
+		Logger::error("VK: Failed to create uniform buffer");
+		return false;
 	}
 
-	void* data;
-	vkMapMemory(device, m_uniformMemory, 0, uboSize, 0, &data);
+	VkSamplerCreateInfo samplerInfo{};
+	samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+	samplerInfo.magFilter = VK_FILTER_LINEAR;
+	samplerInfo.minFilter = VK_FILTER_LINEAR;
+	samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	samplerInfo.anisotropyEnable = VK_FALSE;
+	samplerInfo.maxAnisotropy = 1.0f;
+	samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+	samplerInfo.unnormalizedCoordinates = VK_FALSE;
+	samplerInfo.compareEnable = VK_FALSE;
+	samplerInfo.compareOp = VK_COMPARE_OP_ALWAYS;
+	samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+	samplerInfo.minLod = 0.0f;
+	samplerInfo.maxLod = VK_LOD_CLAMP_NONE;
 
+	if (vkCreateSampler(device, &samplerInfo, nullptr, &m_textureSampler) != VK_SUCCESS)
+	{
+		Logger::error("VK: Failed to create texture sampler");
+		return false;
+	}
+
+	if (!m_vulkanResources.createImage(m_vulkanDevice, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
+			VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, 0.5f,
+			m_textureImage, m_textureAllocation))
+	{
+		Logger::error("VK: Failed to create placeholder texture");
+		return false;
+	}
+
+	m_textureWidth = 1;
+	m_textureHeight = 1;
+
+	VkImageViewCreateInfo viewInfo{};
+	viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+	viewInfo.image = m_textureImage;
+	viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+	viewInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
+	viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	viewInfo.subresourceRange.baseMipLevel = 0;
+	viewInfo.subresourceRange.levelCount = 1;
+	viewInfo.subresourceRange.baseArrayLayer = 0;
+	viewInfo.subresourceRange.layerCount = 1;
+
+	if (vkCreateImageView(device, &viewInfo, nullptr, &m_textureView) != VK_SUCCESS)
+	{
+		Logger::error("VK: Failed to create placeholder texture view");
+		return false;
+	}
+
+	VkDescriptorPoolSize poolSizes[2]{};
+	poolSizes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+	poolSizes[0].descriptorCount = 1;
+	poolSizes[1].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+	poolSizes[1].descriptorCount = 1;
+
+	VkDescriptorPoolCreateInfo poolInfo{};
+	poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+	poolInfo.poolSizeCount = 2;
+	poolInfo.pPoolSizes = poolSizes;
+	poolInfo.maxSets = 1;
+
+	if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &m_descriptorPool) != VK_SUCCESS)
+	{
+		Logger::error("VK: Failed to create descriptor pool");
+		return false;
+	}
+
+	VkDescriptorSetLayout layout = m_vulkanPipeline.getDescriptorSetLayout();
+	VkDescriptorSetAllocateInfo allocInfoDesc{};
+	allocInfoDesc.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+	allocInfoDesc.descriptorPool = m_descriptorPool;
+	allocInfoDesc.descriptorSetCount = 1;
+	allocInfoDesc.pSetLayouts = &layout;
+
+	if (vkAllocateDescriptorSets(device, &allocInfoDesc, &m_descriptorSet) != VK_SUCCESS)
+	{
+		Logger::error("VK: Failed to allocate descriptor set");
+		return false;
+	}
+
+	writeDescriptorSets();
+	return true;
+}
+
+void VulkanRenderer::updateUniformBuffer()
+{
 	VkExtent2D extent = m_vulkanSwapchain.getExtent();
 	float autoRotateY = 0.0f;
 	if (m_animationEnabled)
@@ -664,9 +576,7 @@ void VulkanRenderer::updateUniformBuffer()
 	}
 	auto matrices = CameraUtils::computeMatrices(m_camera, extent.width, extent.height, autoRotateY);
 	auto uboData = UniformBufferUtils::buildUniformBufferData(matrices, m_lighting, true);
-	std::memcpy(data, &uboData, sizeof(uboData));
-
-	vkUnmapMemory(device, m_uniformMemory);
+	std::memcpy(m_uniformAllocInfo.pMappedData, &uboData, sizeof(uboData));
 }
 
 bool VulkanRenderer::uploadTexture()
@@ -676,6 +586,7 @@ bool VulkanRenderer::uploadTexture()
 
 	VkDevice device = m_vulkanDevice.getDevice();
 	VkQueue queue = m_vulkanDevice.getGraphicsQueue();
+	VmaAllocator allocator = m_vulkanDevice.getAllocator();
 
 	const auto* textureData = m_icon->getTextureData();
 	if (!textureData)
@@ -701,112 +612,91 @@ bool VulkanRenderer::uploadTexture()
 		return false;
 	}
 
-	Logger::debug("VK: Texture converted to RGBA, size={} bytes", rgba.size());
 	VkDeviceSize imageSize = rgba.size();
 
-	VkBuffer stagingBuffer = VK_NULL_HANDLE;
-	VkDeviceMemory stagingBufferMemory = VK_NULL_HANDLE;
-
-	VkBufferCreateInfo bufferInfo{};
-	bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-	bufferInfo.size = imageSize;
-	bufferInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-	bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-	if (vkCreateBuffer(device, &bufferInfo, nullptr, &stagingBuffer) != VK_SUCCESS)
+	if (m_stagingBuffer == VK_NULL_HANDLE || m_stagingBufferSize < imageSize)
 	{
-		Logger::error("VK: Failed to create texture staging buffer");
+		if (m_stagingBuffer != VK_NULL_HANDLE)
+			vmaDestroyBuffer(allocator, m_stagingBuffer, m_stagingAllocation);
+
+		if (!m_vulkanResources.createMappedBuffer(m_vulkanDevice, imageSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, 0.0f,
+				m_stagingBuffer, m_stagingAllocation, m_stagingAllocInfo))
+		{
+			Logger::error("VK: Failed to create texture staging buffer");
+			m_stagingBuffer = VK_NULL_HANDLE;
+			return false;
+		}
+
+		m_stagingBufferSize = imageSize;
+	}
+
+	std::memcpy(m_stagingAllocInfo.pMappedData, rgba.data(), static_cast<size_t>(imageSize));
+
+	const bool newTexture = m_textureImage == VK_NULL_HANDLE || m_textureWidth != texWidth || m_textureHeight != texHeight;
+
+	if (newTexture)
+	{
+		if (m_textureView != VK_NULL_HANDLE)
+			vkDestroyImageView(device, m_textureView, nullptr);
+		if (m_textureImage != VK_NULL_HANDLE)
+			vmaDestroyImage(allocator, m_textureImage, m_textureAllocation);
+		m_textureView = VK_NULL_HANDLE;
+
+		if (!m_vulkanResources.createImage(m_vulkanDevice, texWidth, texHeight, textureFormat,
+				VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, 0.5f,
+				m_textureImage, m_textureAllocation))
+		{
+			Logger::error("VK: Failed to create texture image");
+			return false;
+		}
+		m_textureWidth = texWidth;
+		m_textureHeight = texHeight;
+
+		if (!m_vulkanResources.transitionImageLayout(device, queue, m_textureImage, textureFormat,
+				VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL))
+			return false;
+
+		VkImageViewCreateInfo viewInfo{};
+		viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+		viewInfo.image = m_textureImage;
+		viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+		viewInfo.format = textureFormat;
+		viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		viewInfo.subresourceRange.baseMipLevel = 0;
+		viewInfo.subresourceRange.levelCount = 1;
+		viewInfo.subresourceRange.baseArrayLayer = 0;
+		viewInfo.subresourceRange.layerCount = 1;
+
+		if (vkCreateImageView(device, &viewInfo, nullptr, &m_textureView) != VK_SUCCESS)
+		{
+			Logger::error("VK: Failed to create texture image view");
+			return false;
+		}
+	}
+	else if (!m_vulkanResources.transitionImageLayout(device, queue, m_textureImage, textureFormat,
+				 VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL))
+	{
 		return false;
 	}
 
-	VkMemoryRequirements memRequirements;
-	vkGetBufferMemoryRequirements(device, stagingBuffer, &memRequirements);
-
-	VkMemoryAllocateInfo allocInfo{};
-	allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-	allocInfo.allocationSize = memRequirements.size;
-	allocInfo.memoryTypeIndex = m_vulkanDevice.findMemoryType(memRequirements.memoryTypeBits,
-		VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-
-	if (allocInfo.memoryTypeIndex == UINT32_MAX)
-	{
-		Logger::error("VK: Failed to find memory type for texture staging");
-		vkDestroyBuffer(device, stagingBuffer, nullptr);
+	if (!m_vulkanResources.copyBufferToImage(device, queue, m_stagingBuffer, m_textureImage, texWidth, texHeight))
 		return false;
-	}
-
-	if (vkAllocateMemory(device, &allocInfo, nullptr, &stagingBufferMemory) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to allocate texture staging memory");
-		vkDestroyBuffer(device, stagingBuffer, nullptr);
+	if (!m_vulkanResources.transitionImageLayout(device, queue, m_textureImage, textureFormat,
+			VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL))
 		return false;
-	}
 
-	vkBindBufferMemory(device, stagingBuffer, stagingBufferMemory, 0);
-
-	void* data;
-	vkMapMemory(device, stagingBufferMemory, 0, imageSize, 0, &data);
-	std::memcpy(data, rgba.data(), static_cast<size_t>(imageSize));
-	vkUnmapMemory(device, stagingBufferMemory);
-
-	if (m_textureView != VK_NULL_HANDLE)
-		vkDestroyImageView(device, m_textureView, nullptr);
-	if (m_textureImage != VK_NULL_HANDLE)
-		vkDestroyImage(device, m_textureImage, nullptr);
-	if (m_textureMemory != VK_NULL_HANDLE)
-		vkFreeMemory(device, m_textureMemory, nullptr);
-
-	if (!m_vulkanResources.createImage(m_vulkanDevice, texWidth, texHeight, textureFormat, VK_IMAGE_TILING_OPTIMAL,
-			VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-			m_textureImage, m_textureMemory))
+	if (newTexture)
 	{
-		Logger::error("VK: Failed to create texture image");
-		vkDestroyBuffer(device, stagingBuffer, nullptr);
-		vkFreeMemory(device, stagingBufferMemory, nullptr);
-		return false;
+		Logger::info("VK: Texture loaded: {}x{}", texWidth, texHeight);
+		writeDescriptorSets();
 	}
-	Logger::debug("VK: Texture image created {}x{}", texWidth, texHeight);
-
-	m_vulkanResources.transitionImageLayout(device, queue, m_textureImage, textureFormat,
-		VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-	m_vulkanResources.copyBufferToImage(device, queue, stagingBuffer, m_textureImage, texWidth, texHeight);
-	m_vulkanResources.transitionImageLayout(device, queue, m_textureImage, textureFormat,
-		VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-	Logger::debug("VK: Texture data uploaded and transitioned to shader-readable");
-
-	VkImageViewCreateInfo viewInfo{};
-	viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-	viewInfo.image = m_textureImage;
-	viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-	viewInfo.format = textureFormat;
-	viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-	viewInfo.subresourceRange.baseMipLevel = 0;
-	viewInfo.subresourceRange.levelCount = 1;
-	viewInfo.subresourceRange.baseArrayLayer = 0;
-	viewInfo.subresourceRange.layerCount = 1;
-
-	if (vkCreateImageView(device, &viewInfo, nullptr, &m_textureView) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create texture image view");
-		vkDestroyBuffer(device, stagingBuffer, nullptr);
-		vkFreeMemory(device, stagingBufferMemory, nullptr);
-		return false;
-	}
-	Logger::debug("VK: Texture image view created, calling updateUniformBuffer");
-
-	writeDescriptorSets();
 	updateUniformBuffer();
 
-	vkDestroyBuffer(device, stagingBuffer, nullptr);
-	vkFreeMemory(device, stagingBufferMemory, nullptr);
-	Logger::debug("VK: Texture upload complete");
 	return true;
 }
 
 void VulkanRenderer::updateBackgroundVertexData()
 {
-	VkDevice device = m_vulkanDevice.getDevice();
-
 	VulkanBGVertex verts[4];
 	auto writeColor = [](const glm::vec4& c) {
 		VulkanBGVertex v{};
@@ -830,10 +720,10 @@ void VulkanRenderer::updateBackgroundVertexData()
 	verts[3].pos[0] = 1.0f;
 	verts[3].pos[1] = -1.0f;
 
-	m_vulkanResources.updateBackgroundVertexData(device, verts, 4);
+	m_vulkanResources.updateBackgroundVertexData(verts, 4);
 }
 
-bool VulkanRenderer::createCommandBuffers()
+bool VulkanRenderer::allocateCommandBuffers()
 {
 	VkDevice device = m_vulkanDevice.getDevice();
 
@@ -845,17 +735,56 @@ bool VulkanRenderer::createCommandBuffers()
 	}
 
 	const auto& swapchainImages = m_vulkanSwapchain.getImages();
-	const auto& framebuffers = m_vulkanSwapchain.getFramebuffers();
-	VkExtent2D extent = m_vulkanSwapchain.getExtent();
-	VkRenderPass renderPass = m_vulkanSwapchain.getRenderPass();
 
 	VkCommandBufferAllocateInfo allocInfo{};
 	allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
 	allocInfo.commandPool = m_vulkanResources.getCommandPool();
 	allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-	allocInfo.commandBufferCount = 1;
+	allocInfo.commandBufferCount = static_cast<uint32_t>(swapchainImages.size());
 
 	m_commandBuffers.resize(swapchainImages.size());
+
+	if (vkAllocateCommandBuffers(device, &allocInfo, m_commandBuffers.data()) != VK_SUCCESS)
+	{
+		Logger::error("VK: Failed to allocate command buffers");
+		m_commandBuffers.clear();
+		return false;
+	}
+
+	return true;
+}
+
+bool VulkanRenderer::recordCommandBuffer(uint32_t imageIndex)
+{
+	const auto& framebuffers = m_vulkanSwapchain.getFramebuffers();
+	VkExtent2D extent = m_vulkanSwapchain.getExtent();
+	VkRenderPass renderPass = m_vulkanSwapchain.getRenderPass();
+	VkCommandBuffer cmd = m_commandBuffers[imageIndex];
+
+	vkResetCommandBuffer(cmd, 0);
+
+	VkCommandBufferBeginInfo beginInfo{};
+	beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+	beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+	if (vkBeginCommandBuffer(cmd, &beginInfo) != VK_SUCCESS)
+	{
+		Logger::error("VK: Failed to record command buffer");
+		return false;
+	}
+
+	VkRenderPassBeginInfo renderPassInfo{};
+	renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+	renderPassInfo.renderPass = renderPass;
+	renderPassInfo.framebuffer = framebuffers[imageIndex];
+	renderPassInfo.renderArea.offset = {0, 0};
+	renderPassInfo.renderArea.extent = extent;
+
+	std::array<VkClearValue, 2> clearValues{};
+	clearValues[0].color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+	clearValues[1].depthStencil = {1.0f, 0};
+	renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());
+	renderPassInfo.pClearValues = clearValues.data();
 
 	VkViewport viewport{};
 	viewport.x = 0.0f;
@@ -869,184 +798,156 @@ bool VulkanRenderer::createCommandBuffers()
 	scissor.offset = {0, 0};
 	scissor.extent = extent;
 
-	for (size_t i = 0; i < m_commandBuffers.size(); ++i)
+	VkSubpassBeginInfo subpassBegin{};
+	subpassBegin.sType = VK_STRUCTURE_TYPE_SUBPASS_BEGIN_INFO;
+	subpassBegin.contents = VK_SUBPASS_CONTENTS_INLINE;
+	vkCmdBeginRenderPass2(cmd, &renderPassInfo, &subpassBegin);
+
+	VkBuffer bgBuffer = m_vulkanResources.getBackgroundVertexBuffer();
+	if (m_background.shouldRender && m_vulkanPipeline.getBackgroundPipeline() != VK_NULL_HANDLE && bgBuffer != VK_NULL_HANDLE)
 	{
-		if (vkAllocateCommandBuffers(device, &allocInfo, &m_commandBuffers[i]) != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to allocate command buffer");
-			return false;
-		}
-
-		VkCommandBufferBeginInfo beginInfo{};
-		beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-		beginInfo.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
-
-		vkBeginCommandBuffer(m_commandBuffers[i], &beginInfo);
-
-		VkRenderPassBeginInfo renderPassInfo{};
-		renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-		renderPassInfo.renderPass = renderPass;
-		renderPassInfo.framebuffer = framebuffers[i];
-		renderPassInfo.renderArea.offset = {0, 0};
-		renderPassInfo.renderArea.extent = extent;
-
-		std::array<VkClearValue, 2> clearValues{};
-		clearValues[0].color = {{0.0f, 0.0f, 0.0f, 1.0f}};
-		clearValues[1].depthStencil = {1.0f, 0};
-		renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());
-		renderPassInfo.pClearValues = clearValues.data();
-
-		VkSubpassBeginInfo subpassBegin{};
-		subpassBegin.sType = VK_STRUCTURE_TYPE_SUBPASS_BEGIN_INFO;
-		subpassBegin.contents = VK_SUBPASS_CONTENTS_INLINE;
-		vkCmdBeginRenderPass2(m_commandBuffers[i], &renderPassInfo, &subpassBegin);
-
-		VkBuffer bgBuffer = m_vulkanResources.getBackgroundVertexBuffer();
-		if (m_background.shouldRender && m_vulkanPipeline.getBackgroundPipeline() != VK_NULL_HANDLE && bgBuffer != VK_NULL_HANDLE)
-		{
-			VkBuffer bgBuffers[] = {bgBuffer};
-			VkDeviceSize bgOffsets[] = {0};
-			vkCmdBindPipeline(m_commandBuffers[i], VK_PIPELINE_BIND_POINT_GRAPHICS, m_vulkanPipeline.getBackgroundPipeline());
-			vkCmdSetViewport(m_commandBuffers[i], 0, 1, &viewport);
-			vkCmdSetScissor(m_commandBuffers[i], 0, 1, &scissor);
-			vkCmdBindVertexBuffers(m_commandBuffers[i], 0, 1, bgBuffers, bgOffsets);
-			vkCmdDraw(m_commandBuffers[i], 4, 1, 0, 0);
-		}
-
-		vkCmdBindPipeline(m_commandBuffers[i], VK_PIPELINE_BIND_POINT_GRAPHICS, m_vulkanPipeline.getGraphicsPipeline());
-		vkCmdSetViewport(m_commandBuffers[i], 0, 1, &viewport);
-		vkCmdSetScissor(m_commandBuffers[i], 0, 1, &scissor);
-
-		if (m_vertexBuffer != VK_NULL_HANDLE && m_vertexCount > 0)
-		{
-			VkBuffer vertexBuffers[] = {m_vertexBuffer};
-			VkDeviceSize offsets[] = {0};
-			vkCmdBindVertexBuffers(m_commandBuffers[i], 0, 1, vertexBuffers, offsets);
-
-			if (m_descriptorSet != VK_NULL_HANDLE)
-			{
-				vkCmdBindDescriptorSets(m_commandBuffers[i], VK_PIPELINE_BIND_POINT_GRAPHICS,
-					m_vulkanPipeline.getPipelineLayout(), 0, 1, &m_descriptorSet, 0, nullptr);
-			}
-
-			struct PushConstants
-			{
-				int32_t useTexture;
-				int32_t enableAlpha;
-				float alphaOverride;
-			} pc;
-			pc.useTexture = (m_icon && m_icon->hasTexture()) ? 1 : 0;
-			pc.enableAlpha = (m_icon && m_icon->hasAlpha()) ? 1 : 0;
-			pc.alphaOverride = 1.0f;
-			vkCmdPushConstants(m_commandBuffers[i], m_vulkanPipeline.getPipelineLayout(),
-				VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(pc), &pc);
-
-			vkCmdDraw(m_commandBuffers[i], m_vertexCount, 1, 0, 0);
-		}
-
-		VkSubpassEndInfo subpassEnd{};
-		subpassEnd.sType = VK_STRUCTURE_TYPE_SUBPASS_END_INFO;
-		vkCmdEndRenderPass2(m_commandBuffers[i], &subpassEnd);
-
-		if (vkEndCommandBuffer(m_commandBuffers[i]) != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to record command buffer");
-			return false;
-		}
+		VkBuffer bgBuffers[] = {bgBuffer};
+		VkDeviceSize bgOffsets[] = {0};
+		vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_vulkanPipeline.getBackgroundPipeline());
+		vkCmdSetViewport(cmd, 0, 1, &viewport);
+		vkCmdSetScissor(cmd, 0, 1, &scissor);
+		vkCmdBindVertexBuffers(cmd, 0, 1, bgBuffers, bgOffsets);
+		vkCmdDraw(cmd, 4, 1, 0, 0);
 	}
 
-	Logger::info("VK: Command buffers created successfully");
+	if (m_vertexBuffer != VK_NULL_HANDLE && m_vertexCount > 0)
+	{
+		vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_vulkanPipeline.getGraphicsPipeline());
+		vkCmdSetViewport(cmd, 0, 1, &viewport);
+		vkCmdSetScissor(cmd, 0, 1, &scissor);
+		VkBuffer vertexBuffers[] = {m_vertexBuffer};
+		VkDeviceSize offsets[] = {0};
+		vkCmdBindVertexBuffers(cmd, 0, 1, vertexBuffers, offsets);
+
+		if (m_descriptorSet != VK_NULL_HANDLE)
+		{
+			vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+				m_vulkanPipeline.getPipelineLayout(), 0, 1, &m_descriptorSet, 0, nullptr);
+		}
+
+		struct PushConstants
+		{
+			int32_t useTexture;
+			int32_t enableAlpha;
+			float alphaOverride;
+		} pc;
+		pc.useTexture = (m_icon && m_icon->hasTexture()) ? 1 : 0;
+		pc.enableAlpha = (m_icon && m_icon->hasAlpha()) ? 1 : 0;
+		pc.alphaOverride = 1.0f;
+		vkCmdPushConstants(cmd, m_vulkanPipeline.getPipelineLayout(),
+			VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(pc), &pc);
+
+		vkCmdDraw(cmd, m_vertexCount, 1, 0, 0);
+	}
+
+	VkSubpassEndInfo subpassEnd{};
+	subpassEnd.sType = VK_STRUCTURE_TYPE_SUBPASS_END_INFO;
+	vkCmdEndRenderPass2(cmd, &subpassEnd);
+
+	if (vkEndCommandBuffer(cmd) != VK_SUCCESS)
+	{
+		Logger::error("VK: Failed to record command buffer");
+		return false;
+	}
+
 	return true;
 }
 
 void VulkanRenderer::submitFrame()
 {
-	try
+	VkDevice device = m_vulkanDevice.getDevice();
+	VkQueue queue = m_vulkanDevice.getGraphicsQueue();
+	VkSwapchainKHR swapchain = m_vulkanSwapchain.getSwapchain();
+
+	if (!m_initialized || swapchain == VK_NULL_HANDLE)
 	{
-		VkDevice device = m_vulkanDevice.getDevice();
-		VkQueue queue = m_vulkanDevice.getGraphicsQueue();
-		VkSwapchainKHR swapchain = m_vulkanSwapchain.getSwapchain();
-
-		if (!m_initialized || swapchain == VK_NULL_HANDLE)
-		{
-			Logger::error("VK: Not initialized or no swapchain");
-			return;
-		}
-
-		VkFence fence = m_vulkanResources.getInFlightFence(m_currentFrame);
-		VkSemaphore imageAvailable = m_vulkanResources.getImageAvailableSemaphore(m_currentFrame);
-		vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
-
-		uint32_t imageIndex;
-		VkResult result = vkAcquireNextImageKHR(device, swapchain, UINT64_MAX, imageAvailable, VK_NULL_HANDLE, &imageIndex);
-
-		if (result == VK_ERROR_OUT_OF_DATE_KHR)
-		{
-			Logger::warn("VK: Swapchain out of date");
-			return;
-		}
-
-		if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR)
-		{
-			Logger::error("VK: Failed to acquire next image: {}", static_cast<int>(result));
-			return;
-		}
-
-		VkSemaphore renderFinished = m_vulkanResources.getRenderFinishedSemaphore(imageIndex);
-
-		if (m_imagesInFlight[imageIndex] != VK_NULL_HANDLE)
-		{
-			vkWaitForFences(device, 1, &m_imagesInFlight[imageIndex], VK_TRUE, UINT64_MAX);
-		}
-		m_imagesInFlight[imageIndex] = fence;
-
-		vkResetFences(device, 1, &fence);
-
-		VkSubmitInfo submitInfo{};
-		submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-
-		VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT};
-		submitInfo.waitSemaphoreCount = 1;
-		submitInfo.pWaitSemaphores = &imageAvailable;
-		submitInfo.pWaitDstStageMask = waitStages;
-		submitInfo.commandBufferCount = 1;
-		submitInfo.pCommandBuffers = &m_commandBuffers[imageIndex];
-		submitInfo.signalSemaphoreCount = 1;
-		submitInfo.pSignalSemaphores = &renderFinished;
-
-		if (vkQueueSubmit(queue, 1, &submitInfo, fence) != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to submit draw command buffer");
-			return;
-		}
-
-		VkPresentInfoKHR presentInfo{};
-		presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
-		presentInfo.waitSemaphoreCount = 1;
-		presentInfo.pWaitSemaphores = &renderFinished;
-		presentInfo.swapchainCount = 1;
-		presentInfo.pSwapchains = &swapchain;
-		presentInfo.pImageIndices = &imageIndex;
-
-		result = vkQueuePresentKHR(queue, &presentInfo);
-
-		if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR)
-		{
-			Logger::debug("VK: Swapchain suboptimal or out of date");
-			return;
-		}
-
-		if (result != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to present image: {}", static_cast<int>(result));
-		}
-
-		m_currentFrame = (m_currentFrame + 1) % MAX_FRAMES_IN_FLIGHT;
+		Logger::error("VK: Not initialized or no swapchain");
+		return;
 	}
-	catch (const std::exception& e)
+
+	if (swapchainNeedsRecreate())
 	{
-		Logger::error("VK: Exception: {}", e.what());
+		recreateSwapchain();
+		return;
 	}
+
+	VkFence fence = m_vulkanResources.getInFlightFence(m_currentFrame);
+	VkSemaphore imageAvailable = m_vulkanResources.getImageAvailableSemaphore(m_currentFrame);
+	vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
+
+	uint32_t imageIndex;
+	VkResult result = vkAcquireNextImageKHR(device, swapchain, UINT64_MAX, imageAvailable, VK_NULL_HANDLE, &imageIndex);
+
+	if (result == VK_ERROR_OUT_OF_DATE_KHR)
+	{
+		recreateSwapchain();
+		return;
+	}
+
+	if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR)
+	{
+		Logger::error("VK: Failed to acquire next image: {}", static_cast<int>(result));
+		return;
+	}
+
+	VkSemaphore renderFinished = m_vulkanResources.getRenderFinishedSemaphore(imageIndex);
+
+	if (m_imagesInFlight[imageIndex] != VK_NULL_HANDLE)
+	{
+		vkWaitForFences(device, 1, &m_imagesInFlight[imageIndex], VK_TRUE, UINT64_MAX);
+	}
+	m_imagesInFlight[imageIndex] = fence;
+
+	vkResetFences(device, 1, &fence);
+
+	if (!recordCommandBuffer(imageIndex))
+		return;
+
+	VkSubmitInfo submitInfo{};
+	submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+
+	VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT};
+	submitInfo.waitSemaphoreCount = 1;
+	submitInfo.pWaitSemaphores = &imageAvailable;
+	submitInfo.pWaitDstStageMask = waitStages;
+	submitInfo.commandBufferCount = 1;
+	submitInfo.pCommandBuffers = &m_commandBuffers[imageIndex];
+	submitInfo.signalSemaphoreCount = 1;
+	submitInfo.pSignalSemaphores = &renderFinished;
+
+	if (vkQueueSubmit(queue, 1, &submitInfo, fence) != VK_SUCCESS)
+	{
+		Logger::error("VK: Failed to submit draw command buffer");
+		return;
+	}
+
+	VkPresentInfoKHR presentInfo{};
+	presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+	presentInfo.waitSemaphoreCount = 1;
+	presentInfo.pWaitSemaphores = &renderFinished;
+	presentInfo.swapchainCount = 1;
+	presentInfo.pSwapchains = &swapchain;
+	presentInfo.pImageIndices = &imageIndex;
+
+	result = vkQueuePresentKHR(queue, &presentInfo);
+
+	if (result == VK_ERROR_OUT_OF_DATE_KHR)
+	{
+		recreateSwapchain();
+		return;
+	}
+
+	if (result != VK_SUCCESS)
+	{
+		Logger::error("VK: Failed to present image: {}", static_cast<int>(result));
+	}
+
+	m_currentFrame = (m_currentFrame + 1) % VulkanResources::frameCount;
 }
 
 void VulkanRenderer::setVSync(bool enabled)
@@ -1058,22 +959,16 @@ void VulkanRenderer::setVSync(bool enabled)
 	if (m_vulkanSwapchain.setVSync(m_vulkanDevice, enabled))
 	{
 		vkDeviceWaitIdle(device);
-		m_imagesInFlight.clear();
-		m_imagesInFlight.resize(m_vulkanSwapchain.getImages().size(), VK_NULL_HANDLE);
-		if (!m_vulkanResources.recreateRenderFinishedSemaphores(device,
-				static_cast<uint32_t>(m_vulkanSwapchain.getImages().size())))
-		{
-			Logger::error("VK: Failed to recreate render-finished semaphores after VSync change");
-		}
+
 		if (!m_commandBuffers.empty())
 		{
 			vkFreeCommandBuffers(device, m_vulkanResources.getCommandPool(),
 				static_cast<uint32_t>(m_commandBuffers.size()), m_commandBuffers.data());
 			m_commandBuffers.clear();
 		}
-		if (!createCommandBuffers())
-			Logger::error("VK: Failed to recreate command buffers after VSync change");
-		m_iconChanged = true;
+
+		if (!rebuildPerImageResources())
+			Logger::error("VK: Failed to rebuild per-image resources after VSync change");
 	}
 
 	if (m_config)

--- a/src/core/renderer/Vulkan/VulkanRenderer.h
+++ b/src/core/renderer/Vulkan/VulkanRenderer.h
@@ -80,14 +80,24 @@ private:
 
 	std::shared_ptr<PS2Icon::Icon> m_icon;
 	VkBuffer m_vertexBuffer;
-	VkDeviceMemory m_vertexMemory;
+	VmaAllocation m_vertexAllocation = VK_NULL_HANDLE;
+	VmaAllocationInfo m_vertexAllocInfo{};
+	VkDeviceSize m_vertexBufferSize = 0;
 	VkBuffer m_uniformBuffer;
-	VkDeviceMemory m_uniformMemory;
+	VmaAllocation m_uniformAllocation = VK_NULL_HANDLE;
+	VmaAllocationInfo m_uniformAllocInfo{};
 
 	VkImage m_textureImage;
-	VkDeviceMemory m_textureMemory;
+	VmaAllocation m_textureAllocation = VK_NULL_HANDLE;
+	uint32_t m_textureWidth = 0;
+	uint32_t m_textureHeight = 0;
 	VkImageView m_textureView;
 	VkSampler m_textureSampler;
+
+	VkBuffer m_stagingBuffer = VK_NULL_HANDLE;
+	VmaAllocation m_stagingAllocation = VK_NULL_HANDLE;
+	VmaAllocationInfo m_stagingAllocInfo{};
+	VkDeviceSize m_stagingBufferSize = 0;
 
 	VkDescriptorPool m_descriptorPool;
 	VkDescriptorSet m_descriptorSet;
@@ -103,12 +113,18 @@ private:
 	BackgroundState m_background;
 	Config* m_config;
 
-	bool createCommandBuffers();
+	bool allocateCommandBuffers();
+	bool createDescriptorResources();
+	bool recordCommandBuffer(uint32_t imageIndex);
 	bool uploadTexture();
 	void writeDescriptorSets();
 	void updateBackgroundVertexData();
+	bool rebuildPerImageResources();
 
 	void prepareVertexData();
 	void updateUniformBuffer();
 	void submitFrame();
+
+	bool swapchainNeedsRecreate() const;
+	bool recreateSwapchain();
 };

--- a/src/core/renderer/Vulkan/VulkanResources.cpp
+++ b/src/core/renderer/Vulkan/VulkanResources.cpp
@@ -67,7 +67,7 @@ bool VulkanResources::createSyncObjects(VkDevice device, uint32_t swapchainImage
 	fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
 	fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
 
-	for (uint32_t i = 0; i < MAX_FRAMES_IN_FLIGHT; ++i)
+	for (uint32_t i = 0; i < frameCount; ++i)
 	{
 		if (vkCreateSemaphore(device, &semaphoreInfo, nullptr, &m_imageAvailableSemaphores[i]) != VK_SUCCESS ||
 			vkCreateFence(device, &fenceInfo, nullptr, &m_inFlightFences[i]) != VK_SUCCESS)
@@ -82,7 +82,7 @@ bool VulkanResources::createSyncObjects(VkDevice device, uint32_t swapchainImage
 
 	VkFenceCreateInfo singleTimeFenceInfo{};
 	singleTimeFenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-	singleTimeFenceInfo.flags = 0; // Not signaled
+	singleTimeFenceInfo.flags = 0;
 
 	if (vkCreateFence(device, &singleTimeFenceInfo, nullptr, &m_singleTimeFence) != VK_SUCCESS)
 	{
@@ -90,13 +90,13 @@ bool VulkanResources::createSyncObjects(VkDevice device, uint32_t swapchainImage
 		return false;
 	}
 
-	Logger::info("VK: Created sync objects for {} frames in flight", MAX_FRAMES_IN_FLIGHT);
+	Logger::info("VK: Created sync objects for {} frames", frameCount);
 	return true;
 }
 
-void VulkanResources::destroy(VkDevice device)
+void VulkanResources::destroy(VkDevice device, VmaAllocator allocator)
 {
-	destroyBackgroundVertexBuffer(device);
+	destroyBackgroundVertexBuffer(allocator);
 
 	if (m_singleTimeFence != VK_NULL_HANDLE)
 	{
@@ -111,7 +111,7 @@ void VulkanResources::destroy(VkDevice device)
 	}
 	m_renderFinishedSemaphores.clear();
 
-	for (uint32_t i = 0; i < MAX_FRAMES_IN_FLIGHT; ++i)
+	for (uint32_t i = 0; i < frameCount; ++i)
 	{
 		if (m_inFlightFences[i] != VK_NULL_HANDLE)
 		{
@@ -168,8 +168,7 @@ void VulkanResources::endSingleTimeCommands(VkDevice device, VkQueue queue, VkCo
 }
 
 bool VulkanResources::createImage(VulkanDevice& device, uint32_t width, uint32_t height, VkFormat format,
-	VkImageTiling tiling, VkImageUsageFlags usage, VkMemoryPropertyFlags properties,
-	VkImage& image, VkDeviceMemory& imageMemory)
+	VkImageUsageFlags usage, float priority, VkImage& image, VmaAllocation& allocation)
 {
 	VkImageCreateInfo imageInfo{};
 	imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -180,35 +179,22 @@ bool VulkanResources::createImage(VulkanDevice& device, uint32_t width, uint32_t
 	imageInfo.mipLevels = 1;
 	imageInfo.arrayLayers = 1;
 	imageInfo.format = format;
-	imageInfo.tiling = tiling;
+	imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
 	imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 	imageInfo.usage = usage;
 	imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 	imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
 
-	if (vkCreateImage(device.getDevice(), &imageInfo, nullptr, &image) != VK_SUCCESS)
+	VmaAllocationCreateInfo allocInfo{};
+	allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+	device.setAllocationPriority(allocInfo, priority);
+
+	if (vmaCreateImage(device.getAllocator(), &imageInfo, &allocInfo, &image, &allocation, nullptr) != VK_SUCCESS)
 	{
 		Logger::error("VK: Failed to create image");
 		return false;
 	}
 
-	VkMemoryRequirements memRequirements;
-	vkGetImageMemoryRequirements(device.getDevice(), image, &memRequirements);
-
-	VkMemoryAllocateInfo allocInfo{};
-	allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-	allocInfo.allocationSize = memRequirements.size;
-	allocInfo.memoryTypeIndex = device.findMemoryType(memRequirements.memoryTypeBits, properties);
-
-	if (allocInfo.memoryTypeIndex == UINT32_MAX || vkAllocateMemory(device.getDevice(), &allocInfo, nullptr, &imageMemory) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to allocate image memory");
-		vkDestroyImage(device.getDevice(), image, nullptr);
-		image = VK_NULL_HANDLE;
-		return false;
-	}
-
-	vkBindImageMemory(device.getDevice(), image, imageMemory, 0);
 	return true;
 }
 
@@ -247,6 +233,13 @@ bool VulkanResources::transitionImageLayout(VkDevice device, VkQueue queue, VkIm
 		sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
 		destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 	}
+	else if (oldLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL)
+	{
+		barrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+		barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+		sourceStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+		destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+	}
 	else
 	{
 		Logger::error("VK: Unsupported layout transition");
@@ -282,65 +275,51 @@ bool VulkanResources::copyBufferToImage(VkDevice device, VkQueue queue, VkBuffer
 	return true;
 }
 
-bool VulkanResources::createBackgroundVertexBuffer(VulkanDevice& device)
+bool VulkanResources::createMappedBuffer(VulkanDevice& device, VkDeviceSize size, VkBufferUsageFlags usage, float priority,
+	VkBuffer& buffer, VmaAllocation& allocation, VmaAllocationInfo& mapped)
 {
-	destroyBackgroundVertexBuffer(device.getDevice());
-
 	VkBufferCreateInfo bufferInfo{};
 	bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-	bufferInfo.size = sizeof(VulkanBGVertex) * 4;
-	bufferInfo.usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+	bufferInfo.size = size;
+	bufferInfo.usage = usage;
 	bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-	if (vkCreateBuffer(device.getDevice(), &bufferInfo, nullptr, &m_bgVertexBuffer) != VK_SUCCESS)
+	VmaAllocationCreateInfo allocInfo{};
+	allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+	allocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
+	device.setAllocationPriority(allocInfo, priority);
+
+	return vmaCreateBuffer(device.getAllocator(), &bufferInfo, &allocInfo, &buffer, &allocation, &mapped) == VK_SUCCESS;
+}
+
+bool VulkanResources::createBackgroundVertexBuffer(VulkanDevice& device)
+{
+	destroyBackgroundVertexBuffer(device.getAllocator());
+
+	if (!createMappedBuffer(device, sizeof(VulkanBGVertex) * 4, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, 0.5f,
+			m_bgVertexBuffer, m_bgVertexAllocation, m_bgVertexAllocInfo))
 	{
 		Logger::error("VK: Failed to create background vertex buffer");
 		return false;
 	}
 
-	VkMemoryRequirements memReq;
-	vkGetBufferMemoryRequirements(device.getDevice(), m_bgVertexBuffer, &memReq);
-
-	VkMemoryAllocateInfo allocInfo{};
-	allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-	allocInfo.allocationSize = memReq.size;
-	allocInfo.memoryTypeIndex = device.findMemoryType(memReq.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-
-	if (allocInfo.memoryTypeIndex == UINT32_MAX || vkAllocateMemory(device.getDevice(), &allocInfo, nullptr, &m_bgVertexMemory) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to allocate background vertex memory");
-		vkDestroyBuffer(device.getDevice(), m_bgVertexBuffer, nullptr);
-		m_bgVertexBuffer = VK_NULL_HANDLE;
-		return false;
-	}
-
-	vkBindBufferMemory(device.getDevice(), m_bgVertexBuffer, m_bgVertexMemory, 0);
 	return true;
 }
 
-void VulkanResources::updateBackgroundVertexData(VkDevice device, const VulkanBGVertex* vertices, size_t count)
+void VulkanResources::updateBackgroundVertexData(const VulkanBGVertex* vertices, size_t count)
 {
-	if (m_bgVertexMemory == VK_NULL_HANDLE || !vertices || count == 0)
+	if (m_bgVertexAllocation == VK_NULL_HANDLE || !vertices || count == 0)
 		return;
 
-	void* data = nullptr;
-	if (vkMapMemory(device, m_bgVertexMemory, 0, sizeof(VulkanBGVertex) * count, 0, &data) == VK_SUCCESS)
-	{
-		std::memcpy(data, vertices, sizeof(VulkanBGVertex) * count);
-		vkUnmapMemory(device, m_bgVertexMemory);
-	}
+	std::memcpy(m_bgVertexAllocInfo.pMappedData, vertices, sizeof(VulkanBGVertex) * count);
 }
 
-void VulkanResources::destroyBackgroundVertexBuffer(VkDevice device)
+void VulkanResources::destroyBackgroundVertexBuffer(VmaAllocator allocator)
 {
 	if (m_bgVertexBuffer != VK_NULL_HANDLE)
 	{
-		vkDestroyBuffer(device, m_bgVertexBuffer, nullptr);
+		vmaDestroyBuffer(allocator, m_bgVertexBuffer, m_bgVertexAllocation);
 		m_bgVertexBuffer = VK_NULL_HANDLE;
-	}
-	if (m_bgVertexMemory != VK_NULL_HANDLE)
-	{
-		vkFreeMemory(device, m_bgVertexMemory, nullptr);
-		m_bgVertexMemory = VK_NULL_HANDLE;
+		m_bgVertexAllocation = VK_NULL_HANDLE;
 	}
 }

--- a/src/core/renderer/Vulkan/VulkanResources.h
+++ b/src/core/renderer/Vulkan/VulkanResources.h
@@ -4,40 +4,19 @@
 #pragma once
 
 #include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
 #include <cstdint>
 #include <array>
 #include <vector>
-#include "Logger.h"
 
 class VulkanDevice;
 struct VulkanBGVertex;
 
-static constexpr uint32_t MAX_FRAMES_IN_FLIGHT = 2;
-
-#define VK_CHECK(call) \
-	do \
-	{ \
-		VkResult result = call; \
-		if (result != VK_SUCCESS) \
-		{ \
-			Logger::error("VK: {} failed with error {} at {}:{}", #call, static_cast<int>(result), __FILE__, __LINE__); \
-		} \
-	} while (0)
-
-#define VK_CHECK_RETURN(call) \
-	do \
-	{ \
-		VkResult result = call; \
-		if (result != VK_SUCCESS) \
-		{ \
-			Logger::error("VK: {} failed with error {} at {}:{}", #call, static_cast<int>(result), __FILE__, __LINE__); \
-			return false; \
-		} \
-	} while (0)
-
 class VulkanResources
 {
 public:
+	static constexpr uint32_t frameCount = 2;
+
 	VulkanResources();
 	~VulkanResources();
 
@@ -47,22 +26,24 @@ public:
 	bool createCommandPool(VkDevice device, uint32_t queueFamily);
 	bool createSyncObjects(VkDevice device, uint32_t swapchainImageCount);
 	bool recreateRenderFinishedSemaphores(VkDevice device, uint32_t swapchainImageCount);
-	void destroy(VkDevice device);
+	void destroy(VkDevice device, VmaAllocator allocator);
 
 	VkCommandBuffer beginSingleTimeCommands(VkDevice device);
 	void endSingleTimeCommands(VkDevice device, VkQueue queue, VkCommandBuffer commandBuffer);
 
 	bool createImage(VulkanDevice& device, uint32_t width, uint32_t height, VkFormat format,
-		VkImageTiling tiling, VkImageUsageFlags usage, VkMemoryPropertyFlags properties,
-		VkImage& image, VkDeviceMemory& imageMemory);
+		VkImageUsageFlags usage, float priority, VkImage& image, VmaAllocation& allocation);
 	bool transitionImageLayout(VkDevice device, VkQueue queue, VkImage image, VkFormat format,
 		VkImageLayout oldLayout, VkImageLayout newLayout);
 	bool copyBufferToImage(VkDevice device, VkQueue queue, VkBuffer buffer, VkImage image,
 		uint32_t width, uint32_t height);
 
+	bool createMappedBuffer(VulkanDevice& device, VkDeviceSize size, VkBufferUsageFlags usage, float priority,
+		VkBuffer& buffer, VmaAllocation& allocation, VmaAllocationInfo& mapped);
+
 	bool createBackgroundVertexBuffer(VulkanDevice& device);
-	void updateBackgroundVertexData(VkDevice device, const VulkanBGVertex* vertices, size_t count);
-	void destroyBackgroundVertexBuffer(VkDevice device);
+	void updateBackgroundVertexData(const VulkanBGVertex* vertices, size_t count);
+	void destroyBackgroundVertexBuffer(VmaAllocator allocator);
 
 	VkCommandPool getCommandPool() const { return m_commandPool; }
 	VkSemaphore getImageAvailableSemaphore(uint32_t frameIndex) const { return m_imageAvailableSemaphores[frameIndex]; }
@@ -72,11 +53,12 @@ public:
 
 private:
 	VkCommandPool m_commandPool = VK_NULL_HANDLE;
-	std::array<VkSemaphore, MAX_FRAMES_IN_FLIGHT> m_imageAvailableSemaphores{};
+	std::array<VkSemaphore, frameCount> m_imageAvailableSemaphores{};
 	std::vector<VkSemaphore> m_renderFinishedSemaphores;
-	std::array<VkFence, MAX_FRAMES_IN_FLIGHT> m_inFlightFences{};
+	std::array<VkFence, frameCount> m_inFlightFences{};
 	VkFence m_singleTimeFence = VK_NULL_HANDLE;
 
 	VkBuffer m_bgVertexBuffer = VK_NULL_HANDLE;
-	VkDeviceMemory m_bgVertexMemory = VK_NULL_HANDLE;
+	VmaAllocation m_bgVertexAllocation = VK_NULL_HANDLE;
+	VmaAllocationInfo m_bgVertexAllocInfo{};
 };

--- a/src/core/renderer/Vulkan/VulkanSwapchain.cpp
+++ b/src/core/renderer/Vulkan/VulkanSwapchain.cpp
@@ -4,10 +4,11 @@
 #include "VulkanSwapchain.h"
 #include "VulkanDevice.h"
 
+#include <vk_mem_alloc.h>
+
 #include <algorithm>
 #include <array>
 #include "Logger.h"
-#include <vector>
 
 VulkanSwapchain::VulkanSwapchain() = default;
 
@@ -28,9 +29,8 @@ bool VulkanSwapchain::create(VulkanDevice& device, uint32_t width, uint32_t heig
 	return true;
 }
 
-void VulkanSwapchain::destroy(VkDevice device)
+void VulkanSwapchain::destroy(VkDevice device, VmaAllocator allocator)
 {
-	Logger::info("VK: VulkanSwapchain::destroy start");
 	for (auto framebuffer : m_framebuffers)
 	{
 		if (framebuffer != VK_NULL_HANDLE)
@@ -44,7 +44,7 @@ void VulkanSwapchain::destroy(VkDevice device)
 		m_renderPass = VK_NULL_HANDLE;
 	}
 
-	destroyDepthResources(device);
+	destroyDepthResources(device, allocator);
 
 	for (auto imageView : m_imageViews)
 	{
@@ -53,23 +53,60 @@ void VulkanSwapchain::destroy(VkDevice device)
 	}
 	m_imageViews.clear();
 
-	Logger::info("VK: Destroying swapchain handle: {}", (void*)m_swapchain);
 	if (m_swapchain != VK_NULL_HANDLE)
 	{
 		vkDestroySwapchainKHR(device, m_swapchain, nullptr);
 		m_swapchain = VK_NULL_HANDLE;
 	}
-	Logger::info("VK: VulkanSwapchain::destroy end");
 }
 
 bool VulkanSwapchain::recreate(VulkanDevice& device, uint32_t width, uint32_t height)
 {
-	vkDeviceWaitIdle(device.getDevice());
-	destroy(device.getDevice());
-	return create(device, width, height);
+	if (m_swapchain == VK_NULL_HANDLE)
+		return create(device, width, height);
+
+	VkSwapchainKHR oldSwapchain = m_swapchain;
+
+	if (!createSwapchain(device, width, height, oldSwapchain))
+		return false;
+
+	if (!rebuildAttachments(device, oldSwapchain))
+	{
+		Logger::error("VK: Failed to recreate swapchain resources");
+		return false;
+	}
+	return true;
 }
 
-bool VulkanSwapchain::createSwapchain(VulkanDevice& device, uint32_t width, uint32_t height)
+bool VulkanSwapchain::rebuildAttachments(VulkanDevice& device, VkSwapchainKHR oldSwapchain)
+{
+	VkDevice vkDevice = device.getDevice();
+
+	for (auto imageView : m_imageViews)
+		vkDestroyImageView(vkDevice, imageView, nullptr);
+	m_imageViews.clear();
+
+	for (auto framebuffer : m_framebuffers)
+		vkDestroyFramebuffer(vkDevice, framebuffer, nullptr);
+	m_framebuffers.clear();
+
+	destroyDepthResources(vkDevice, device.getAllocator());
+
+	uint32_t imageCount = 0;
+	vkGetSwapchainImagesKHR(vkDevice, m_swapchain, &imageCount, nullptr);
+	m_images.resize(imageCount);
+	vkGetSwapchainImagesKHR(vkDevice, m_swapchain, &imageCount, m_images.data());
+
+	if (!createImageViews(vkDevice) || !createDepthResources(device) || !createFramebuffers(vkDevice))
+		return false;
+
+	if (oldSwapchain != VK_NULL_HANDLE)
+		vkDestroySwapchainKHR(vkDevice, oldSwapchain, nullptr);
+	return true;
+}
+
+bool VulkanSwapchain::createSwapchain(VulkanDevice& device, uint32_t width, uint32_t height,
+	VkSwapchainKHR oldSwapchain)
 {
 	VkSurfaceCapabilitiesKHR capabilities;
 	vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device.getPhysicalDevice(), device.getSurface(), &capabilities);
@@ -94,14 +131,32 @@ bool VulkanSwapchain::createSwapchain(VulkanDevice& device, uint32_t width, uint
 	std::vector<VkPresentModeKHR> presentModes(presentModeCount);
 	vkGetPhysicalDeviceSurfacePresentModesKHR(device.getPhysicalDevice(), device.getSurface(), &presentModeCount, presentModes.data());
 
-	VkPresentModeKHR presentMode = VK_PRESENT_MODE_FIFO_KHR;
-	for (const auto& mode : presentModes)
+	VkPresentModeKHR presentMode = m_presentMode;
+	if (oldSwapchain == VK_NULL_HANDLE)
 	{
-		if (mode == VK_PRESENT_MODE_FIFO_KHR)
+		presentMode = VK_PRESENT_MODE_FIFO_KHR;
+		for (const auto& mode : presentModes)
 		{
-			presentMode = mode;
-			break;
+			if (mode == VK_PRESENT_MODE_FIFO_KHR)
+			{
+				presentMode = mode;
+				break;
+			}
 		}
+	}
+	else
+	{
+		bool supported = false;
+		for (const auto& mode : presentModes)
+		{
+			if (mode == m_presentMode)
+			{
+				supported = true;
+				break;
+			}
+		}
+		if (!supported)
+			presentMode = VK_PRESENT_MODE_FIFO_KHR;
 	}
 
 	m_presentMode = presentMode;
@@ -131,6 +186,7 @@ bool VulkanSwapchain::createSwapchain(VulkanDevice& device, uint32_t width, uint
 	createInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
 	createInfo.presentMode = presentMode;
 	createInfo.clipped = VK_TRUE;
+	createInfo.oldSwapchain = oldSwapchain;
 
 	if (vkCreateSwapchainKHR(device.getDevice(), &createInfo, nullptr, &m_swapchain) != VK_SUCCESS)
 	{
@@ -180,9 +236,8 @@ bool VulkanSwapchain::createImageViews(VkDevice device)
 VkFormat VulkanSwapchain::findDepthFormat(VkPhysicalDevice physicalDevice)
 {
 	VkFormat candidates[] = {
-		VK_FORMAT_D32_SFLOAT,
-		VK_FORMAT_D32_SFLOAT_S8_UINT,
-		VK_FORMAT_D24_UNORM_S8_UINT};
+		VK_FORMAT_D24_UNORM_S8_UINT,
+		VK_FORMAT_D32_SFLOAT_S8_UINT};
 
 	for (VkFormat format : candidates)
 	{
@@ -194,10 +249,10 @@ VkFormat VulkanSwapchain::findDepthFormat(VkPhysicalDevice physicalDevice)
 			return format;
 		}
 	}
-	return VK_FORMAT_D32_SFLOAT;
+	return VK_FORMAT_D24_UNORM_S8_UINT;
 }
 
-void VulkanSwapchain::destroyDepthResources(VkDevice device)
+void VulkanSwapchain::destroyDepthResources(VkDevice device, VmaAllocator allocator)
 {
 	for (auto v : m_depthImageViews)
 	{
@@ -206,36 +261,30 @@ void VulkanSwapchain::destroyDepthResources(VkDevice device)
 	}
 	m_depthImageViews.clear();
 
-	for (auto img : m_depthImages)
+	for (size_t i = 0; i < m_depthImages.size(); ++i)
 	{
-		if (img != VK_NULL_HANDLE)
-			vkDestroyImage(device, img, nullptr);
+		if (m_depthImages[i] != VK_NULL_HANDLE)
+			vmaDestroyImage(allocator, m_depthImages[i], m_depthAllocations[i]);
 	}
 	m_depthImages.clear();
-
-	for (auto mem : m_depthMemories)
-	{
-		if (mem != VK_NULL_HANDLE)
-			vkFreeMemory(device, mem, nullptr);
-	}
-	m_depthMemories.clear();
+	m_depthAllocations.clear();
 }
 
 bool VulkanSwapchain::createDepthResources(VulkanDevice& device)
 {
-	destroyDepthResources(device.getDevice());
+	destroyDepthResources(device.getDevice(), device.getAllocator());
 
 	m_depthFormat = findDepthFormat(device.getPhysicalDevice());
 
 	const size_t n = m_images.size();
 	m_depthImages.resize(n);
-	m_depthMemories.resize(n);
+	m_depthAllocations.resize(n);
 	m_depthImageViews.resize(n);
 
 	for (size_t i = 0; i < n; ++i)
 	{
 		m_depthImages[i] = VK_NULL_HANDLE;
-		m_depthMemories[i] = VK_NULL_HANDLE;
+		m_depthAllocations[i] = VK_NULL_HANDLE;
 		m_depthImageViews[i] = VK_NULL_HANDLE;
 
 		VkImageCreateInfo imageInfo{};
@@ -253,36 +302,16 @@ bool VulkanSwapchain::createDepthResources(VulkanDevice& device)
 		imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
 		imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-		if (vkCreateImage(device.getDevice(), &imageInfo, nullptr, &m_depthImages[i]) != VK_SUCCESS)
+		VmaAllocationCreateInfo allocInfo{};
+		allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+		device.setAllocationPriority(allocInfo, 1.0f);
+
+		if (vmaCreateImage(device.getAllocator(), &imageInfo, &allocInfo, &m_depthImages[i], &m_depthAllocations[i], nullptr) != VK_SUCCESS)
 		{
 			Logger::error("VK: Failed to create depth image");
-			destroyDepthResources(device.getDevice());
+			destroyDepthResources(device.getDevice(), device.getAllocator());
 			return false;
 		}
-
-		VkMemoryRequirements memRequirements;
-		vkGetImageMemoryRequirements(device.getDevice(), m_depthImages[i], &memRequirements);
-
-		VkMemoryAllocateInfo allocInfo{};
-		allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-		allocInfo.allocationSize = memRequirements.size;
-		allocInfo.memoryTypeIndex = device.findMemoryType(memRequirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-
-		if (allocInfo.memoryTypeIndex == UINT32_MAX)
-		{
-			Logger::error("VK: Failed to find suitable memory type for depth buffer");
-			destroyDepthResources(device.getDevice());
-			return false;
-		}
-
-		if (vkAllocateMemory(device.getDevice(), &allocInfo, nullptr, &m_depthMemories[i]) != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to allocate depth image memory");
-			destroyDepthResources(device.getDevice());
-			return false;
-		}
-
-		vkBindImageMemory(device.getDevice(), m_depthImages[i], m_depthMemories[i], 0);
 
 		VkImageViewCreateInfo viewInfo{};
 		viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
@@ -298,12 +327,11 @@ bool VulkanSwapchain::createDepthResources(VulkanDevice& device)
 		if (vkCreateImageView(device.getDevice(), &viewInfo, nullptr, &m_depthImageViews[i]) != VK_SUCCESS)
 		{
 			Logger::error("VK: Failed to create depth image view");
-			destroyDepthResources(device.getDevice());
+			destroyDepthResources(device.getDevice(), device.getAllocator());
 			return false;
 		}
 	}
 
-	Logger::info("VK: Depth buffer created successfully");
 	return true;
 }
 
@@ -413,69 +441,21 @@ bool VulkanSwapchain::setVSync(VulkanDevice& device, bool enabled)
 	if (newPresentMode == m_presentMode || m_swapchain == VK_NULL_HANDLE)
 		return false;
 
-	Logger::info("VK: Recreating swapchain with VSync {}", enabled ? "enabled" : "disabled");
+	Logger::info("VK: VSync {}", enabled ? "enabled" : "disabled");
 
-	vkDeviceWaitIdle(device.getDevice());
+	m_presentMode = newPresentMode;
 
 	VkSwapchainKHR oldSwapchain = m_swapchain;
-
-	VkSurfaceCapabilitiesKHR capabilities;
-	vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device.getPhysicalDevice(), device.getSurface(), &capabilities);
-
-	VkSwapchainCreateInfoKHR createInfo{};
-	createInfo.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
-	createInfo.pNext = nullptr;
-	createInfo.surface = device.getSurface();
-	createInfo.minImageCount = capabilities.minImageCount + 1;
-	createInfo.imageFormat = m_format;
-	createInfo.imageColorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-	createInfo.imageExtent = m_extent;
-	createInfo.imageArrayLayers = 1;
-	createInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-	createInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
-	createInfo.preTransform = capabilities.currentTransform;
-	createInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
-	createInfo.presentMode = newPresentMode;
-	createInfo.clipped = VK_TRUE;
-	createInfo.oldSwapchain = oldSwapchain;
-
-	VkSwapchainKHR newSwapchain;
-	if (vkCreateSwapchainKHR(device.getDevice(), &createInfo, nullptr, &newSwapchain) != VK_SUCCESS)
+	if (!createSwapchain(device, m_extent.width, m_extent.height, oldSwapchain))
 	{
 		Logger::error("VK: Failed to recreate swapchain for VSync change");
 		return false;
 	}
 
-	m_swapchain = newSwapchain;
-	m_presentMode = newPresentMode;
-
-	for (auto imageView : m_imageViews)
-	{
-		vkDestroyImageView(device.getDevice(), imageView, nullptr);
-	}
-	m_imageViews.clear();
-
-	for (auto framebuffer : m_framebuffers)
-	{
-		vkDestroyFramebuffer(device.getDevice(), framebuffer, nullptr);
-	}
-	m_framebuffers.clear();
-
-	destroyDepthResources(device.getDevice());
-
-	uint32_t imageCount;
-	vkGetSwapchainImagesKHR(device.getDevice(), m_swapchain, &imageCount, nullptr);
-	m_images.resize(imageCount);
-	vkGetSwapchainImagesKHR(device.getDevice(), m_swapchain, &imageCount, m_images.data());
-	if (!createImageViews(device.getDevice()) || !createDepthResources(device) || !createFramebuffers(device.getDevice()))
+	if (!rebuildAttachments(device, oldSwapchain))
 	{
 		Logger::error("VK: Failed to recreate swapchain resources for VSync change");
 		return false;
-	}
-
-	if (oldSwapchain != VK_NULL_HANDLE)
-	{
-		vkDestroySwapchainKHR(device.getDevice(), oldSwapchain, nullptr);
 	}
 	return true;
 }

--- a/src/core/renderer/Vulkan/VulkanSwapchain.h
+++ b/src/core/renderer/Vulkan/VulkanSwapchain.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
 #include <cstdint>
 #include <vector>
 
@@ -19,7 +20,7 @@ public:
 	VulkanSwapchain& operator=(const VulkanSwapchain&) = delete;
 
 	bool create(VulkanDevice& device, uint32_t width, uint32_t height);
-	void destroy(VkDevice device);
+	void destroy(VkDevice device, VmaAllocator allocator);
 	bool recreate(VulkanDevice& device, uint32_t width, uint32_t height);
 
 	VkSwapchainKHR getSwapchain() const { return m_swapchain; }
@@ -34,12 +35,14 @@ public:
 	bool setVSync(VulkanDevice& device, bool enabled);
 
 private:
-	bool createSwapchain(VulkanDevice& device, uint32_t width, uint32_t height);
+	bool createSwapchain(VulkanDevice& device, uint32_t width, uint32_t height,
+		VkSwapchainKHR oldSwapchain = VK_NULL_HANDLE);
+	bool rebuildAttachments(VulkanDevice& device, VkSwapchainKHR oldSwapchain);
 	bool createImageViews(VkDevice device);
 	bool createDepthResources(VulkanDevice& device);
 	bool createRenderPass(VkDevice device);
 	bool createFramebuffers(VkDevice device);
-	void destroyDepthResources(VkDevice device);
+	void destroyDepthResources(VkDevice device, VmaAllocator allocator);
 	VkFormat findDepthFormat(VkPhysicalDevice physicalDevice);
 
 	VkSwapchainKHR m_swapchain = VK_NULL_HANDLE;
@@ -49,7 +52,7 @@ private:
 	VkExtent2D m_extent = {0, 0};
 
 	std::vector<VkImage> m_depthImages;
-	std::vector<VkDeviceMemory> m_depthMemories;
+	std::vector<VmaAllocation> m_depthAllocations;
 	std::vector<VkImageView> m_depthImageViews;
 	VkFormat m_depthFormat = VK_FORMAT_UNDEFINED;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,6 @@
 #include "QtMain.h"
 #include <filesystem>
 #include "Logger.h"
-#include "ResourcePath.h"
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>
@@ -17,40 +16,7 @@
 #include <Windows.h>
 #endif
 
-#if defined(__APPLE__)
-#include "CocoaTools.h"
-#endif
-
 namespace fs = std::filesystem;
-
-#if !defined(__APPLE__)
-static fs::path getExecutableDir(const char* argv0)
-{
-#if defined(_WIN32)
-	char modulePath[MAX_PATH] = {};
-	const DWORD length = GetModuleFileNameA(nullptr, modulePath, MAX_PATH);
-	if (length > 0)
-	{
-		return fs::path(modulePath).parent_path();
-	}
-#endif
-	if (argv0 != nullptr && argv0[0] != '\0')
-	{
-		std::error_code ec;
-		fs::path resolved = fs::weakly_canonical(fs::path(argv0), ec);
-		if (!ec && !resolved.empty())
-		{
-			if (resolved.has_parent_path())
-				return resolved.parent_path();
-			return resolved;
-		}
-	}
-
-	std::error_code ec;
-	fs::path current = fs::current_path(ec);
-	return ec ? fs::path(".") : current;
-}
-#endif
 
 static int appMain(int argc, char* argv[])
 {
@@ -157,21 +123,6 @@ static int appMain(int argc, char* argv[])
 	{
 		Logger::info("Main: Failed to load config, using defaults");
 	}
-
-#if defined(__APPLE__)
-	if (auto bundlePath = CocoaTools::GetResourcePath())
-	{
-		config.setResourcesPath(*bundlePath);
-	}
-	else
-	{
-		config.setResourcesPath("resources");
-	}
-#else
-	config.setResourcesPath((getExecutableDir(argc > 0 ? argv[0] : nullptr) / "resources").string());
-#endif
-	ResourcePath::set(config.getResourcesPath());
-	Logger::info("Main: Resources path: {}", ResourcePath::get().string());
 
 	return runQtMainApp(argc, argv, config);
 }

--- a/src/ui/QtMain.cpp
+++ b/src/ui/QtMain.cpp
@@ -6,14 +6,37 @@
 #include "Config.h"
 #include "MainWindow.h"
 #include "TranslationManager.h"
+#include "ResourcePath.h"
 #include "version.h"
 #include "Logger.h"
 
+#include <QCoreApplication>
 #include <QLibraryInfo>
+
+#if defined(__APPLE__)
+#include "CocoaTools.h"
+#endif
+
+namespace fs = std::filesystem;
+
+static void initResourcePath(Config& config)
+{
+#if defined(__APPLE__)
+	if (auto bundlePath = CocoaTools::GetResourcePath())
+		config.setResourcesPath(*bundlePath);
+	else
+		config.setResourcesPath("resources");
+#else
+	config.setResourcesPath(fs::path(QCoreApplication::applicationDirPath().toStdString()) / "resources");
+#endif
+	ResourcePath::set(config.getResourcesPath());
+	Logger::info("Main: Resources path: {}", ResourcePath::get().string());
+}
 
 int runQtMainApp(int argc, char* argv[], Config& config)
 {
 	QApplication app(argc, argv);
+	initResourcePath(config);
 	app.setApplicationName(MYMCpp_APP_NAME);
 	app.setApplicationVersion(myMCpp_VERSION_STRING);
 	app.setOrganizationName("myMCpp");

--- a/src/ui/widgets/IconWidget.cpp
+++ b/src/ui/widgets/IconWidget.cpp
@@ -296,6 +296,9 @@ void IconWidget::applyConfigToRenderer(PS2IconSys* iconSys)
 
 void IconWidget::startRendering()
 {
+	if (m_renderLoopEnabled && m_renderTimer.isActive())
+		return;
+
 	Logger::info("IconWidget::startRendering {}", (void*)this);
 	m_renderLoopEnabled = true;
 
@@ -317,16 +320,7 @@ void IconWidget::startRendering()
 	if (interval <= 0)
 		interval = 16;
 
-	if (m_renderTimer.isActive())
-	{
-		m_renderTimer.stop();
-		m_renderTimer.start(interval, this);
-	}
-	else
-	{
-		m_renderTimer.start(interval, this);
-	}
-
+	m_renderTimer.start(interval, this);
 	renderFrame();
 }
 
@@ -567,6 +561,7 @@ void IconWidget::resizeEvent(QResizeEvent* event)
 		m_renderer->resize(
 			static_cast<uint32_t>(event->size().width() * dpr),
 			static_cast<uint32_t>(event->size().height() * dpr));
+		renderFrame();
 	}
 }
 


### PR DESCRIPTION
### Description of Changes
Finished moving the VK renderer over to VMA. Resize no longer rebuilds the swapchain inside `resizeEvent` that happens when we actually present. Also fixed some validation stuff (depth sync, layout transitions) and moved descriptor init out of `updateUniformBuffer`. And removed old unneeded code

### Rationale behind Changes
Manual memory management was annoying and resize felt bad when resizing the window.

### Suggested Testing Steps
Validation layers on, load an icon, resize a bunch, flip VSync.

### Related Issues / Links
N/A 

### Did you use AI to help find, test, or implement this issue or feature?
No