### PR TITLE
Renderer/Qt: Fix MoltenVK resizing and show init failures in the status bar

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -2,6 +2,7 @@ set(COMMON_SOURCES
     sjis.cpp
     lzari.cpp
     Logger.cpp
+    Error.cpp
     WindowInfo.cpp
     Config.cpp
     BuildVersion.cpp
@@ -14,6 +15,7 @@ set(COMMON_HEADERS
     sjis.h
     lzari.h
     Logger.h
+    Error.h
     WindowInfo.h
     Config.h
 )
@@ -39,7 +41,7 @@ target_link_libraries(myMCpp-common PUBLIC
 if(APPLE)
     find_library(ICONV_LIBRARY iconv)
     target_link_libraries(myMCpp-common PUBLIC ${ICONV_LIBRARY})
-    
+
     set_source_files_properties(
         CocoaTools.mm
         PROPERTIES COMPILE_FLAGS "-fobjc-arc"

--- a/src/common/CocoaTools.h
+++ b/src/common/CocoaTools.h
@@ -14,6 +14,7 @@ namespace CocoaTools
 {
 	bool CreateMetalLayer(WindowInfo* wi);
 	void DestroyMetalLayer(WindowInfo* wi);
+	void SetDrawableSize(WindowInfo* wi, uint32_t width, uint32_t height);
 	std::optional<float> GetViewRefreshRate(const WindowInfo& wi);
 
 	// Helpers for extracting WindowInfo from a native window handle

--- a/src/common/CocoaTools.mm
+++ b/src/common/CocoaTools.mm
@@ -46,6 +46,20 @@ bool CocoaTools::CreateMetalLayer(WindowInfo* wi)
 	return true;
 }
 
+void CocoaTools::SetDrawableSize(WindowInfo* wi, uint32_t width, uint32_t height)
+{
+	if (!wi || !wi->surface_handle || width == 0 || height == 0)
+		return;
+
+	if (![NSThread isMainThread])
+	{
+		dispatch_sync(dispatch_get_main_queue(), [wi, width, height] { SetDrawableSize(wi, width, height); });
+		return;
+	}
+
+	((__bridge CAMetalLayer*)wi->surface_handle).drawableSize = CGSizeMake(width, height);
+}
+
 void CocoaTools::DestroyMetalLayer(WindowInfo* wi)
 {
 	if (!wi)

--- a/src/common/Error.cpp
+++ b/src/common/Error.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2025-2026 SternXD
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "Error.h"
+#include "Logger.h"
+
+void Error::Clear()
+{
+	m_description.clear();
+}
+
+void Error::setDescription(std::string description)
+{
+	m_description = std::move(description);
+}
+
+bool Error::Fail(std::string message)
+{
+	setDescription(std::move(message));
+	Logger::error("{}", m_description);
+	return false;
+}
+
+bool Error::Assign(const Error& other)
+{
+	m_description = other.m_description;
+	return false;
+}
+
+bool Error::Assign(std::string message)
+{
+	setDescription(std::move(message));
+	return false;
+}
+
+Error Error::CreateString(std::string description)
+{
+	Error ret;
+	ret.setDescription(std::move(description));
+	return ret;
+}
+
+bool Error::Fail(Error* errptr, std::string message)
+{
+	if (errptr)
+		return errptr->Fail(std::move(message));
+	Logger::error("{}", message);
+	return false;
+}

--- a/src/common/Error.h
+++ b/src/common/Error.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025-2026 SternXD
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include <string>
+
+class Error
+{
+public:
+	Error() = default;
+	Error(const Error& other) = default;
+	Error(Error&& other) = default;
+	~Error() = default;
+
+	Error& operator=(const Error& other) = default;
+	Error& operator=(Error&& other) = default;
+
+	bool IsValid() const { return !m_description.empty(); }
+	const std::string& GetDescription() const { return m_description; }
+
+	void Clear();
+
+	bool Fail(std::string message);
+	bool Assign(const Error& other);
+	bool Assign(std::string message);
+
+	static Error CreateString(std::string description);
+	static bool Fail(Error* errptr, std::string message);
+
+private:
+	void setDescription(std::string description);
+
+	std::string m_description;
+};

--- a/src/common/common.vcxproj
+++ b/src/common/common.vcxproj
@@ -46,6 +46,7 @@ call "$(SolutionDir)scripts\generate_svnrev.cmd" "$(SolutionDir)" "$(SolutionDir
     <ClCompile Include="sjis.cpp" />
     <ClCompile Include="lzari.cpp" />
     <ClCompile Include="Logger.cpp" />
+    <ClCompile Include="Error.cpp" />
     <ClCompile Include="WindowInfo.cpp" />
     <ClCompile Include="Config.cpp" />
     <ClCompile Include="BuildVersion.cpp" />
@@ -58,6 +59,7 @@ call "$(SolutionDir)scripts\generate_svnrev.cmd" "$(SolutionDir)" "$(SolutionDir
     <ClInclude Include="sjis.h" />
     <ClInclude Include="lzari.h" />
     <ClInclude Include="Logger.h" />
+    <ClInclude Include="Error.h" />
     <ClInclude Include="WindowInfo.h" />
     <ClInclude Include="Config.h" />
   </ItemGroup>

--- a/src/common/common.vcxproj.filters
+++ b/src/common/common.vcxproj.filters
@@ -14,6 +14,7 @@
     <ClCompile Include="sjis.cpp"><Filter>src</Filter></ClCompile>
     <ClCompile Include="lzari.cpp"><Filter>src</Filter></ClCompile>
     <ClCompile Include="Logger.cpp"><Filter>src</Filter></ClCompile>
+    <ClCompile Include="Error.cpp"><Filter>src</Filter></ClCompile>
     <ClCompile Include="WindowInfo.cpp"><Filter>src</Filter></ClCompile>
     <ClCompile Include="Config.cpp"><Filter>src</Filter></ClCompile>
     <ClCompile Include="BuildVersion.cpp"><Filter>src</Filter></ClCompile>
@@ -25,6 +26,7 @@
     <ClInclude Include="sjis.h"><Filter>headers</Filter></ClInclude>
     <ClInclude Include="lzari.h"><Filter>headers</Filter></ClInclude>
     <ClInclude Include="Logger.h"><Filter>headers</Filter></ClInclude>
+    <ClInclude Include="Error.h"><Filter>headers</Filter></ClInclude>
     <ClInclude Include="WindowInfo.h"><Filter>headers</Filter></ClInclude>
     <ClInclude Include="Config.h"><Filter>headers</Filter></ClInclude>
   </ItemGroup>

--- a/src/core/renderer/Metal/MetalDevice.h
+++ b/src/core/renderer/Metal/MetalDevice.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <Metal/Metal.h>
+#include "../../../common/Error.h"
 
 class MetalDevice
 {
@@ -14,10 +15,13 @@ public:
 	bool initialize();
 	void shutdown();
 
+	const Error& GetError() const { return m_error; }
+
 	id<MTLDevice> getDevice() const { return m_device; }
 	id<MTLCommandQueue> getCommandQueue() const { return m_commandQueue; }
 
 private:
+	Error m_error;
 	id<MTLDevice> m_device = nil;
 	id<MTLCommandQueue> m_commandQueue = nil;
 };

--- a/src/core/renderer/Metal/MetalDevice.mm
+++ b/src/core/renderer/Metal/MetalDevice.mm
@@ -15,20 +15,17 @@ MetalDevice::~MetalDevice()
 
 bool MetalDevice::initialize()
 {
+	m_error.Clear();
+
 	m_device = MTLCreateSystemDefaultDevice();
 	if (!m_device)
-	{
-		Logger::error("MTL: Failed to create Metal device");
-		return false;
-	}
+		return m_error.Fail("MTL: Failed to create Metal device");
 
 	m_commandQueue = [m_device newCommandQueue];
 	if (!m_commandQueue)
-	{
-		Logger::error("MTL: Failed to create Metal command queue");
-		return false;
-	}
+		return m_error.Fail("MTL: Failed to create Metal command queue");
 
+	Logger::info("MTL: Using device: {}", [m_device.name UTF8String]);
 	return true;
 }
 

--- a/src/core/renderer/Metal/MetalPipeline.h
+++ b/src/core/renderer/Metal/MetalPipeline.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <Metal/Metal.h>
+#include "../../../common/Error.h"
 
 class MetalPipeline
 {
@@ -15,12 +16,15 @@ public:
 	bool createBackgroundPipeline(id<MTLDevice> device);
 	void shutdown();
 
+	const Error& GetError() const { return m_error; }
+
 	id<MTLRenderPipelineState> getPipelineState() const { return m_pipelineState; }
 	id<MTLRenderPipelineState> getBackgroundPipelineState() const { return m_bgPipelineState; }
 	id<MTLDepthStencilState> getDepthStencilState() const { return m_depthStencilState; }
 	id<MTLDepthStencilState> getBackgroundDepthStencilState() const { return m_bgDepthStencilState; }
 
 private:
+	Error m_error;
 	id<MTLLibrary> m_library = nil;
 	id<MTLRenderPipelineState> m_pipelineState = nil;
 	id<MTLRenderPipelineState> m_bgPipelineState = nil;

--- a/src/core/renderer/Metal/MetalPipeline.mm
+++ b/src/core/renderer/Metal/MetalPipeline.mm
@@ -16,6 +16,8 @@ MetalPipeline::~MetalPipeline()
 
 bool MetalPipeline::initialize(id<MTLDevice> device)
 {
+	m_error.Clear();
+
 	fs::path resourcePath = ResourcePath::get();
 	fs::path metallibPath = resourcePath / "shaders" / "Metal" / "default.metallib";
 
@@ -36,31 +38,20 @@ bool MetalPipeline::initialize(id<MTLDevice> device)
 		{
 			if (error)
 			{
-				Logger::error("MTL: Failed to load metallib from {}: {}.",
-					metallibPath.string(),
-					[[error description] UTF8String]);
+				return m_error.Fail(std::string("MTL: Failed to load metallib from ") + metallibPath.string() + ": " + [[error description] UTF8String]);
 			}
-			else
-			{
-				Logger::error("MTL: Metallib not available at {}.", metallibPath.string());
-			}
+			return m_error.Fail("MTL: Metallib not available at " + metallibPath.string());
 		}
 	}
 
 	if (!library)
-	{
-		Logger::error("MTL: Failed to load shader library from metallib and default library fallback");
-		return false;
-	}
+		return m_error.Fail("MTL: Failed to load shader library from metallib and default library fallback");
 
 	id<MTLFunction> vertexFunc = [library newFunctionWithName:@"IconVSMain"];
 	id<MTLFunction> fragmentFunc = [library newFunctionWithName:@"IconPSMain"];
 
 	if (!vertexFunc || !fragmentFunc)
-	{
-		Logger::error("MTL: Failed to find shader entry points IconVSMain/IconPSMain");
-		return false;
-	}
+		return m_error.Fail("MTL: Failed to find shader entry points IconVSMain/IconPSMain");
 
 	MTLRenderPipelineDescriptor* psoDesc = [[MTLRenderPipelineDescriptor alloc] init];
 	psoDesc.vertexFunction = vertexFunc;
@@ -102,10 +93,7 @@ bool MetalPipeline::initialize(id<MTLDevice> device)
 
 	m_pipelineState = [device newRenderPipelineStateWithDescriptor:psoDesc error:&error];
 	if (!m_pipelineState)
-	{
-		Logger::error("MTL: Failed to create pipeline state: {}", [[error description] UTF8String]);
-		return false;
-	}
+		return m_error.Fail(std::string("MTL: Failed to create pipeline state: ") + [[error description] UTF8String]);
 
 	MTLDepthStencilDescriptor* depthDesc = [[MTLDepthStencilDescriptor alloc] init];
 	depthDesc.depthCompareFunction = MTLCompareFunctionLess;
@@ -119,20 +107,16 @@ bool MetalPipeline::initialize(id<MTLDevice> device)
 
 bool MetalPipeline::createBackgroundPipeline(id<MTLDevice> device)
 {
+	m_error.Clear();
+
 	if (!m_library)
-	{
-		Logger::error("MTL: No library loaded - call initialize first");
-		return false;
-	}
+		return m_error.Fail("MTL: No library loaded - call initialize first");
 
 	id<MTLFunction> vertexFunc = [m_library newFunctionWithName:@"BackgroundVSMain"];
 	id<MTLFunction> fragmentFunc = [m_library newFunctionWithName:@"BackgroundPSMain"];
 
 	if (!vertexFunc || !fragmentFunc)
-	{
-		Logger::error("MTL: Failed to find background shader entry points");
-		return false;
-	}
+		return m_error.Fail("MTL: Failed to find background shader entry points");
 
 	MTLRenderPipelineDescriptor* psoDesc = [[MTLRenderPipelineDescriptor alloc] init];
 	psoDesc.vertexFunction = vertexFunc;
@@ -166,16 +150,14 @@ bool MetalPipeline::createBackgroundPipeline(id<MTLDevice> device)
 	NSError* error = nil;
 	m_bgPipelineState = [device newRenderPipelineStateWithDescriptor:psoDesc error:&error];
 	if (!m_bgPipelineState)
-	{
-		Logger::error("MTL: Failed to create background pipeline state: {}", [[error description] UTF8String]);
-	}
+		return m_error.Fail(std::string("MTL: Failed to create background pipeline state: ") + [[error description] UTF8String]);
 
 	MTLDepthStencilDescriptor* depthDesc = [[MTLDepthStencilDescriptor alloc] init];
 	depthDesc.depthCompareFunction = MTLCompareFunctionAlways;
 	depthDesc.depthWriteEnabled = NO;
 	m_bgDepthStencilState = [device newDepthStencilStateWithDescriptor:depthDesc];
 
-	return m_bgPipelineState != nil;
+	return true;
 }
 
 void MetalPipeline::shutdown()

--- a/src/core/renderer/Metal/MetalRenderer.mm
+++ b/src/core/renderer/Metal/MetalRenderer.mm
@@ -339,10 +339,7 @@ void MetalRenderer::resize(uint32_t width, uint32_t height)
 	if (!m_impl)
 		return;
 
-	if (m_impl->metalLayer)
-	{
-		m_impl->metalLayer.drawableSize = CGSizeMake(width, height);
-	}
+	CocoaTools::SetDrawableSize(&m_windowInfo, width, height);
 
 	if (width == 0 || height == 0)
 	{

--- a/src/core/renderer/Metal/MetalRenderer.mm
+++ b/src/core/renderer/Metal/MetalRenderer.mm
@@ -135,22 +135,13 @@ bool MetalRenderer::initialize()
 		return true;
 
 	if (!m_impl)
-	{
-		Logger::error("MTL: Internal renderer state was not created");
-		return false;
-	}
+		return m_error.Fail("MTL: Internal renderer state was not created");
 
 	if (!m_impl->device.initialize())
-	{
-		Logger::error("MTL: Failed to initialize device");
-		return false;
-	}
+		return m_error.Assign(m_impl->device.GetError());
 
 	if (!CocoaTools::CreateMetalLayer(&m_windowInfo))
-	{
-		Logger::error("MTL: Failed to create Metal layer");
-		return false;
-	}
+		return m_error.Fail("MTL: Failed to create Metal layer");
 
 	m_impl->metalLayer = (__bridge CAMetalLayer*)m_windowInfo.surface_handle;
 	m_impl->metalLayer.device = m_impl->device.getDevice();
@@ -158,22 +149,13 @@ bool MetalRenderer::initialize()
 	m_impl->metalLayer.framebufferOnly = YES;
 
 	if (!m_impl->pipeline.initialize(m_impl->device.getDevice()))
-	{
-		Logger::error("MTL: Failed to initialize pipeline");
-		return false;
-	}
+		return m_error.Assign(m_impl->pipeline.GetError());
 
 	if (!m_impl->pipeline.createBackgroundPipeline(m_impl->device.getDevice()))
-	{
-		Logger::error("MTL: Failed to create background pipeline");
-		return false;
-	}
+		return m_error.Assign(m_impl->pipeline.GetError());
 
 	if (!m_impl->resources.initialize(m_impl->device.getDevice()))
-	{
-		Logger::error("MTL: Failed to initialize resources");
-		return false;
-	}
+		return m_error.Assign(m_impl->resources.GetError());
 
 	resize(m_windowInfo.surface_width, m_windowInfo.surface_height);
 
@@ -188,15 +170,17 @@ bool MetalRenderer::initialize()
 
 void MetalRenderer::shutdown()
 {
-	if (m_initialized && m_impl)
-	{
+	if (!m_impl)
+		return;
+
+	if (m_windowInfo.surface_handle)
 		CocoaTools::DestroyMetalLayer(&m_windowInfo);
-		m_impl->resources.shutdown();
-		m_impl->pipeline.shutdown();
-		m_impl->device.shutdown();
-		m_impl->metalLayer = nil;
-		m_initialized = false;
-	}
+
+	m_impl->resources.shutdown();
+	m_impl->pipeline.shutdown();
+	m_impl->device.shutdown();
+	m_impl->metalLayer = nil;
+	m_initialized = false;
 }
 
 void MetalRenderer::setIcon(std::shared_ptr<PS2Icon::Icon> icon)

--- a/src/core/renderer/Metal/MetalResources.h
+++ b/src/core/renderer/Metal/MetalResources.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cstdint>
 #include <array>
+#include "../../../common/Error.h"
 
 static const int kMaxFramesInFlight = 3;
 
@@ -19,6 +20,8 @@ public:
 
 	bool initialize(id<MTLDevice> device);
 	void shutdown();
+
+	const Error& GetError() const { return m_error; }
 
 	void uploadTexture(id<MTLDevice> device, const uint8_t* rgbaData, uint32_t width, uint32_t height);
 	id<MTLTexture> getTexture() const { return m_texture; }
@@ -39,6 +42,7 @@ public:
 	const FrameResources& getFrameResources(uint32_t index) const { return m_frames[index]; }
 
 private:
+	Error m_error;
 	id<MTLTexture> m_texture = nil;
 	id<MTLSamplerState> m_samplerState = nil;
 	id<MTLTexture> m_depthTexture = nil;

--- a/src/core/renderer/Metal/MetalResources.mm
+++ b/src/core/renderer/Metal/MetalResources.mm
@@ -22,6 +22,8 @@ MetalResources::~MetalResources()
 
 bool MetalResources::initialize(id<MTLDevice> device)
 {
+	m_error.Clear();
+
 	for (int i = 0; i < kMaxFramesInFlight; i++)
 	{
 		m_renderSemaphores[i] = dispatch_semaphore_create(1);
@@ -34,9 +36,7 @@ bool MetalResources::initialize(id<MTLDevice> device)
 		m_frames[i].backgroundBuffer = [device newBufferWithLength:kBackgroundBufferBytes options:MTLResourceStorageModeShared];
 
 		if (!m_frames[i].vertexBuffer || !m_frames[i].uniformBuffer || !m_frames[i].backgroundBuffer)
-		{
-			return false;
-		}
+			return m_error.Fail("MTL: Failed to create frame buffers");
 	}
 
 	MTLSamplerDescriptor* samplerDesc = [[MTLSamplerDescriptor alloc] init];
@@ -47,9 +47,7 @@ bool MetalResources::initialize(id<MTLDevice> device)
 	m_samplerState = [device newSamplerStateWithDescriptor:samplerDesc];
 
 	if (!m_samplerState)
-	{
-		return false;
-	}
+		return m_error.Fail("MTL: Failed to create sampler state");
 
 	return true;
 }

--- a/src/core/renderer/OpenGL/GLContext.cpp
+++ b/src/core/renderer/OpenGL/GLContext.cpp
@@ -20,6 +20,7 @@
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
+#include "../../../common/Error.h"
 #include "../../../common/Logger.h"
 
 GLContext::GLContext(const WindowInfo& windowInfo)
@@ -31,7 +32,15 @@ GLContext::GLContext(const WindowInfo& windowInfo)
 
 GLContext::~GLContext() = default;
 
-std::unique_ptr<GLContext> GLContext::Create(const WindowInfo& windowInfo, std::string* error)
+bool GLContext::failCreation(std::string message)
+{
+	if (m_creationError)
+		return Error::Fail(m_creationError, std::move(message));
+	Logger::error("{}", message);
+	return false;
+}
+
+std::unique_ptr<GLContext> GLContext::Create(const WindowInfo& windowInfo, Error* error)
 {
 	std::unique_ptr<GLContext> context;
 
@@ -42,25 +51,26 @@ std::unique_ptr<GLContext> GLContext::Create(const WindowInfo& windowInfo, std::
 #elif defined(__linux__)
 	context = GLContextEGL::Create(windowInfo, error);
 #else
-	if (error)
-		*error = "Unsupported platform for OpenGL context creation";
+	Error::Fail(error, "GL: Unsupported platform for OpenGL context creation");
 	return nullptr;
 #endif
 
 	if (!context)
 		return nullptr;
 
+	context->setCreationError(error);
+
 	if (!context->initialize())
 	{
-		if (error)
-			*error = "Failed to initialize OpenGL context";
+		if (!error || !error->IsValid())
+			Error::Fail(error, "GL: Failed to initialize OpenGL context");
 		return nullptr;
 	}
 
 	if (!context->makeCurrent())
 	{
-		if (error)
-			*error = "Failed to make OpenGL context current";
+		if (!error || !error->IsValid())
+			Error::Fail(error, "GL: Failed to make OpenGL context current");
 		return nullptr;
 	}
 
@@ -73,17 +83,20 @@ std::unique_ptr<GLContext> GLContext::Create(const WindowInfo& windowInfo, std::
 		}))
 	{
 		context->releaseCurrent();
-		if (error)
-			*error = "Failed to load GL functions for GLAD";
+		Error::Fail(error, "GL: Failed to load GL functions for GLAD");
 		return nullptr;
 	}
 
 	contextBeingCreated = nullptr;
 
+	const char* renderer = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
 	const char* version = reinterpret_cast<const char*>(glGetString(GL_VERSION));
-	Logger::info("GLContext: Created successfully with OpenGL {}", version ? version : "unknown");
+	Logger::info("GL: Using device: {} (OpenGL {})",
+		renderer ? renderer : "unknown",
+		version ? version : "unknown");
 
 	context->releaseCurrent();
+	context->setCreationError(nullptr);
 
 	return context;
 }

--- a/src/core/renderer/OpenGL/GLContext.h
+++ b/src/core/renderer/OpenGL/GLContext.h
@@ -8,6 +8,8 @@
 #include <memory>
 #include <string>
 
+class Error;
+
 class GLContext
 {
 public:
@@ -19,7 +21,7 @@ public:
 
 	virtual ~GLContext();
 
-	static std::unique_ptr<GLContext> Create(const WindowInfo& windowInfo, std::string* error = nullptr);
+	static std::unique_ptr<GLContext> Create(const WindowInfo& windowInfo, Error* error = nullptr);
 
 	virtual bool initialize() = 0;
 	virtual bool makeCurrent() = 0;
@@ -33,10 +35,15 @@ public:
 	uint32_t getWidth() const { return m_width; }
 	uint32_t getHeight() const { return m_height; }
 
+	void setCreationError(Error* error) { m_creationError = error; }
+
 protected:
 	GLContext(const WindowInfo& windowInfo);
+
+	bool failCreation(std::string message);
 
 	WindowInfo m_windowInfo;
 	uint32_t m_width;
 	uint32_t m_height;
+	Error* m_creationError = nullptr;
 };

--- a/src/core/renderer/OpenGL/GLContextAGL.h
+++ b/src/core/renderer/OpenGL/GLContextAGL.h
@@ -22,7 +22,7 @@ class GLContextAGL : public GLContext
 public:
 	~GLContextAGL() override;
 
-	static std::unique_ptr<GLContext> Create(const WindowInfo& windowInfo, std::string* error);
+	static std::unique_ptr<GLContext> Create(const WindowInfo& windowInfo, Error* error);
 
 	bool initialize() override;
 	bool makeCurrent() override;

--- a/src/core/renderer/OpenGL/GLContextAGL.mm
+++ b/src/core/renderer/OpenGL/GLContextAGL.mm
@@ -32,7 +32,7 @@ GLContextAGL::~GLContextAGL()
 	m_view = nil;
 }
 
-std::unique_ptr<GLContext> GLContextAGL::Create(const WindowInfo& windowInfo, [[maybe_unused]] std::string* error)
+std::unique_ptr<GLContext> GLContextAGL::Create(const WindowInfo& windowInfo, [[maybe_unused]] Error* error)
 {
 	auto context = std::unique_ptr<GLContextAGL>(new GLContextAGL(windowInfo));
 

--- a/src/core/renderer/OpenGL/GLContextEGL.cpp
+++ b/src/core/renderer/OpenGL/GLContextEGL.cpp
@@ -9,6 +9,7 @@
 #include <wayland-egl.h>
 #include <wayland-client.h>
 #include "Logger.h"
+#include "../../../common/Error.h"
 #include <cstring>
 
 GLContextEGL::GLContextEGL(const WindowInfo& windowInfo)
@@ -26,14 +27,14 @@ GLContextEGL::~GLContextEGL()
 	cleanup();
 }
 
-std::unique_ptr<GLContext> GLContextEGL::Create(const WindowInfo& windowInfo, std::string* error)
+std::unique_ptr<GLContext> GLContextEGL::Create(const WindowInfo& windowInfo, Error* error)
 {
 	std::unique_ptr<GLContextEGL> context(new GLContextEGL(windowInfo));
 
 	if (!context)
 	{
 		if (error)
-			*error = "Failed to allocate GLContextEGL";
+			*error = Error::CreateString("GL: Failed to allocate GLContextEGL");
 		return nullptr;
 	}
 
@@ -46,28 +47,22 @@ bool GLContextEGL::initialize()
 		return true;
 
 	if (!initializeDisplay())
-	{
-		Logger::error("GL: Failed to initialize display");
 		return false;
-	}
 
 	if (!chooseConfig())
 	{
-		Logger::error("GL: Failed to choose config");
 		cleanup();
 		return false;
 	}
 
 	if (!createSurface())
 	{
-		Logger::error("GL: Failed to create surface");
 		cleanup();
 		return false;
 	}
 
 	if (!createContext())
 	{
-		Logger::error("GL: Failed to create context");
 		cleanup();
 		return false;
 	}
@@ -89,15 +84,12 @@ bool GLContextEGL::initializeDisplay()
 	}
 
 	if (m_display == EGL_NO_DISPLAY)
-	{
-		Logger::error("GL: Failed to get EGL display");
-		return false;
-	}
+		return failCreation("GL: Failed to get EGL display");
 
 	EGLint major, minor;
 	if (!eglInitialize(m_display, &major, &minor))
 	{
-		Logger::error("GL: Failed to initialize EGL: {}", eglGetError());
+		failCreation("GL: Failed to initialize EGL (EGL error " + std::to_string(eglGetError()) + ")");
 		m_display = EGL_NO_DISPLAY;
 		return false;
 	}
@@ -121,10 +113,7 @@ bool GLContextEGL::chooseConfig()
 
 	EGLint numConfigs;
 	if (!eglChooseConfig(m_display, configAttribs, &m_config, 1, &numConfigs) || numConfigs == 0)
-	{
-		Logger::error("GL: Failed to choose EGL config: {}", eglGetError());
-		return false;
-	}
+		return failCreation("GL: Failed to choose EGL config (EGL error " + std::to_string(eglGetError()) + ")");
 
 	Logger::info("GL: EGL config chosen");
 	return true;
@@ -133,10 +122,7 @@ bool GLContextEGL::chooseConfig()
 bool GLContextEGL::createSurface()
 {
 	if (!m_windowInfo.window_handle)
-	{
-		Logger::error("GL: No native window handle provided");
-		return false;
-	}
+		return failCreation("GL: No native window handle provided");
 
 	EGLNativeWindowType nativeWindow = reinterpret_cast<EGLNativeWindowType>(m_windowInfo.window_handle);
 
@@ -145,20 +131,14 @@ bool GLContextEGL::createSurface()
 		struct wl_surface* surf = reinterpret_cast<struct wl_surface*>(m_windowInfo.window_handle);
 		m_waylandWindow = wl_egl_window_create(surf, m_width, m_height);
 		if (!m_waylandWindow)
-		{
-			Logger::error("GL: Failed to create wl_egl_window");
-			return false;
-		}
+			return failCreation("GL: Failed to create wl_egl_window");
 		nativeWindow = reinterpret_cast<EGLNativeWindowType>(m_waylandWindow);
 	}
 
 	m_surface = eglCreateWindowSurface(m_display, m_config, nativeWindow, nullptr);
 
 	if (m_surface == EGL_NO_SURFACE)
-	{
-		Logger::error("GL: Failed to create EGL surface: {}", eglGetError());
-		return false;
-	}
+		return failCreation("GL: Failed to create EGL surface (EGL error " + std::to_string(eglGetError()) + ")");
 
 	Logger::info("GL: EGL surface created");
 	return true;
@@ -167,10 +147,7 @@ bool GLContextEGL::createSurface()
 bool GLContextEGL::createContext()
 {
 	if (!eglBindAPI(EGL_OPENGL_API))
-	{
-		Logger::error("GL: Failed to bind OpenGL API: {}", eglGetError());
-		return false;
-	}
+		return failCreation("GL: Failed to bind OpenGL API (EGL error " + std::to_string(eglGetError()) + ")");
 
 	const EGLint contextAttribs[] = {
 		EGL_CONTEXT_MAJOR_VERSION, 3,
@@ -180,10 +157,7 @@ bool GLContextEGL::createContext()
 
 	m_context = eglCreateContext(m_display, m_config, EGL_NO_CONTEXT, contextAttribs);
 	if (m_context == EGL_NO_CONTEXT)
-	{
-		Logger::error("GL: Failed to create EGL context: {}", eglGetError());
-		return false;
-	}
+		return failCreation("GL: Failed to create EGL context (EGL error " + std::to_string(eglGetError()) + ")");
 
 	Logger::info("GL: EGL context created");
 	return true;
@@ -195,10 +169,7 @@ bool GLContextEGL::makeCurrent()
 		return false;
 
 	if (!eglMakeCurrent(m_display, m_surface, m_surface, m_context))
-	{
-		Logger::error("GL: Failed to make context current: {}", eglGetError());
-		return false;
-	}
+		return failCreation("GL: Failed to make context current (EGL error " + std::to_string(eglGetError()) + ")");
 
 	return true;
 }

--- a/src/core/renderer/OpenGL/GLContextEGL.h
+++ b/src/core/renderer/OpenGL/GLContextEGL.h
@@ -15,7 +15,7 @@
 class GLContextEGL : public GLContext
 {
 public:
-	static std::unique_ptr<GLContext> Create(const WindowInfo& windowInfo, std::string* error = nullptr);
+	static std::unique_ptr<GLContext> Create(const WindowInfo& windowInfo, Error* error = nullptr);
 
 	~GLContextEGL() override;
 

--- a/src/core/renderer/OpenGL/GLContextWGL.cpp
+++ b/src/core/renderer/OpenGL/GLContextWGL.cpp
@@ -16,6 +16,7 @@
 #pragma clang diagnostic pop
 #endif
 #include "Logger.h"
+#include "../../../common/Error.h"
 #include <cstring>
 
 extern "C" {
@@ -58,14 +59,14 @@ GLContextWGL::~GLContextWGL()
 	cleanup();
 }
 
-std::unique_ptr<GLContext> GLContextWGL::Create(const WindowInfo& windowInfo, std::string* error)
+std::unique_ptr<GLContext> GLContextWGL::Create(const WindowInfo& windowInfo, Error* error)
 {
 	std::unique_ptr<GLContextWGL> context(new GLContextWGL(windowInfo));
 
 	if (!context)
 	{
 		if (error)
-			*error = "Failed to allocate GLContextWGL";
+			*error = Error::CreateString("GL: Failed to allocate GLContextWGL");
 		return nullptr;
 	}
 
@@ -80,14 +81,10 @@ bool GLContextWGL::initialize()
 			return true;
 
 		if (!createWindow())
-		{
-			Logger::error("GL: Failed to create window");
 			return false;
-		}
 
 		if (!createContext())
 		{
-			Logger::error("GL: Failed to create context");
 			cleanup();
 			return false;
 		}
@@ -98,7 +95,7 @@ bool GLContextWGL::initialize()
 	}
 	catch (const std::exception& e)
 	{
-		Logger::error("GL: Exception during initialization: {}", e.what());
+		failCreation(std::string("GL: Exception during initialization: ") + e.what());
 		cleanup();
 		return false;
 	}
@@ -112,16 +109,12 @@ bool GLContextWGL::createWindow()
 		{
 			m_hwnd = reinterpret_cast<HWND>(m_windowInfo.window_handle);
 			if (!m_hwnd)
-			{
-				Logger::error("GL: External window handle is null");
-				return false;
-			}
+				return failCreation("GL: External window handle is null");
 
 			m_hdc = GetDC(m_hwnd);
 			if (!m_hdc)
 			{
-				Logger::error("GL: Failed to get device context for external window: {}", GetLastError());
-				return false;
+				return failCreation("GL: Failed to get device context for external window (Win32 error " + std::to_string(GetLastError()) + ")");
 			}
 
 			Logger::info("GL: Using external window for OpenGL context");
@@ -149,15 +142,12 @@ bool GLContextWGL::createWindow()
 			this);
 
 		if (!m_hwnd)
-		{
-			Logger::error("GL: Failed to create window: {}", GetLastError());
-			return false;
-		}
+			return failCreation("GL: Failed to create window (Win32 error " + std::to_string(GetLastError()) + ")");
 
 		m_hdc = GetDC(m_hwnd);
 		if (!m_hdc)
 		{
-			Logger::error("GL: Failed to get device context: {}", GetLastError());
+			failCreation("GL: Failed to get device context (Win32 error " + std::to_string(GetLastError()) + ")");
 			DestroyWindow(m_hwnd);
 			m_hwnd = nullptr;
 			return false;
@@ -168,8 +158,7 @@ bool GLContextWGL::createWindow()
 	}
 	catch (const std::exception& e)
 	{
-		Logger::error("GL: Exception creating window: {}", e.what());
-		return false;
+		return failCreation(std::string("GL: Exception creating window: ") + e.what());
 	}
 }
 
@@ -195,30 +184,18 @@ bool GLContextWGL::createContext()
 
 			int pixelFormat = ChoosePixelFormat(m_hdc, &pfd);
 			if (pixelFormat == 0)
-			{
-				Logger::error("GL: Failed to choose pixel format: {}", GetLastError());
-				return false;
-			}
+				return failCreation("GL: Failed to choose pixel format (Win32 error " + std::to_string(GetLastError()) + ")");
 
 			if (!SetPixelFormat(m_hdc, pixelFormat, &pfd))
-			{
-				Logger::error("GL: Failed to set pixel format: {}", GetLastError());
-				return false;
-			}
+				return failCreation("GL: Failed to set pixel format (Win32 error " + std::to_string(GetLastError()) + ")");
 		}
 
 		m_hglrc = wglCreateContext(m_hdc);
 		if (!m_hglrc)
-		{
-			Logger::error("GL: Failed to create GL context: {}", GetLastError());
-			return false;
-		}
+			return failCreation("GL: Failed to create GL context (Win32 error " + std::to_string(GetLastError()) + ")");
 
 		if (!wglMakeCurrent(m_hdc, m_hglrc))
-		{
-			Logger::error("GL: Failed to make context current for VSync setup: {}", GetLastError());
-			return false;
-		}
+			return failCreation("GL: Failed to make context current for VSync setup (Win32 error " + std::to_string(GetLastError()) + ")");
 
 		wglSwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC)wglGetProcAddress("wglSwapIntervalEXT");
 
@@ -239,8 +216,7 @@ bool GLContextWGL::createContext()
 	}
 	catch (const std::exception& e)
 	{
-		Logger::error("GL: Exception creating context: {}", e.what());
-		return false;
+		return failCreation(std::string("GL: Exception creating context: ") + e.what());
 	}
 }
 
@@ -252,17 +228,13 @@ bool GLContextWGL::makeCurrent()
 			return false;
 
 		if (!wglMakeCurrent(m_hdc, m_hglrc))
-		{
-			Logger::error("GL: Failed to make context current: {}", GetLastError());
-			return false;
-		}
+			return failCreation("GL: Failed to make context current (Win32 error " + std::to_string(GetLastError()) + ")");
 
 		return true;
 	}
 	catch (const std::exception& e)
 	{
-		Logger::error("GL: Exception making context current: {}", e.what());
-		return false;
+		return failCreation(std::string("GL: Exception making context current: ") + e.what());
 	}
 }
 

--- a/src/core/renderer/OpenGL/GLContextWGL.h
+++ b/src/core/renderer/OpenGL/GLContextWGL.h
@@ -25,7 +25,7 @@
 class GLContextWGL : public GLContext
 {
 public:
-	static std::unique_ptr<GLContext> Create(const WindowInfo& windowInfo, std::string* error = nullptr);
+	static std::unique_ptr<GLContext> Create(const WindowInfo& windowInfo, Error* error = nullptr);
 
 	~GLContextWGL() override;
 

--- a/src/core/renderer/OpenGL/OpenGLRenderer.cpp
+++ b/src/core/renderer/OpenGL/OpenGLRenderer.cpp
@@ -20,6 +20,7 @@
 #pragma clang diagnostic pop
 #endif
 #include "OpenGLRenderer.h"
+#include "../../../common/Error.h"
 #include "ps2iconsys.h"
 #include "ps2icon.h"
 #include "../../../common/Config.h"
@@ -49,24 +50,51 @@ OpenGLRenderer::~OpenGLRenderer()
 	shutdown();
 }
 
+bool OpenGLRenderer::failInit(Error error, bool log)
+{
+	releaseGL();
+	if (!error.IsValid())
+		return m_error.Fail("GL: Renderer initialization failed");
+	if (log)
+		return m_error.Fail(error.GetDescription());
+	return m_error.Assign(std::move(error));
+}
+
+void OpenGLRenderer::releaseGL()
+{
+	try
+	{
+		if (m_context)
+		{
+			if (m_context->makeCurrent())
+			{
+				m_resources.destroy();
+				m_shader.destroy();
+			}
+			m_context->releaseCurrent();
+			m_context.reset();
+		}
+	}
+	catch (const std::exception& e)
+	{
+		Logger::error("GL: Error releasing OpenGL resources: {}", e.what());
+		m_context.reset();
+	}
+}
+
 bool OpenGLRenderer::initialize()
 {
 	try
 	{
-		std::string error;
+		Error error;
 		m_context = GLContext::Create(m_windowInfo, &error);
 		if (!m_context)
-		{
-			Logger::error("GL: Failed to create GL context: {}", error);
-			return false;
-		}
+			return error.IsValid() ? m_error.Assign(error) : m_error.Fail("GL: Failed to create OpenGL context");
 
+		m_context->setCreationError(&error);
 		if (!m_context->makeCurrent())
-		{
-			Logger::error("GL: Failed to make context current");
-			m_context.reset();
-			return false;
-		}
+			return failInit(error.IsValid() ? error : Error::CreateString("GL: Failed to make context current"), !error.IsValid());
+		m_context->setCreationError(nullptr);
 
 		glEnable(GL_DEPTH_TEST);
 		glDepthFunc(GL_LEQUAL);
@@ -83,52 +111,22 @@ bool OpenGLRenderer::initialize()
 		glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
 
 		if (!m_shader.loadIconShaders())
-		{
-			Logger::error("GL: Failed to setup icon shaders");
-			m_context->releaseCurrent();
-			m_context.reset();
-			return false;
-		}
+			return failInit(m_shader.GetError(), false);
 
 		if (!m_shader.loadBackgroundShaders())
-		{
-			Logger::error("GL: Failed to setup background shaders");
-			m_context->releaseCurrent();
-			m_context.reset();
-			return false;
-		}
+			return failInit(m_shader.GetError(), false);
 
 		if (!m_resources.createIconBuffers())
-		{
-			Logger::error("GL: Failed to create icon buffers");
-			m_context->releaseCurrent();
-			m_context.reset();
-			return false;
-		}
+			return failInit(m_resources.GetError(), false);
 
 		if (!m_resources.createBackgroundBuffers())
-		{
-			Logger::error("GL: Failed to create background buffers");
-			m_context->releaseCurrent();
-			m_context.reset();
-			return false;
-		}
+			return failInit(m_resources.GetError(), false);
 
 		if (!m_resources.createUniformBuffer())
-		{
-			Logger::error("GL: Failed to create uniform buffer");
-			m_context->releaseCurrent();
-			m_context.reset();
-			return false;
-		}
+			return failInit(m_resources.GetError(), false);
 
 		if (!m_resources.createTexture())
-		{
-			Logger::error("GL: Failed to create texture");
-			m_context->releaseCurrent();
-			m_context.reset();
-			return false;
-		}
+			return failInit(m_resources.GetError(), false);
 
 		m_context->releaseCurrent();
 
@@ -145,37 +143,15 @@ bool OpenGLRenderer::initialize()
 	}
 	catch (const std::exception& e)
 	{
-		Logger::error("GL: Initialization failed: {}", e.what());
-		if (m_context)
-		{
-			m_context->releaseCurrent();
-			m_context.reset();
-		}
-		return false;
+		return failInit(Error::CreateString(std::string("GL: Initialization failed: ") + e.what()));
 	}
 }
 
 void OpenGLRenderer::shutdown()
 {
-	if (!m_initialized)
-		return;
-
 	try
 	{
-		if (m_context)
-		{
-			m_context->makeCurrent();
-		}
-
-		m_resources.destroy();
-		m_shader.destroy();
-
-		if (m_context)
-		{
-			m_context->releaseCurrent();
-			m_context.reset();
-		}
-
+		releaseGL();
 		m_initialized = false;
 		Logger::info("GL: Shutdown complete");
 	}

--- a/src/core/renderer/OpenGL/OpenGLRenderer.h
+++ b/src/core/renderer/OpenGL/OpenGLRenderer.h
@@ -58,6 +58,8 @@ private:
 	void prepareVertexData();
 	void setupTexture();
 	void updateBackgroundVertexData();
+	bool failInit(Error error, bool log = true);
+	void releaseGL();
 
 	bool m_initialized;
 	uint32_t m_width;

--- a/src/core/renderer/OpenGL/OpenGLResources.cpp
+++ b/src/core/renderer/OpenGL/OpenGLResources.cpp
@@ -73,21 +73,21 @@ void OpenGLResources::destroy()
 
 bool OpenGLResources::createIconBuffers()
 {
+	m_error.Clear();
+
 	glGenVertexArrays(1, &m_iconVAO);
 	glGenBuffers(1, &m_iconVBO);
 	glGenBuffers(1, &m_iconEBO);
 
-	if (m_iconVAO == 0 || m_iconVBO == 0)
-	{
-		Logger::error("GL: Failed to create icon buffers");
-		return false;
-	}
+	if (m_iconVAO == 0 || m_iconVBO == 0 || m_iconEBO == 0)
+		return m_error.Fail("GL: Failed to create icon buffers");
 
 	return true;
 }
 
 bool OpenGLResources::createBackgroundBuffers()
 {
+	m_error.Clear();
 	float quadVertices[] = {
 		-1.0f, 1.0f, // top-left
 		-1.0f, -1.0f, // bottom-left
@@ -100,10 +100,7 @@ bool OpenGLResources::createBackgroundBuffers()
 	glGenBuffers(1, &m_backgroundColorVBO);
 
 	if (m_backgroundVAO == 0 || m_backgroundVBO == 0 || m_backgroundColorVBO == 0)
-	{
-		Logger::error("GL: Failed to create background buffers");
-		return false;
-	}
+		return m_error.Fail("GL: Failed to create background buffers");
 
 	glBindVertexArray(m_backgroundVAO);
 
@@ -131,12 +128,11 @@ bool OpenGLResources::createBackgroundBuffers()
 
 bool OpenGLResources::createUniformBuffer()
 {
+	m_error.Clear();
+
 	glGenBuffers(1, &m_UBO);
 	if (m_UBO == 0)
-	{
-		Logger::error("GL: Failed to create uniform buffer");
-		return false;
-	}
+		return m_error.Fail("GL: Failed to create uniform buffer");
 
 	glBindBuffer(GL_UNIFORM_BUFFER, m_UBO);
 	glBufferData(GL_UNIFORM_BUFFER, 512, nullptr, GL_DYNAMIC_DRAW);
@@ -147,12 +143,11 @@ bool OpenGLResources::createUniformBuffer()
 
 bool OpenGLResources::createTexture()
 {
+	m_error.Clear();
+
 	glGenTextures(1, &m_textureID);
 	if (m_textureID == 0)
-	{
-		Logger::error("GL: Failed to create texture");
-		return false;
-	}
+		return m_error.Fail("GL: Failed to create texture");
 
 	return true;
 }

--- a/src/core/renderer/OpenGL/OpenGLResources.h
+++ b/src/core/renderer/OpenGL/OpenGLResources.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <cstddef>
+#include "../../../common/Error.h"
 
 typedef unsigned int GLuint;
 typedef int GLint;
@@ -38,6 +39,8 @@ public:
 	bool createTexture();
 	void destroy();
 
+	const Error& GetError() const { return m_error; }
+
 	void uploadVertexData(const OpenGLVertex* vertices, uint32_t count);
 	void uploadTexture(const uint8_t* rgba, uint32_t width, uint32_t height);
 	void updateUniformBuffer(const void* data, size_t size);
@@ -49,6 +52,7 @@ public:
 	GLuint getUBO() const { return m_UBO; }
 
 private:
+	Error m_error;
 	GLuint m_iconVAO = 0;
 	GLuint m_iconVBO = 0;
 	GLuint m_iconEBO = 0;

--- a/src/core/renderer/OpenGL/OpenGLShader.cpp
+++ b/src/core/renderer/OpenGL/OpenGLShader.cpp
@@ -45,7 +45,7 @@ std::string OpenGLShader::readShaderFile(const std::string& filename)
 	std::ifstream file(filename);
 	if (!file.is_open())
 	{
-		Logger::error("GL: Failed to open shader file: {}", filename);
+		m_error.Fail("GL: Failed to open shader file: " + filename);
 		return "";
 	}
 	std::stringstream buffer;
@@ -66,8 +66,8 @@ GLuint OpenGLShader::compileShader(const std::string& source, GLenum shaderType)
 	if (!success)
 	{
 		glGetShaderInfoLog(shader, 512, nullptr, infoLog);
-		Logger::error("GL: Shader compilation failed:\n{}", infoLog);
 		glDeleteShader(shader);
+		m_error.Fail(std::string("GL: Shader compilation failed:\n") + infoLog);
 		return 0;
 	}
 
@@ -87,8 +87,8 @@ GLuint OpenGLShader::linkProgram(GLuint vertexShader, GLuint fragmentShader)
 	if (!success)
 	{
 		glGetProgramInfoLog(program, 512, nullptr, infoLog);
-		Logger::error("GL: Program linking failed:\n{}", infoLog);
 		glDeleteProgram(program);
+		m_error.Fail(std::string("GL: Program linking failed:\n") + infoLog);
 		return 0;
 	}
 
@@ -99,39 +99,33 @@ GLuint OpenGLShader::linkProgram(GLuint vertexShader, GLuint fragmentShader)
 
 bool OpenGLShader::loadIconShaders()
 {
+	m_error.Clear();
+
 	fs::path vertexShaderPath = ResourcePath::shaders() / "OpenGL" / "icon.vert";
 	fs::path fragmentShaderPath = ResourcePath::shaders() / "OpenGL" / "icon.frag";
 
 	std::string vertSource = readShaderFile(vertexShaderPath.string());
-	std::string fragSource = readShaderFile(fragmentShaderPath.string());
-
-	if (vertSource.empty() || fragSource.empty())
-	{
-		Logger::error("GL: Failed to load icon shader sources");
+	if (vertSource.empty())
 		return false;
-	}
+
+	std::string fragSource = readShaderFile(fragmentShaderPath.string());
+	if (fragSource.empty())
+		return false;
 
 	GLuint vertexShader = compileShader(vertSource, GL_VERTEX_SHADER);
 	if (vertexShader == 0)
-	{
-		Logger::error("GL: Failed to compile icon vertex shader");
 		return false;
-	}
 
 	GLuint fragmentShader = compileShader(fragSource, GL_FRAGMENT_SHADER);
 	if (fragmentShader == 0)
 	{
 		glDeleteShader(vertexShader);
-		Logger::error("GL: Failed to compile icon fragment shader");
 		return false;
 	}
 
 	m_iconProgram = linkProgram(vertexShader, fragmentShader);
 	if (m_iconProgram == 0)
-	{
-		Logger::error("GL: Failed to link icon shader program");
 		return false;
-	}
 
 	m_uboBlockIndex = glGetUniformBlockIndex(m_iconProgram, "UniformBufferObject");
 	m_texSamplerLocation = glGetUniformLocation(m_iconProgram, "texSampler");
@@ -145,39 +139,33 @@ bool OpenGLShader::loadIconShaders()
 
 bool OpenGLShader::loadBackgroundShaders()
 {
+	m_error.Clear();
+
 	fs::path bgVertexShaderPath = ResourcePath::shaders() / "OpenGL" / "background.vert";
 	fs::path bgFragmentShaderPath = ResourcePath::shaders() / "OpenGL" / "background.frag";
 
 	std::string bgVertSource = readShaderFile(bgVertexShaderPath.string());
-	std::string bgFragSource = readShaderFile(bgFragmentShaderPath.string());
-
-	if (bgVertSource.empty() || bgFragSource.empty())
-	{
-		Logger::error("GL: Failed to load background shader sources");
+	if (bgVertSource.empty())
 		return false;
-	}
+
+	std::string bgFragSource = readShaderFile(bgFragmentShaderPath.string());
+	if (bgFragSource.empty())
+		return false;
 
 	GLuint bgVertexShader = compileShader(bgVertSource, GL_VERTEX_SHADER);
 	if (bgVertexShader == 0)
-	{
-		Logger::error("GL: Failed to compile background vertex shader");
 		return false;
-	}
 
 	GLuint bgFragmentShader = compileShader(bgFragSource, GL_FRAGMENT_SHADER);
 	if (bgFragmentShader == 0)
 	{
 		glDeleteShader(bgVertexShader);
-		Logger::error("GL: Failed to compile background fragment shader");
 		return false;
 	}
 
 	m_backgroundProgram = linkProgram(bgVertexShader, bgFragmentShader);
 	if (m_backgroundProgram == 0)
-	{
-		Logger::error("GL: Failed to link background shader program");
 		return false;
-	}
 
 	Logger::info("GL: Background shaders loaded and compiled successfully");
 	return true;

--- a/src/core/renderer/OpenGL/OpenGLShader.h
+++ b/src/core/renderer/OpenGL/OpenGLShader.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <string>
+#include "../../../common/Error.h"
 
 typedef unsigned int GLuint;
 typedef int GLint;
@@ -23,6 +24,8 @@ public:
 	bool loadBackgroundShaders();
 	void destroy();
 
+	const Error& GetError() const { return m_error; }
+
 	GLuint getIconProgram() const { return m_iconProgram; }
 	GLuint getBackgroundProgram() const { return m_backgroundProgram; }
 
@@ -33,10 +36,11 @@ public:
 	GLint getAlphaOverrideLocation() const { return m_alphaOverrideLocation; }
 
 private:
-	static std::string readShaderFile(const std::string& filename);
-	static GLuint compileShader(const std::string& source, GLenum shaderType);
-	static GLuint linkProgram(GLuint vertexShader, GLuint fragmentShader);
+	std::string readShaderFile(const std::string& filename);
+	GLuint compileShader(const std::string& source, GLenum shaderType);
+	GLuint linkProgram(GLuint vertexShader, GLuint fragmentShader);
 
+	Error m_error;
 	GLuint m_iconProgram = 0;
 	GLuint m_backgroundProgram = 0;
 

--- a/src/core/renderer/Renderer.cpp
+++ b/src/core/renderer/Renderer.cpp
@@ -36,33 +36,39 @@ std::unique_ptr<Renderer> RendererFactory::createRenderer(
 }
 
 #if defined(ENABLE_VULKAN)
-std::unique_ptr<Renderer> RendererFactory::createVulkanRenderer(const WindowInfo& windowInfo, Config* config)
+std::unique_ptr<Renderer> RendererFactory::createVulkanRenderer(const WindowInfo& windowInfo, Config* config, Error* error)
 {
 	auto renderer = std::make_unique<VulkanRenderer>(windowInfo, config);
 	if (!renderer->initialize())
 	{
+		if (error)
+			*error = renderer->GetError();
 		return nullptr;
 	}
 	return renderer;
 }
 #endif
 
-std::unique_ptr<Renderer> RendererFactory::createOpenGLRenderer(const WindowInfo& windowInfo, Config* config)
+std::unique_ptr<Renderer> RendererFactory::createOpenGLRenderer(const WindowInfo& windowInfo, Config* config, Error* error)
 {
 	auto renderer = std::make_unique<OpenGLRenderer>(windowInfo, config);
 	if (!renderer->initialize())
 	{
+		if (error)
+			*error = renderer->GetError();
 		return nullptr;
 	}
 	return renderer;
 }
 
 #if defined(__APPLE__)
-std::unique_ptr<Renderer> RendererFactory::createMetalRenderer(const WindowInfo& windowInfo, Config* config)
+std::unique_ptr<Renderer> RendererFactory::createMetalRenderer(const WindowInfo& windowInfo, Config* config, Error* error)
 {
 	auto renderer = std::make_unique<MetalRenderer>(windowInfo, config);
 	if (!renderer->initialize())
 	{
+		if (error)
+			*error = renderer->GetError();
 		return nullptr;
 	}
 	return renderer;

--- a/src/core/renderer/Renderer.h
+++ b/src/core/renderer/Renderer.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
+#include "../../common/Error.h"
 #include "WindowInfo.h"
 
 class Config;
@@ -38,6 +39,8 @@ class Renderer
 public:
 	virtual ~Renderer() = default;
 
+	const Error& GetError() const { return m_error; }
+
 	virtual bool initialize() = 0;
 	virtual void shutdown() = 0;
 	virtual bool isInitialized() const = 0;
@@ -65,6 +68,9 @@ public:
 
 	virtual uint32_t getVertexCount() const = 0;
 	virtual uint32_t getFrameCount() const = 0;
+
+protected:
+	Error m_error;
 };
 
 class RendererFactory
@@ -84,15 +90,18 @@ public:
 
 	static std::unique_ptr<Renderer> createVulkanRenderer(
 		const WindowInfo& windowInfo,
-		Config* config = nullptr);
+		Config* config = nullptr,
+		Error* error = nullptr);
 
 	static std::unique_ptr<Renderer> createOpenGLRenderer(
 		const WindowInfo& windowInfo,
-		Config* config = nullptr);
+		Config* config = nullptr,
+		Error* error = nullptr);
 
 	static std::unique_ptr<Renderer> createMetalRenderer(
 		const WindowInfo& windowInfo,
-		Config* config = nullptr);
+		Config* config = nullptr,
+		Error* error = nullptr);
 
 	static void registerRenderer(Renderer* renderer);
 	static void unregisterRenderer(Renderer* renderer);

--- a/src/core/renderer/Vulkan/VulkanDevice.cpp
+++ b/src/core/renderer/Vulkan/VulkanDevice.cpp
@@ -46,14 +46,24 @@ VulkanDevice::~VulkanDevice()
 
 bool VulkanDevice::create(const WindowInfo& windowInfo)
 {
+	m_error.Clear();
 	if (!createInstance())
 		return false;
 	if (!createSurface(windowInfo))
+	{
+		destroy();
 		return false;
+	}
 	if (!selectPhysicalDevice())
+	{
+		destroy();
 		return false;
+	}
 	if (!createLogicalDevice())
+	{
+		destroy();
 		return false;
+	}
 	return true;
 }
 
@@ -183,10 +193,7 @@ bool VulkanDevice::createInstance()
 #endif
 
 	if (vkCreateInstance(&createInfo, nullptr, &m_instance) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create Vulkan instance");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create Vulkan instance");
 
 #ifndef NDEBUG
 	if (enableDebugValidation)
@@ -214,25 +221,16 @@ bool VulkanDevice::createInstance()
 bool VulkanDevice::createSurface(const WindowInfo& windowInfo)
 {
 	if (windowInfo.type != WindowInfo::Type::Surfaceless && !windowInfo.window_handle)
-	{
-		Logger::error("VK: No native window handle available");
-		return false;
-	}
+		return m_error.Fail("VK: No native window handle available");
 
 #if defined(_WIN32)
 	if (windowInfo.type != WindowInfo::Type::Win32)
-	{
-		Logger::error("VK: Invalid window type for Windows");
-		return false;
-	}
+		return m_error.Fail("VK: Invalid window type for Windows");
 
 	HWND hwnd = reinterpret_cast<HWND>(windowInfo.window_handle);
 
 	if (!IsWindow(hwnd))
-	{
-		Logger::error("VK: Window handle is invalid");
-		return false;
-	}
+		return m_error.Fail("VK: Window handle is invalid");
 
 	VkWin32SurfaceCreateInfoKHR createInfo{};
 	createInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
@@ -242,10 +240,7 @@ bool VulkanDevice::createSurface(const WindowInfo& windowInfo)
 	VkResult result = vkCreateWin32SurfaceKHR(m_instance, &createInfo, nullptr, &m_surface);
 
 	if (result != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create window surface: {}", static_cast<int>(result));
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create window surface (VkResult " + std::to_string(static_cast<int>(result)) + ")");
 
 	Logger::info("VK: Win32 surface created successfully");
 	return true;
@@ -258,10 +253,7 @@ bool VulkanDevice::createSurface(const WindowInfo& windowInfo)
 		createInfo.surface = static_cast<wl_surface*>(windowInfo.window_handle);
 
 		if (vkCreateWaylandSurfaceKHR(m_instance, &createInfo, nullptr, &m_surface) != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to create Wayland surface");
-			return false;
-		}
+			return m_error.Fail("VK: Failed to create Wayland surface");
 		Logger::info("VK: Wayland surface created successfully");
 		return true;
 	}
@@ -274,10 +266,7 @@ bool VulkanDevice::createSurface(const WindowInfo& windowInfo)
 		{
 			display = XOpenDisplay(nullptr);
 			if (!display)
-			{
-				Logger::error("VK: Failed to open X display");
-				return false;
-			}
+				return m_error.Fail("VK: Failed to open X display");
 			ownDisplay = true;
 		}
 
@@ -288,10 +277,9 @@ bool VulkanDevice::createSurface(const WindowInfo& windowInfo)
 
 		if (vkCreateXlibSurfaceKHR(m_instance, &createInfo, nullptr, &m_surface) != VK_SUCCESS)
 		{
-			Logger::error("VK: Failed to create Xlib surface");
 			if (ownDisplay)
 				XCloseDisplay(display);
-			return false;
+			return m_error.Fail("VK: Failed to create Xlib surface");
 		}
 
 		if (ownDisplay)
@@ -301,22 +289,13 @@ bool VulkanDevice::createSurface(const WindowInfo& windowInfo)
 		return true;
 	}
 	else
-	{
-		Logger::error("VK: Unknown or invalid window type for Linux");
-		return false;
-	}
+		return m_error.Fail("VK: Unknown or invalid window type for Linux");
 #elif defined(__APPLE__)
 	if (windowInfo.type != WindowInfo::Type::MacOS)
-	{
-		Logger::error("VK: Invalid window type for macOS");
-		return false;
-	}
+		return m_error.Fail("VK: Invalid window type for macOS");
 
 	if (!windowInfo.surface_handle)
-	{
-		Logger::error("VK: Metal layer not created for MoltenVK");
-		return false;
-	}
+		return m_error.Fail("VK: Metal layer not created for MoltenVK");
 
 	VkMetalSurfaceCreateInfoEXT createInfo{};
 	createInfo.sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
@@ -325,16 +304,12 @@ bool VulkanDevice::createSurface(const WindowInfo& windowInfo)
 	VkResult result = vkCreateMetalSurfaceEXT(m_instance, &createInfo, nullptr, &m_surface);
 
 	if (result != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create Metal surface: {}", static_cast<int>(result));
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create Metal surface (VkResult " + std::to_string(static_cast<int>(result)) + ")");
 
 	Logger::info("VK: Metal surface created successfully for MoltenVK");
 	return true;
 #else
-	Logger::error("VK: Vulkan surface creation not implemented for this platform");
-	return false;
+	return m_error.Fail("VK: Vulkan surface creation not implemented for this platform");
 #endif
 }
 
@@ -344,10 +319,7 @@ bool VulkanDevice::selectPhysicalDevice()
 	vkEnumeratePhysicalDevices(m_instance, &deviceCount, nullptr);
 
 	if (deviceCount == 0)
-	{
-		Logger::error("VK: No Vulkan devices found");
-		return false;
-	}
+		return m_error.Fail("VK: No Vulkan devices found");
 
 	std::vector<VkPhysicalDevice> devices(deviceCount);
 	vkEnumeratePhysicalDevices(m_instance, &deviceCount, devices.data());
@@ -381,15 +353,14 @@ bool VulkanDevice::selectPhysicalDevice()
 				{
 					m_physicalDevice = device;
 					m_graphicsQueueFamily = i;
-					Logger::info("VK: Selected device: {}", props.deviceName);
+					Logger::info("VK: Using device: {}", props.deviceName);
 					return true;
 				}
 			}
 		}
 	}
 
-	Logger::error("VK: No suitable GPU found");
-	return false;
+	return m_error.Fail("VK: No suitable device found");
 }
 
 bool VulkanDevice::createLogicalDevice()
@@ -460,10 +431,7 @@ bool VulkanDevice::createLogicalDevice()
 	createInfo.ppEnabledExtensionNames = extensions.data();
 
 	if (vkCreateDevice(m_physicalDevice, &createInfo, nullptr, &m_device) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create logical device");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create logical device");
 
 	m_supportsMemoryPriority = supportsMemoryPriority;
 
@@ -478,10 +446,7 @@ bool VulkanDevice::createLogicalDevice()
 		allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT;
 
 	if (vmaCreateAllocator(&allocatorInfo, &m_allocator) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create VMA allocator");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create VMA allocator");
 
 	Logger::info("VK: VMA allocator created successfully");
 	return true;

--- a/src/core/renderer/Vulkan/VulkanDevice.h
+++ b/src/core/renderer/Vulkan/VulkanDevice.h
@@ -6,6 +6,7 @@
 #include <vulkan/vulkan.h>
 #include <vk_mem_alloc.h>
 #include <cstdint>
+#include "../../../common/Error.h"
 
 struct WindowInfo;
 
@@ -20,6 +21,8 @@ public:
 
 	bool create(const WindowInfo& windowInfo);
 	void destroy();
+
+	const Error& GetError() const { return m_error; }
 
 	VkInstance getInstance() const { return m_instance; }
 	VkSurfaceKHR getSurface() const { return m_surface; }
@@ -37,6 +40,8 @@ private:
 	bool createSurface(const WindowInfo& windowInfo);
 	bool selectPhysicalDevice();
 	bool createLogicalDevice();
+
+	Error m_error;
 
 	VkInstance m_instance = VK_NULL_HANDLE;
 	VkSurfaceKHR m_surface = VK_NULL_HANDLE;

--- a/src/core/renderer/Vulkan/VulkanPipeline.cpp
+++ b/src/core/renderer/Vulkan/VulkanPipeline.cpp
@@ -14,17 +14,15 @@
 #include <glslang/Public/ResourceLimits.h>
 #include <SPIRV/GlslangToSpv.h>
 
+namespace fs = std::filesystem;
+
 namespace
 {
 	bool InitializeGlslang()
 	{
 		static bool initialized = false;
 		if (!initialized)
-		{
 			initialized = glslang::InitializeProcess();
-			if (!initialized)
-				Logger::error("VK: Failed to initialize glslang");
-		}
 		return initialized;
 	}
 
@@ -40,63 +38,51 @@ namespace
 			return EShLangFragment;
 		return EShLangVertex;
 	}
-
-	bool CompileGlslToSpirv(const fs::path& path, std::vector<uint32_t>& spirv)
-	{
-		if (!InitializeGlslang())
-			return false;
-
-		std::ifstream file(path);
-		if (!file.is_open())
-		{
-			Logger::error("VK: Failed to open GLSL shader file: {}", path.string());
-			return false;
-		}
-
-		std::stringstream buffer;
-		buffer << file.rdbuf();
-		const std::string source = buffer.str();
-
-		const std::string pathStr = path.string();
-		const char* cstr = source.c_str();
-
-		EShLanguage stage = GetShaderStage(pathStr.c_str());
-		glslang::TShader shader(stage);
-		shader.setStrings(&cstr, 1);
-		shader.setEntryPoint("main");
-		shader.setSourceEntryPoint("main");
-		shader.setEnvInput(glslang::EShSourceGlsl, stage, glslang::EShClientVulkan, 1);
-		shader.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetVulkan_1_2);
-		shader.setEnvTarget(glslang::EShTargetSpv, glslang::EShTargetSpv_1_5);
-
-		EShMessages messages = (EShMessages)(EShMsgSpvRules | EShMsgVulkanRules);
-
-		const TBuiltInResource* resources = GetDefaultResources();
-		if (!resources)
-		{
-			Logger::error("VK: glslang::GetDefaultResources() returned null for {}", pathStr);
-			return false;
-		}
-
-		if (!shader.parse(resources, 100, false, messages))
-		{
-			Logger::error("VK: GLSL shader parse failed for {}:\n{}", pathStr, shader.getInfoLog());
-			return false;
-		}
-
-		glslang::TProgram program;
-		program.addShader(&shader);
-
-		if (!program.link(messages))
-		{
-			Logger::error("VK: GLSL program link failed for {}:\n{}", pathStr, program.getInfoLog());
-			return false;
-		}
-
-		glslang::GlslangToSpv(*program.getIntermediate(stage), spirv);
-		return true;
-	}
 } // namespace
+
+bool VulkanPipeline::compileGlslToSpirv(const fs::path& path, std::vector<uint32_t>& spirv)
+{
+	if (!InitializeGlslang())
+		return m_error.Fail("VK: Failed to initialize glslang");
+
+	std::ifstream file(path);
+	if (!file.is_open())
+		return m_error.Fail("VK: Failed to open GLSL shader file: " + path.string());
+
+	std::stringstream buffer;
+	buffer << file.rdbuf();
+	const std::string source = buffer.str();
+
+	const std::string pathStr = path.string();
+	const char* cstr = source.c_str();
+
+	EShLanguage stage = GetShaderStage(pathStr.c_str());
+	glslang::TShader shader(stage);
+	shader.setStrings(&cstr, 1);
+	shader.setEntryPoint("main");
+	shader.setSourceEntryPoint("main");
+	shader.setEnvInput(glslang::EShSourceGlsl, stage, glslang::EShClientVulkan, 1);
+	shader.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetVulkan_1_2);
+	shader.setEnvTarget(glslang::EShTargetSpv, glslang::EShTargetSpv_1_5);
+
+	EShMessages messages = (EShMessages)(EShMsgSpvRules | EShMsgVulkanRules);
+
+	const TBuiltInResource* resources = GetDefaultResources();
+	if (!resources)
+		return m_error.Fail("VK: glslang::GetDefaultResources() returned null for " + pathStr);
+
+	if (!shader.parse(resources, 100, false, messages))
+		return m_error.Fail("VK: GLSL shader parse failed for " + pathStr + ":\n" + shader.getInfoLog());
+
+	glslang::TProgram program;
+	program.addShader(&shader);
+
+	if (!program.link(messages))
+		return m_error.Fail("VK: GLSL program link failed for " + pathStr + ":\n" + program.getInfoLog());
+
+	glslang::GlslangToSpv(*program.getIntermediate(stage), spirv);
+	return true;
+}
 
 VulkanPipeline::VulkanPipeline() = default;
 
@@ -148,16 +134,15 @@ void VulkanPipeline::destroy(VkDevice device)
 
 bool VulkanPipeline::createPipelineCache(VkDevice device)
 {
+	m_error.Clear();
+
 	VkPipelineCacheCreateInfo cacheInfo{};
 	cacheInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
 	cacheInfo.initialDataSize = 0;
 	cacheInfo.pInitialData = nullptr;
 
 	if (vkCreatePipelineCache(device, &cacheInfo, nullptr, &m_pipelineCache) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create pipeline cache");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create pipeline cache");
 
 	return true;
 }
@@ -170,9 +155,10 @@ VkShaderModule VulkanPipeline::createShaderModule(VkDevice device, const std::ve
 	createInfo.pCode = reinterpret_cast<const uint32_t*>(code.data());
 
 	VkShaderModule shaderModule;
-	if (vkCreateShaderModule(device, &createInfo, nullptr, &shaderModule) != VK_SUCCESS)
+	const VkResult result = vkCreateShaderModule(device, &createInfo, nullptr, &shaderModule);
+	if (result != VK_SUCCESS)
 	{
-		Logger::error("VK: Failed to create shader module");
+		m_error.Fail("VK: Failed to create shader module (VkResult " + std::to_string(static_cast<int>(result)) + ")");
 		return VK_NULL_HANDLE;
 	}
 
@@ -187,9 +173,9 @@ bool VulkanPipeline::createShaderModules(VkDevice device)
 	std::vector<uint32_t> vertSpirv;
 	std::vector<uint32_t> fragSpirv;
 
-	if (!CompileGlslToSpirv(vertPath, vertSpirv))
+	if (!compileGlslToSpirv(vertPath, vertSpirv))
 		return false;
-	if (!CompileGlslToSpirv(fragPath, fragSpirv))
+	if (!compileGlslToSpirv(fragPath, fragSpirv))
 		return false;
 
 	std::vector<char> vertCode(reinterpret_cast<char*>(vertSpirv.data()),
@@ -201,10 +187,7 @@ bool VulkanPipeline::createShaderModules(VkDevice device)
 	m_fragmentShader = createShaderModule(device, fragCode);
 
 	if (m_vertexShader == VK_NULL_HANDLE || m_fragmentShader == VK_NULL_HANDLE)
-	{
-		Logger::error("VK: Failed to create shader modules");
 		return false;
-	}
 
 	Logger::info("VK: Shader modules created successfully");
 	return true;
@@ -212,6 +195,8 @@ bool VulkanPipeline::createShaderModules(VkDevice device)
 
 bool VulkanPipeline::createMainPipeline(VkDevice device, VkRenderPass renderPass)
 {
+	m_error.Clear();
+
 	if (!createShaderModules(device))
 		return false;
 
@@ -322,10 +307,7 @@ bool VulkanPipeline::createMainPipeline(VkDevice device, VkRenderPass renderPass
 	layoutInfo.pBindings = bindings;
 
 	if (vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &m_descriptorSetLayout) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create descriptor set layout");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create descriptor set layout");
 
 	VkPushConstantRange pushConstantRange{};
 	pushConstantRange.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
@@ -340,10 +322,7 @@ bool VulkanPipeline::createMainPipeline(VkDevice device, VkRenderPass renderPass
 	pipelineLayoutInfo.pPushConstantRanges = &pushConstantRange;
 
 	if (vkCreatePipelineLayout(device, &pipelineLayoutInfo, nullptr, &m_pipelineLayout) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create pipeline layout");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create pipeline layout");
 
 	VkPipelineDepthStencilStateCreateInfo depthStencil{};
 	depthStencil.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
@@ -379,25 +358,24 @@ bool VulkanPipeline::createMainPipeline(VkDevice device, VkRenderPass renderPass
 	pipelineInfo.subpass = 0;
 
 	if (vkCreateGraphicsPipelines(device, m_pipelineCache, 1, &pipelineInfo, nullptr, &m_graphicsPipeline) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create graphics pipeline");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create graphics pipeline");
 
 	return true;
 }
 
 bool VulkanPipeline::createBackgroundPipeline(VkDevice device, VkRenderPass renderPass)
 {
+	m_error.Clear();
+
 	fs::path vertPath = ResourcePath::shaders() / "Vulkan" / "background.vert.glsl";
 	fs::path fragPath = ResourcePath::shaders() / "Vulkan" / "background.frag.glsl";
 
 	std::vector<uint32_t> vertSpirv;
 	std::vector<uint32_t> fragSpirv;
 
-	if (!CompileGlslToSpirv(vertPath, vertSpirv))
+	if (!compileGlslToSpirv(vertPath, vertSpirv))
 		return false;
-	if (!CompileGlslToSpirv(fragPath, fragSpirv))
+	if (!compileGlslToSpirv(fragPath, fragSpirv))
 		return false;
 
 	std::vector<char> vertCode(reinterpret_cast<char*>(vertSpirv.data()),
@@ -408,10 +386,7 @@ bool VulkanPipeline::createBackgroundPipeline(VkDevice device, VkRenderPass rend
 	VkShaderModule bgVert = createShaderModule(device, vertCode);
 	VkShaderModule bgFrag = createShaderModule(device, fragCode);
 	if (bgVert == VK_NULL_HANDLE || bgFrag == VK_NULL_HANDLE)
-	{
-		Logger::error("VK: Failed to create background shader modules");
 		return false;
-	}
 
 	VkPipelineShaderStageCreateInfo stages[2]{};
 	stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
@@ -497,10 +472,9 @@ bool VulkanPipeline::createBackgroundPipeline(VkDevice device, VkRenderPass rend
 
 	if (vkCreatePipelineLayout(device, &pl, nullptr, &m_bgPipelineLayout) != VK_SUCCESS)
 	{
-		Logger::error("VK: Failed to create background pipeline layout");
 		vkDestroyShaderModule(device, bgVert, nullptr);
 		vkDestroyShaderModule(device, bgFrag, nullptr);
-		return false;
+		return m_error.Fail("VK: Failed to create background pipeline layout");
 	}
 
 	VkPipelineDepthStencilStateCreateInfo bgDepth{};
@@ -538,12 +512,11 @@ bool VulkanPipeline::createBackgroundPipeline(VkDevice device, VkRenderPass rend
 
 	if (vkCreateGraphicsPipelines(device, m_pipelineCache, 1, &pi, nullptr, &m_bgPipeline) != VK_SUCCESS)
 	{
-		Logger::error("VK: Failed to create background pipeline");
 		vkDestroyPipelineLayout(device, m_bgPipelineLayout, nullptr);
 		m_bgPipelineLayout = VK_NULL_HANDLE;
 		vkDestroyShaderModule(device, bgVert, nullptr);
 		vkDestroyShaderModule(device, bgFrag, nullptr);
-		return false;
+		return m_error.Fail("VK: Failed to create background pipeline");
 	}
 
 	vkDestroyShaderModule(device, bgVert, nullptr);

--- a/src/core/renderer/Vulkan/VulkanPipeline.h
+++ b/src/core/renderer/Vulkan/VulkanPipeline.h
@@ -5,7 +5,9 @@
 
 #include <vulkan/vulkan.h>
 #include <cstdint>
+#include <filesystem>
 #include <vector>
+#include "../../../common/Error.h"
 
 class VulkanDevice;
 class VulkanSwapchain;
@@ -39,6 +41,8 @@ public:
 	bool createBackgroundPipeline(VkDevice device, VkRenderPass renderPass);
 	void destroy(VkDevice device);
 
+	const Error& GetError() const { return m_error; }
+
 	VkPipeline getGraphicsPipeline() const { return m_graphicsPipeline; }
 	VkPipelineLayout getPipelineLayout() const { return m_pipelineLayout; }
 	VkDescriptorSetLayout getDescriptorSetLayout() const { return m_descriptorSetLayout; }
@@ -47,8 +51,10 @@ public:
 
 private:
 	bool createShaderModules(VkDevice device);
+	bool compileGlslToSpirv(const std::filesystem::path& path, std::vector<uint32_t>& spirv);
 	VkShaderModule createShaderModule(VkDevice device, const std::vector<char>& code);
 
+	Error m_error;
 	VkPipelineCache m_pipelineCache = VK_NULL_HANDLE;
 	VkShaderModule m_vertexShader = VK_NULL_HANDLE;
 	VkShaderModule m_fragmentShader = VK_NULL_HANDLE;

--- a/src/core/renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/core/renderer/Vulkan/VulkanRenderer.cpp
@@ -63,43 +63,40 @@ bool VulkanRenderer::initialize()
 	if (!m_windowInfo.surface_handle)
 	{
 		if (!CocoaTools::CreateMetalLayer(&m_windowInfo))
-		{
-			Logger::error("VK: Failed to create Metal layer for MoltenVK");
-			return false;
-		}
+			return m_error.Fail("VK: Failed to create Metal layer for MoltenVK");
 	}
 	CocoaTools::SetDrawableSize(&m_windowInfo, m_width, m_height);
 #endif
 
 	if (!m_vulkanDevice.create(m_windowInfo))
-		return false;
+		return m_error.Assign(m_vulkanDevice.GetError());
 
 	if (!m_vulkanSwapchain.create(m_vulkanDevice, m_width, m_height))
-		return false;
+		return m_error.Assign(m_vulkanSwapchain.GetError());
 
 	VkRenderPass renderPass = m_vulkanSwapchain.getRenderPass();
 
 	if (!m_vulkanPipeline.createPipelineCache(m_vulkanDevice.getDevice()))
-		return false;
+		return m_error.Assign(m_vulkanPipeline.GetError());
 
 	if (!m_vulkanPipeline.createMainPipeline(m_vulkanDevice.getDevice(), renderPass))
-		return false;
+		return m_error.Assign(m_vulkanPipeline.GetError());
 
 	if (!m_vulkanPipeline.createBackgroundPipeline(m_vulkanDevice.getDevice(), renderPass))
-		return false;
+		return m_error.Assign(m_vulkanPipeline.GetError());
 
 	if (!createDescriptorResources())
 		return false;
 
 	if (!m_vulkanResources.createCommandPool(m_vulkanDevice.getDevice(), m_vulkanDevice.getGraphicsQueueFamily()))
-		return false;
+		return m_error.Assign(m_vulkanResources.GetError());
 
 	if (!m_vulkanResources.createBackgroundVertexBuffer(m_vulkanDevice))
-		return false;
+		return m_error.Assign(m_vulkanResources.GetError());
 
 	if (!m_vulkanResources.createSyncObjects(m_vulkanDevice.getDevice(),
 			static_cast<uint32_t>(m_vulkanSwapchain.getImages().size())))
-		return false;
+		return m_error.Assign(m_vulkanResources.GetError());
 
 	if (!allocateCommandBuffers())
 		return false;
@@ -113,13 +110,10 @@ bool VulkanRenderer::initialize()
 
 void VulkanRenderer::shutdown()
 {
-	if (!m_initialized)
-		return;
-
 	VkDevice device = m_vulkanDevice.getDevice();
-	VmaAllocator allocator = m_vulkanDevice.getAllocator();
 	if (device != VK_NULL_HANDLE)
 	{
+		VmaAllocator allocator = m_vulkanDevice.getAllocator();
 		vkDeviceWaitIdle(device);
 
 		if (!m_commandBuffers.empty())
@@ -129,25 +123,48 @@ void VulkanRenderer::shutdown()
 			m_commandBuffers.clear();
 		}
 
-		if (m_vertexBuffer != VK_NULL_HANDLE)
-			vmaDestroyBuffer(allocator, m_vertexBuffer, m_vertexAllocation);
-		if (m_uniformBuffer != VK_NULL_HANDLE)
-			vmaDestroyBuffer(allocator, m_uniformBuffer, m_uniformAllocation);
-		if (m_textureSampler != VK_NULL_HANDLE)
-			vkDestroySampler(device, m_textureSampler, nullptr);
-		if (m_textureView != VK_NULL_HANDLE)
-			vkDestroyImageView(device, m_textureView, nullptr);
-		if (m_textureImage != VK_NULL_HANDLE)
-			vmaDestroyImage(allocator, m_textureImage, m_textureAllocation);
-		if (m_stagingBuffer != VK_NULL_HANDLE)
-			vmaDestroyBuffer(allocator, m_stagingBuffer, m_stagingAllocation);
-		if (m_descriptorPool != VK_NULL_HANDLE)
-			vkDestroyDescriptorPool(device, m_descriptorPool, nullptr);
-
 		m_vulkanResources.destroy(device, allocator);
 		m_vulkanPipeline.destroy(device);
 		m_vulkanSwapchain.destroy(device, allocator);
+
+		if (m_vertexBuffer != VK_NULL_HANDLE)
+		{
+			vmaDestroyBuffer(allocator, m_vertexBuffer, m_vertexAllocation);
+			m_vertexBuffer = VK_NULL_HANDLE;
+		}
+		if (m_uniformBuffer != VK_NULL_HANDLE)
+		{
+			vmaDestroyBuffer(allocator, m_uniformBuffer, m_uniformAllocation);
+			m_uniformBuffer = VK_NULL_HANDLE;
+		}
+		if (m_textureSampler != VK_NULL_HANDLE)
+		{
+			vkDestroySampler(device, m_textureSampler, nullptr);
+			m_textureSampler = VK_NULL_HANDLE;
+		}
+		if (m_textureView != VK_NULL_HANDLE)
+		{
+			vkDestroyImageView(device, m_textureView, nullptr);
+			m_textureView = VK_NULL_HANDLE;
+		}
+		if (m_textureImage != VK_NULL_HANDLE)
+		{
+			vmaDestroyImage(allocator, m_textureImage, m_textureAllocation);
+			m_textureImage = VK_NULL_HANDLE;
+		}
+		if (m_stagingBuffer != VK_NULL_HANDLE)
+		{
+			vmaDestroyBuffer(allocator, m_stagingBuffer, m_stagingAllocation);
+			m_stagingBuffer = VK_NULL_HANDLE;
+		}
+		if (m_descriptorPool != VK_NULL_HANDLE)
+		{
+			vkDestroyDescriptorPool(device, m_descriptorPool, nullptr);
+			m_descriptorPool = VK_NULL_HANDLE;
+		}
 	}
+
+	m_vulkanDevice.destroy();
 	m_initialized = false;
 }
 
@@ -423,7 +440,7 @@ void VulkanRenderer::prepareVertexData()
 		if (!m_vulkanResources.createMappedBuffer(m_vulkanDevice, requiredSize, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, 0.5f,
 				m_vertexBuffer, m_vertexAllocation, m_vertexAllocInfo))
 		{
-			Logger::error("VK: Failed to create vertex buffer");
+			Logger::error("{}", m_vulkanResources.GetError().GetDescription());
 			return;
 		}
 
@@ -479,10 +496,7 @@ bool VulkanRenderer::createDescriptorResources()
 
 	if (!m_vulkanResources.createMappedBuffer(m_vulkanDevice, uboSize, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, 0.5f,
 			m_uniformBuffer, m_uniformAllocation, m_uniformAllocInfo))
-	{
-		Logger::error("VK: Failed to create uniform buffer");
-		return false;
-	}
+		return m_error.Assign(m_vulkanResources.GetError());
 
 	VkSamplerCreateInfo samplerInfo{};
 	samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
@@ -502,18 +516,12 @@ bool VulkanRenderer::createDescriptorResources()
 	samplerInfo.maxLod = VK_LOD_CLAMP_NONE;
 
 	if (vkCreateSampler(device, &samplerInfo, nullptr, &m_textureSampler) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create texture sampler");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create texture sampler");
 
 	if (!m_vulkanResources.createImage(m_vulkanDevice, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
 			VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, 0.5f,
 			m_textureImage, m_textureAllocation))
-	{
-		Logger::error("VK: Failed to create placeholder texture");
-		return false;
-	}
+		return m_error.Assign(m_vulkanResources.GetError());
 
 	m_textureWidth = 1;
 	m_textureHeight = 1;
@@ -530,10 +538,7 @@ bool VulkanRenderer::createDescriptorResources()
 	viewInfo.subresourceRange.layerCount = 1;
 
 	if (vkCreateImageView(device, &viewInfo, nullptr, &m_textureView) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create placeholder texture view");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create placeholder texture view");
 
 	VkDescriptorPoolSize poolSizes[2]{};
 	poolSizes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
@@ -548,10 +553,7 @@ bool VulkanRenderer::createDescriptorResources()
 	poolInfo.maxSets = 1;
 
 	if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &m_descriptorPool) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create descriptor pool");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create descriptor pool");
 
 	VkDescriptorSetLayout layout = m_vulkanPipeline.getDescriptorSetLayout();
 	VkDescriptorSetAllocateInfo allocInfoDesc{};
@@ -561,10 +563,7 @@ bool VulkanRenderer::createDescriptorResources()
 	allocInfoDesc.pSetLayouts = &layout;
 
 	if (vkAllocateDescriptorSets(device, &allocInfoDesc, &m_descriptorSet) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to allocate descriptor set");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to allocate descriptor set");
 
 	writeDescriptorSets();
 	return true;
@@ -627,7 +626,7 @@ bool VulkanRenderer::uploadTexture()
 		if (!m_vulkanResources.createMappedBuffer(m_vulkanDevice, imageSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, 0.0f,
 				m_stagingBuffer, m_stagingAllocation, m_stagingAllocInfo))
 		{
-			Logger::error("VK: Failed to create texture staging buffer");
+			Logger::error("{}", m_vulkanResources.GetError().GetDescription());
 			m_stagingBuffer = VK_NULL_HANDLE;
 			return false;
 		}
@@ -651,7 +650,7 @@ bool VulkanRenderer::uploadTexture()
 				VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, 0.5f,
 				m_textureImage, m_textureAllocation))
 		{
-			Logger::error("VK: Failed to create texture image");
+			Logger::error("{}", m_vulkanResources.GetError().GetDescription());
 			return false;
 		}
 		m_textureWidth = texWidth;
@@ -751,9 +750,8 @@ bool VulkanRenderer::allocateCommandBuffers()
 
 	if (vkAllocateCommandBuffers(device, &allocInfo, m_commandBuffers.data()) != VK_SUCCESS)
 	{
-		Logger::error("VK: Failed to allocate command buffers");
 		m_commandBuffers.clear();
-		return false;
+		return m_error.Fail("VK: Failed to allocate command buffers");
 	}
 
 	return true;

--- a/src/core/renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/core/renderer/Vulkan/VulkanRenderer.cpp
@@ -68,6 +68,7 @@ bool VulkanRenderer::initialize()
 			return false;
 		}
 	}
+	CocoaTools::SetDrawableSize(&m_windowInfo, m_width, m_height);
 #endif
 
 	if (!m_vulkanDevice.create(m_windowInfo))
@@ -281,6 +282,10 @@ void VulkanRenderer::resize(uint32_t width, uint32_t height)
 {
 	if (!m_initialized)
 		return;
+
+#ifdef __APPLE__
+	CocoaTools::SetDrawableSize(&m_windowInfo, width, height);
+#endif
 
 	m_width = width;
 	m_height = height;
@@ -936,7 +941,7 @@ void VulkanRenderer::submitFrame()
 
 	result = vkQueuePresentKHR(queue, &presentInfo);
 
-	if (result == VK_ERROR_OUT_OF_DATE_KHR)
+	if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR)
 	{
 		recreateSwapchain();
 		return;

--- a/src/core/renderer/Vulkan/VulkanResources.cpp
+++ b/src/core/renderer/Vulkan/VulkanResources.cpp
@@ -14,16 +14,15 @@ VulkanResources::~VulkanResources() = default;
 
 bool VulkanResources::createCommandPool(VkDevice device, uint32_t queueFamily)
 {
+	m_error.Clear();
+
 	VkCommandPoolCreateInfo poolInfo{};
 	poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
 	poolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
 	poolInfo.queueFamilyIndex = queueFamily;
 
 	if (vkCreateCommandPool(device, &poolInfo, nullptr, &m_commandPool) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create command pool");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create command pool");
 
 	return true;
 }
@@ -45,14 +44,13 @@ bool VulkanResources::recreateRenderFinishedSemaphores(VkDevice device, uint32_t
 	{
 		if (vkCreateSemaphore(device, &semaphoreInfo, nullptr, &m_renderFinishedSemaphores[i]) != VK_SUCCESS)
 		{
-			Logger::error("VK: Failed to create render-finished semaphore {}", i);
 			for (uint32_t j = 0; j < i; ++j)
 			{
 				vkDestroySemaphore(device, m_renderFinishedSemaphores[j], nullptr);
 				m_renderFinishedSemaphores[j] = VK_NULL_HANDLE;
 			}
 			m_renderFinishedSemaphores.clear();
-			return false;
+			return m_error.Fail("VK: Failed to create render-finished semaphore " + std::to_string(i));
 		}
 	}
 	return true;
@@ -60,6 +58,8 @@ bool VulkanResources::recreateRenderFinishedSemaphores(VkDevice device, uint32_t
 
 bool VulkanResources::createSyncObjects(VkDevice device, uint32_t swapchainImageCount)
 {
+	m_error.Clear();
+
 	VkSemaphoreCreateInfo semaphoreInfo{};
 	semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
 
@@ -69,12 +69,16 @@ bool VulkanResources::createSyncObjects(VkDevice device, uint32_t swapchainImage
 
 	for (uint32_t i = 0; i < frameCount; ++i)
 	{
-		if (vkCreateSemaphore(device, &semaphoreInfo, nullptr, &m_imageAvailableSemaphores[i]) != VK_SUCCESS ||
-			vkCreateFence(device, &fenceInfo, nullptr, &m_inFlightFences[i]) != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to create synchronization objects for frame {}", i);
-			return false;
-		}
+		m_imageAvailableSemaphores[i] = VK_NULL_HANDLE;
+		m_inFlightFences[i] = VK_NULL_HANDLE;
+
+		const VkResult semResult = vkCreateSemaphore(device, &semaphoreInfo, nullptr, &m_imageAvailableSemaphores[i]);
+		if (semResult != VK_SUCCESS)
+			return m_error.Fail("VK: Failed to create semaphore for frame " + std::to_string(i) + " (VkResult " + std::to_string(static_cast<int>(semResult)) + ")");
+
+		const VkResult fenceResult = vkCreateFence(device, &fenceInfo, nullptr, &m_inFlightFences[i]);
+		if (fenceResult != VK_SUCCESS)
+			return m_error.Fail("VK: Failed to create fence for frame " + std::to_string(i) + " (VkResult " + std::to_string(static_cast<int>(fenceResult)) + ")");
 	}
 
 	if (!recreateRenderFinishedSemaphores(device, swapchainImageCount))
@@ -85,10 +89,7 @@ bool VulkanResources::createSyncObjects(VkDevice device, uint32_t swapchainImage
 	singleTimeFenceInfo.flags = 0;
 
 	if (vkCreateFence(device, &singleTimeFenceInfo, nullptr, &m_singleTimeFence) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create single-time command fence");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create single-time command fence");
 
 	Logger::info("VK: Created sync objects for {} frames", frameCount);
 	return true;
@@ -189,10 +190,10 @@ bool VulkanResources::createImage(VulkanDevice& device, uint32_t width, uint32_t
 	allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
 	device.setAllocationPriority(allocInfo, priority);
 
-	if (vmaCreateImage(device.getAllocator(), &imageInfo, &allocInfo, &image, &allocation, nullptr) != VK_SUCCESS)
+	const VkResult result = vmaCreateImage(device.getAllocator(), &imageInfo, &allocInfo, &image, &allocation, nullptr);
+	if (result != VK_SUCCESS)
 	{
-		Logger::error("VK: Failed to create image");
-		return false;
+		return m_error.Fail("VK: Failed to create image (" + std::to_string(width) + "x" + std::to_string(height) + ", VkResult " + std::to_string(static_cast<int>(result)) + ")");
 	}
 
 	return true;
@@ -289,19 +290,24 @@ bool VulkanResources::createMappedBuffer(VulkanDevice& device, VkDeviceSize size
 	allocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
 	device.setAllocationPriority(allocInfo, priority);
 
-	return vmaCreateBuffer(device.getAllocator(), &bufferInfo, &allocInfo, &buffer, &allocation, &mapped) == VK_SUCCESS;
+	const VkResult result = vmaCreateBuffer(device.getAllocator(), &bufferInfo, &allocInfo, &buffer, &allocation, &mapped);
+	if (result != VK_SUCCESS)
+	{
+		return m_error.Fail("VK: Failed to create buffer (size " + std::to_string(size) + ", VkResult " + std::to_string(static_cast<int>(result)) + ")");
+	}
+
+	return true;
 }
 
 bool VulkanResources::createBackgroundVertexBuffer(VulkanDevice& device)
 {
+	m_error.Clear();
+
 	destroyBackgroundVertexBuffer(device.getAllocator());
 
 	if (!createMappedBuffer(device, sizeof(VulkanBGVertex) * 4, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, 0.5f,
 			m_bgVertexBuffer, m_bgVertexAllocation, m_bgVertexAllocInfo))
-	{
-		Logger::error("VK: Failed to create background vertex buffer");
 		return false;
-	}
 
 	return true;
 }

--- a/src/core/renderer/Vulkan/VulkanResources.h
+++ b/src/core/renderer/Vulkan/VulkanResources.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <array>
 #include <vector>
+#include "../../../common/Error.h"
 
 class VulkanDevice;
 struct VulkanBGVertex;
@@ -27,6 +28,8 @@ public:
 	bool createSyncObjects(VkDevice device, uint32_t swapchainImageCount);
 	bool recreateRenderFinishedSemaphores(VkDevice device, uint32_t swapchainImageCount);
 	void destroy(VkDevice device, VmaAllocator allocator);
+
+	const Error& GetError() const { return m_error; }
 
 	VkCommandBuffer beginSingleTimeCommands(VkDevice device);
 	void endSingleTimeCommands(VkDevice device, VkQueue queue, VkCommandBuffer commandBuffer);
@@ -52,6 +55,7 @@ public:
 	VkBuffer getBackgroundVertexBuffer() const { return m_bgVertexBuffer; }
 
 private:
+	Error m_error;
 	VkCommandPool m_commandPool = VK_NULL_HANDLE;
 	std::array<VkSemaphore, frameCount> m_imageAvailableSemaphores{};
 	std::vector<VkSemaphore> m_renderFinishedSemaphores;

--- a/src/core/renderer/Vulkan/VulkanSwapchain.cpp
+++ b/src/core/renderer/Vulkan/VulkanSwapchain.cpp
@@ -162,7 +162,11 @@ bool VulkanSwapchain::createSwapchain(VulkanDevice& device, uint32_t width, uint
 	m_presentMode = presentMode;
 
 	VkExtent2D extent = capabilities.currentExtent;
-	if (extent.width == UINT32_MAX)
+	if (extent.width == UINT32_MAX || extent.width == 0 || extent.height == 0
+#if defined(__APPLE__)
+		|| (width > 0 && height > 0 && (extent.width != width || extent.height != height))
+#endif
+	)
 	{
 		extent.width = std::clamp(width, capabilities.minImageExtent.width, capabilities.maxImageExtent.width);
 		extent.height = std::clamp(height, capabilities.minImageExtent.height, capabilities.maxImageExtent.height);

--- a/src/core/renderer/Vulkan/VulkanSwapchain.cpp
+++ b/src/core/renderer/Vulkan/VulkanSwapchain.cpp
@@ -16,6 +16,8 @@ VulkanSwapchain::~VulkanSwapchain() = default;
 
 bool VulkanSwapchain::create(VulkanDevice& device, uint32_t width, uint32_t height)
 {
+	m_error.Clear();
+
 	if (!createSwapchain(device, width, height))
 		return false;
 	if (!createImageViews(device.getDevice()))
@@ -193,10 +195,7 @@ bool VulkanSwapchain::createSwapchain(VulkanDevice& device, uint32_t width, uint
 	createInfo.oldSwapchain = oldSwapchain;
 
 	if (vkCreateSwapchainKHR(device.getDevice(), &createInfo, nullptr, &m_swapchain) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create swapchain");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create swapchain");
 
 	vkGetSwapchainImagesKHR(device.getDevice(), m_swapchain, &imageCount, nullptr);
 	m_images.resize(imageCount);
@@ -229,10 +228,7 @@ bool VulkanSwapchain::createImageViews(VkDevice device)
 		viewCreateInfo.subresourceRange.layerCount = 1;
 
 		if (vkCreateImageView(device, &viewCreateInfo, nullptr, &m_imageViews[i]) != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to create image view");
-			return false;
-		}
+			return m_error.Fail("VK: Failed to create image view");
 	}
 	return true;
 }
@@ -312,9 +308,8 @@ bool VulkanSwapchain::createDepthResources(VulkanDevice& device)
 
 		if (vmaCreateImage(device.getAllocator(), &imageInfo, &allocInfo, &m_depthImages[i], &m_depthAllocations[i], nullptr) != VK_SUCCESS)
 		{
-			Logger::error("VK: Failed to create depth image");
 			destroyDepthResources(device.getDevice(), device.getAllocator());
-			return false;
+			return m_error.Fail("VK: Failed to create depth image");
 		}
 
 		VkImageViewCreateInfo viewInfo{};
@@ -330,9 +325,8 @@ bool VulkanSwapchain::createDepthResources(VulkanDevice& device)
 
 		if (vkCreateImageView(device.getDevice(), &viewInfo, nullptr, &m_depthImageViews[i]) != VK_SUCCESS)
 		{
-			Logger::error("VK: Failed to create depth image view");
 			destroyDepthResources(device.getDevice(), device.getAllocator());
-			return false;
+			return m_error.Fail("VK: Failed to create depth image view");
 		}
 	}
 
@@ -401,10 +395,7 @@ bool VulkanSwapchain::createRenderPass(VkDevice device)
 	renderPassInfo.pDependencies = &dependency;
 
 	if (vkCreateRenderPass2(device, &renderPassInfo, nullptr, &m_renderPass) != VK_SUCCESS)
-	{
-		Logger::error("VK: Failed to create render pass");
-		return false;
-	}
+		return m_error.Fail("VK: Failed to create render pass");
 
 	return true;
 }
@@ -429,10 +420,7 @@ bool VulkanSwapchain::createFramebuffers(VkDevice device)
 		framebufferInfo.layers = 1;
 
 		if (vkCreateFramebuffer(device, &framebufferInfo, nullptr, &m_framebuffers[i]) != VK_SUCCESS)
-		{
-			Logger::error("VK: Failed to create framebuffer");
-			return false;
-		}
+			return m_error.Fail("VK: Failed to create framebuffer");
 	}
 
 	return true;

--- a/src/core/renderer/Vulkan/VulkanSwapchain.h
+++ b/src/core/renderer/Vulkan/VulkanSwapchain.h
@@ -7,6 +7,7 @@
 #include <vk_mem_alloc.h>
 #include <cstdint>
 #include <vector>
+#include "../../../common/Error.h"
 
 class VulkanDevice;
 
@@ -22,6 +23,8 @@ public:
 	bool create(VulkanDevice& device, uint32_t width, uint32_t height);
 	void destroy(VkDevice device, VmaAllocator allocator);
 	bool recreate(VulkanDevice& device, uint32_t width, uint32_t height);
+
+	const Error& GetError() const { return m_error; }
 
 	VkSwapchainKHR getSwapchain() const { return m_swapchain; }
 	VkRenderPass getRenderPass() const { return m_renderPass; }
@@ -45,6 +48,7 @@ private:
 	void destroyDepthResources(VkDevice device, VmaAllocator allocator);
 	VkFormat findDepthFormat(VkPhysicalDevice physicalDevice);
 
+	Error m_error;
 	VkSwapchainKHR m_swapchain = VK_NULL_HANDLE;
 	std::vector<VkImage> m_images;
 	std::vector<VkImageView> m_imageViews;

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -4,6 +4,7 @@
 #include "MainWindow.h"
 #include "MemoryCardBrowser.h"
 #include "SaveDetailsPanel.h"
+#include "IconWidget.h"
 #include "CardActionHandler.h"
 #include "NewCardDialog.h"
 #include "dialogs/AboutDialog.h"
@@ -82,6 +83,13 @@ MainWindow::MainWindow(Config* config, QWidget* parent)
 	else
 		setWindowTitle(baseTitle);
 	ui->detailsPanel->setConfig(config);
+	connect(ui->detailsPanel, &SaveDetailsPanel::iconWidgetChanged, this,
+		[this](IconWidget* iconWidget) {
+			connect(iconWidget, &IconWidget::iconLoadFailed, this,
+				[this](const QString& reason) {
+					ui->statusBar->showMessage(tr("Icon preview unavailable: %1").arg(reason), 8000);
+				});
+		});
 	actionHandler = std::make_unique<CardActionHandler>(this);
 
 	setWindowIcon(QIcon(":/icons/AppIcon.png"));

--- a/src/ui/widgets/IconWidget.cpp
+++ b/src/ui/widgets/IconWidget.cpp
@@ -4,6 +4,7 @@
 #include "IconWidget.h"
 #include "Config.h"
 #include "../../common/Logger.h"
+#include "../../common/Error.h"
 #include "../common/WindowInfo.h"
 #include <QResizeEvent>
 #include <QMouseEvent>
@@ -99,27 +100,16 @@ IconWidget::IconWidget(Config* config, QWidget* parent)
 	setAttribute(Qt::WA_PaintOnScreen);
 	setAttribute(Qt::WA_DontCreateNativeAncestors, true);
 	setFocusPolicy(Qt::NoFocus);
-	printPlatformInfo();
-	Logger::info("IconWidget constructed: {}", (void*)this);
 }
 
 IconWidget::~IconWidget()
 {
-	Logger::info("IconWidget destructor start: {}", (void*)this);
 	stopRendering();
 	if (m_renderer)
 	{
-		Logger::info("IconWidget shutting down renderer");
 		m_renderer->shutdown();
 		m_renderer.reset();
 	}
-	Logger::info("IconWidget destructor end: {}", (void*)this);
-}
-
-void IconWidget::printPlatformInfo()
-{
-	QString platform = QGuiApplication::platformName();
-	qInfo() << "IconWidget: Platform:" << platform;
 }
 
 bool IconWidget::loadIcon(const std::vector<uint8_t>& iconData)
@@ -129,17 +119,17 @@ bool IconWidget::loadIcon(const std::vector<uint8_t>& iconData)
 		m_icon = std::make_shared<PS2Icon::Icon>();
 		if (!m_icon->load(iconData))
 		{
-			QString err = QString::fromStdString(m_icon->getError());
+			const QString err = QString::fromStdString(m_icon->getError());
 			m_icon.reset();
+			Logger::warn("IconWidget: Failed to load icon: {}", err.toStdString());
 			emit iconLoadFailed(err);
 			return false;
 		}
 
-		ensureRenderer();
-		if (m_renderer)
-		{
-			m_renderer->setIcon(m_icon);
-		}
+		if (!ensureRenderer())
+			return false;
+
+		m_renderer->setIcon(m_icon);
 
 		emit iconLoaded();
 
@@ -163,6 +153,7 @@ bool IconWidget::loadIcon(const std::vector<uint8_t>& iconData)
 	}
 	catch (const std::exception& e)
 	{
+		Logger::warn("IconWidget: Exception loading icon: {}", e.what());
 		emit iconLoadFailed(QString::fromStdString(e.what()));
 		return false;
 	}
@@ -299,7 +290,6 @@ void IconWidget::startRendering()
 	if (m_renderLoopEnabled && m_renderTimer.isActive())
 		return;
 
-	Logger::info("IconWidget::startRendering {}", (void*)this);
 	m_renderLoopEnabled = true;
 
 	int maxFps = m_config ? m_config->getMaxFPS() : 30;
@@ -326,7 +316,6 @@ void IconWidget::startRendering()
 
 void IconWidget::stopRendering()
 {
-	Logger::info("IconWidget::stopRendering {}", (void*)this);
 	m_renderLoopEnabled = false;
 	if (m_renderTimer.isActive())
 	{
@@ -334,10 +323,10 @@ void IconWidget::stopRendering()
 	}
 }
 
-void IconWidget::ensureRenderer()
+bool IconWidget::ensureRenderer()
 {
 	if (m_renderer)
-		return;
+		return true;
 
 	winId();
 
@@ -379,7 +368,9 @@ void IconWidget::ensureRenderer()
 			if (!wi.window_handle)
 			{
 				Logger::info("IconWidget: Wayland surface not ready yet");
-				return;
+				if (m_icon)
+					emit iconLoadFailed(tr("Wayland surface is not ready yet"));
+				return false;
 			}
 		}
 		else if (QGuiApplication::platformName().startsWith("xcb", Qt::CaseInsensitive))
@@ -398,43 +389,56 @@ void IconWidget::ensureRenderer()
 		if (!wi.window_handle && wi.type != WindowInfo::Type::Surfaceless)
 		{
 			Logger::error("IconWidget: Invalid window handle, postponing renderer creation");
-			return;
+			if (m_icon)
+				emit iconLoadFailed(tr("Native window is not available yet"));
+			return false;
 		}
 
 		Logger::info("IconWidget: Creating renderer: {}", rendererType);
 
+		Error rendererError;
+
 		if (rendererType == "opengl")
 		{
-			m_renderer = RendererFactory::createOpenGLRenderer(wi, m_config);
+			m_renderer = RendererFactory::createOpenGLRenderer(wi, m_config, &rendererError);
 		}
 #if defined(__APPLE__)
 		else if (rendererType == "metal")
 		{
-			m_renderer = RendererFactory::createMetalRenderer(wi, m_config);
+			m_renderer = RendererFactory::createMetalRenderer(wi, m_config, &rendererError);
 		}
 #endif
 		else
 		{
 #if defined(ENABLE_VULKAN)
-			m_renderer = RendererFactory::createVulkanRenderer(wi, m_config);
+			m_renderer = RendererFactory::createVulkanRenderer(wi, m_config, &rendererError);
 #endif
 		}
 
 		if (!m_renderer)
 		{
-			qWarning() << "IconWidget: renderer creation failed";
-			return;
+			if (m_icon)
+			{
+				const QString msg = rendererError.IsValid() ? QString::fromStdString(rendererError.GetDescription()) : tr("Failed to initialize renderer");
+				emit iconLoadFailed(msg);
+			}
+			return false;
 		}
 
 		if (m_icon)
 		{
 			m_renderer->setIcon(m_icon);
 		}
+
+		return true;
 	}
 	catch (const std::exception& e)
 	{
-		qWarning() << "IconWidget: exception creating renderer:" << e.what();
+		Logger::warn("IconWidget: exception creating renderer: {}", e.what());
 		m_renderer.reset();
+		if (m_icon)
+			emit iconLoadFailed(QString::fromStdString(e.what()));
+		return false;
 	}
 }
 
@@ -446,7 +450,8 @@ void IconWidget::recreateRenderer()
 		m_renderer.reset();
 	}
 
-	ensureRenderer();
+	if (!ensureRenderer())
+		return;
 
 	if (m_renderer && m_icon)
 	{
@@ -473,7 +478,7 @@ void IconWidget::renderFrame()
 	}
 	catch (const std::exception& e)
 	{
-		qWarning() << "IconWidget: render exception, recreating renderer:" << e.what();
+		Logger::warn("IconWidget: render exception, recreating renderer: {}", e.what());
 		recreateRenderer();
 	}
 }

--- a/src/ui/widgets/IconWidget.h
+++ b/src/ui/widgets/IconWidget.h
@@ -61,8 +61,7 @@ protected:
 	void wheelEvent(QWheelEvent* event) override;
 
 private:
-	void printPlatformInfo();
-	void ensureRenderer();
+	bool ensureRenderer();
 	void recreateRenderer();
 	void renderFrame();
 

--- a/src/ui/widgets/SaveDetailsPanel.cpp
+++ b/src/ui/widgets/SaveDetailsPanel.cpp
@@ -141,9 +141,6 @@ void SaveDetailsPanel::setSave(PS2MemoryCard* card, const QString& savePath,
 			if (iconWidget)
 				iconWidget->hide();
 		}
-		else
-		{
-		}
 
 		if (!iconData.empty() && iconWidget)
 		{
@@ -242,6 +239,8 @@ void SaveDetailsPanel::createIconWidget()
 	iconWidget->setSizePolicy(sp);
 	ui->iconLayout->insertWidget(0, iconWidget);
 	iconWidget->hide();
+
+	emit iconWidgetChanged(iconWidget);
 }
 
 void SaveDetailsPanel::refreshConfig()

--- a/src/ui/widgets/SaveDetailsPanel.h
+++ b/src/ui/widgets/SaveDetailsPanel.h
@@ -26,6 +26,9 @@ public:
 	void clear();
 	void refreshConfig();
 
+signals:
+	void iconWidgetChanged(IconWidget* widget);
+
 private:
 	void createIconWidget();
 	void updatePlayPauseButton();


### PR DESCRIPTION
### Description of Changes
fixes swapchain sizing issues on macOS by setting CAMetalLayer size on the main thread. also passes renderer setup errors to the status bar and updates shutdown to clean up resources if init fails midway.

### Rationale behind Changes
MoltenVK was rendering at the wrong size on macOS, some issues were annoying to debug, and failing to initialize halfway was leaking GPU resources.

### Suggested Testing Steps
Break the config and make sure the error shows up in the status bar, and test resizing on macOS Vulkan.

### Related Issues / Links
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No