### PR TITLE
CI/Qt: Update to Qt 6.11.1 and add qt svg to ci/cmake

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -119,7 +119,7 @@ jobs:
         if: inputs.platform != 'arm64'
         uses: jurplel/install-qt-action@v4.3.1
         with:
-          version: '6.11.0'
+          version: '6.11.1'
           host: 'linux'
           target: 'desktop'
           arch: 'linux_gcc_64'
@@ -131,7 +131,7 @@ jobs:
         if: inputs.platform == 'arm64'
         uses: jurplel/install-qt-action@v4.3.1
         with:
-          version: '6.11.0'
+          version: '6.11.1'
           host: 'linux_arm64'
           target: 'desktop'
           arch: 'linux_gcc_arm64'

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -273,7 +273,7 @@ jobs:
           echo "Using QMAKE: $QMAKE_PATH"
           
           echo "Running linuxdeploy to create AppDir..."
-          EXTRA_QT_MODULES="core;gui;widgets;waylandclient;waylandcompositor;xcbqpa" \
+          EXTRA_QT_MODULES="core;gui;svg;widgets;waylandclient;waylandcompositor;xcbqpa" \
           EXTRA_PLATFORM_PLUGINS="libqwayland.so" \
           DEPLOY_PLATFORM_THEMES="1" \
           QMAKE="$QMAKE_PATH" \

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4.3.1
         with:
-          version: '6.11.0'
+          version: '6.11.1'
           host: 'mac'
           target: 'desktop'
           arch: 'clang_64'

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -80,7 +80,7 @@ jobs:
         if: inputs.platform == 'x64'
         uses: jurplel/install-qt-action@v4.3.1
         with:
-          version: '6.11.0'
+          version: '6.11.1'
           host: 'windows'
           target: 'desktop'
           arch: 'win64_msvc2022_64'
@@ -93,7 +93,7 @@ jobs:
         if: inputs.platform == 'ARM64'
         uses: jurplel/install-qt-action@v4.3.1
         with:
-          version: '6.11.0'
+          version: '6.11.1'
           host: 'windows_arm64'
           target: 'desktop'
           arch: 'win64_msvc2022_arm64'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ include_directories("${CMAKE_BINARY_DIR}/generated")
 add_subdirectory(3rdparty)
 
 # System dependencies
-find_package(Qt6 REQUIRED COMPONENTS Core Widgets LinguistTools)
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets LinguistTools Svg)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10.0)
     set(QT_NO_PRIVATE_MODULE_WARNING ON)
     find_package(Qt6 COMPONENTS CorePrivate GuiPrivate WidgetsPrivate REQUIRED)

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -2,5 +2,49 @@
 	<qresource>
 		<file>icons/AppIcon.png</file>
 		<file>icons/qt.svg</file>
+		<file>icons/black/index.theme</file>
+		<file>icons/white/index.theme</file>
+		<file>icons/black/svg/book-marked-fill.svg</file>
+		<file>icons/black/svg/bug-line.svg</file>
+		<file>icons/black/svg/close-circle-fill.svg</file>
+		<file>icons/black/svg/computer-line.svg</file>
+		<file>icons/black/svg/discord.svg</file>
+		<file>icons/black/svg/equalizer-line.svg</file>
+		<file>icons/black/svg/export-fill.svg</file>
+		<file>icons/black/svg/file-info-fill.svg</file>
+		<file>icons/black/svg/fire-fill.svg</file>
+		<file>icons/black/svg/folder-open-line.svg</file>
+		<file>icons/black/svg/github.svg</file>
+		<file>icons/black/svg/import-fill.svg</file>
+		<file>icons/black/svg/list-unordered.svg</file>
+		<file>icons/black/svg/memcard-close.svg</file>
+		<file>icons/black/svg/memcard-line.svg</file>
+		<file>icons/black/svg/memcard-new.svg</file>
+		<file>icons/black/svg/refresh-fill.svg</file>
+		<file>icons/black/svg/save-fill.svg</file>
+		<file>icons/black/svg/settings-fill.svg</file>
+		<file>icons/black/svg/tools-line.svg</file>
+		<file>icons/black/svg/trash-fill.svg</file>
+		<file>icons/white/svg/book-marked-fill.svg</file>
+		<file>icons/white/svg/bug-line.svg</file>
+		<file>icons/white/svg/close-circle-fill.svg</file>
+		<file>icons/white/svg/computer-line.svg</file>
+		<file>icons/white/svg/discord.svg</file>
+		<file>icons/white/svg/equalizer-line.svg</file>
+		<file>icons/white/svg/export-fill.svg</file>
+		<file>icons/white/svg/file-info-fill.svg</file>
+		<file>icons/white/svg/fire-fill.svg</file>
+		<file>icons/white/svg/folder-open-line.svg</file>
+		<file>icons/white/svg/github.svg</file>
+		<file>icons/white/svg/import-fill.svg</file>
+		<file>icons/white/svg/list-unordered.svg</file>
+		<file>icons/white/svg/memcard-close.svg</file>
+		<file>icons/white/svg/memcard-line.svg</file>
+		<file>icons/white/svg/memcard-new.svg</file>
+		<file>icons/white/svg/refresh-fill.svg</file>
+		<file>icons/white/svg/save-fill.svg</file>
+		<file>icons/white/svg/settings-fill.svg</file>
+		<file>icons/white/svg/tools-line.svg</file>
+		<file>icons/white/svg/trash-fill.svg</file>
 	</qresource>
 </RCC>

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(myMCpp-qt PUBLIC
     Qt6::Gui
     Qt6::GuiPrivate
     Qt6::Widgets
+    Qt6::Svg
 )
 
 if(TARGET discord-rpc)

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -61,6 +61,9 @@ MainWindow::MainWindow(Config* config, QWidget* parent)
 	, m_settingsWindow(nullptr)
 	, m_discordRpc(std::make_unique<DiscordRPCManager>(this))
 {
+	if (m_config)
+		Themes::UpdateApplicationTheme(m_config);
+
 	ui->setupUi(this);
 	QString baseTitle = QStringLiteral("%1 v%2")
 	                        .arg(QString::fromUtf8(MYMCpp_APP_NAME))
@@ -345,7 +348,6 @@ MainWindow::MainWindow(Config* config, QWidget* parent)
 
 	if (m_config)
 	{
-		Themes::UpdateApplicationTheme(m_config);
 		m_discordRpc->setEnabled(m_config->getDiscordRPCEnabled());
 		if (m_discordRpc && !currentCardPath.isEmpty())
 		{

--- a/src/ui/Themes.cpp
+++ b/src/ui/Themes.cpp
@@ -3,9 +3,7 @@
 
 #include "Themes.h"
 #include "Config.h"
-#include "ResourcePath.h"
 
-#include <QtCore/QFile>
 #include <QtGui/QPalette>
 #include <QtGui/QPixmapCache>
 #include <QtGui/QStyleHints>
@@ -61,15 +59,6 @@ bool Themes::IsDarkApplicationTheme()
 
 void Themes::SetIconThemeFromStyle()
 {
-	// Add resource icon path to search paths
-	QString iconsPath = QString::fromStdString(ResourcePath::icons().string());
-	QStringList paths = QIcon::themeSearchPaths();
-	if (!paths.contains(iconsPath))
-	{
-		paths.prepend(iconsPath);
-		QIcon::setThemeSearchPaths(paths);
-	}
-
 	const bool dark = IsDarkApplicationTheme();
 	QIcon::setThemeName(dark ? QStringLiteral("white") : QStringLiteral("black"));
 }


### PR DESCRIPTION
### Description of Changes
Fixed us not linking qt svg, embedded theme icons in resources.qrc, and update to Qt 6.11.1

### Rationale behind Changes
SVG icons weren't working on the appimage

### Suggested Testing Steps
See if said icons work

### Related Issues / Links
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No