### PR TITLE
Qt: Open file dialogs in configured folders and remove recent files

### DIFF
--- a/src/common/Config.cpp
+++ b/src/common/Config.cpp
@@ -439,7 +439,7 @@ std::string Config::getMemoryCardFolder() const
 	}
 	catch (...)
 	{
-		return "./memory_cards";
+		return "";
 	}
 }
 
@@ -533,58 +533,6 @@ void Config::setDebugLogging(bool enabled)
 	m_config["debug"]["logging"] = enabled;
 }
 
-std::vector<std::string> Config::getRecentFiles() const
-{
-	std::vector<std::string> files;
-	try
-	{
-		if (m_config.contains("recent_files") && m_config["recent_files"].is_array())
-		{
-			for (const auto& file : m_config["recent_files"])
-			{
-				files.push_back(file.get<std::string>());
-			}
-		}
-	}
-	catch (...)
-	{
-	}
-	return files;
-}
-
-void Config::addRecentFile(const std::string& path)
-{
-	if (!m_config.contains("recent_files") || !m_config["recent_files"].is_array())
-	{
-		m_config["recent_files"] = json::array();
-	}
-
-	// Remove if already exists (to move it to front)
-	auto& recent = m_config["recent_files"];
-	for (auto it = recent.begin(); it != recent.end(); ++it)
-	{
-		if (it->get<std::string>() == path)
-		{
-			recent.erase(it);
-			break;
-		}
-	}
-
-	// Add to front
-	recent.insert(recent.begin(), path);
-
-	// Keep only last 10
-	while (recent.size() > 10)
-	{
-		recent.erase(recent.end() - 1);
-	}
-}
-
-void Config::clearRecentFiles()
-{
-	m_config["recent_files"] = json::array();
-}
-
 void Config::createDefaults()
 {
 	m_config = {
@@ -608,7 +556,7 @@ void Config::createDefaults()
 						 {"hide_to_tray", false},
 						 {"force_import", false},
 						 {"discord_rpc_enabled", true}}},
-		{"paths", {{"memory_card_folder", "./memory_cards"}}},
+		{"paths", {{"memory_card_folder", ""}, {"import_export_folder", ""}}},
 		{"debug", {{"logging", false},
 					  {"verbose", false}}},
 		{"performance", {{"max_fps", 30},
@@ -677,7 +625,9 @@ void Config::ensureKeys()
 		m_config["behavior"]["discord_rpc_enabled"] = true;
 
 	if (!m_config["paths"].contains("memory_card_folder"))
-		m_config["paths"]["memory_card_folder"] = "./memory_cards";
+		m_config["paths"]["memory_card_folder"] = "";
+	if (!m_config["paths"].contains("import_export_folder"))
+		m_config["paths"]["import_export_folder"] = "";
 
 	if (!m_config["debug"].contains("logging"))
 		m_config["debug"]["logging"] = false;

--- a/src/common/Config.h
+++ b/src/common/Config.h
@@ -96,10 +96,6 @@ public:
 	bool getVerboseLogging() const;
 	void setVerboseLogging(bool enabled);
 
-	std::vector<std::string> getRecentFiles() const;
-	void addRecentFile(const std::string& path);
-	void clearRecentFiles();
-
 	const json& getJson() const { return m_config; }
 	json& getJson() { return m_config; }
 

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -38,6 +38,7 @@ set(UI_HEADERS
     Settings/FilesSettingsWidget.h
     Settings/AdvancedSettingsWidget.h
     TranslationManager.h
+    QtUtils.h
 )
 
 file(GLOB_RECURSE UI_FILES

--- a/src/ui/CardActionHandler.cpp
+++ b/src/ui/CardActionHandler.cpp
@@ -68,7 +68,7 @@ void CardActionHandler::closeCard()
 }
 
 
-CardActionHandler::ImportResult CardActionHandler::importSave(PS2MemoryCard* card, const std::shared_ptr<PS2SaveFile>& saveFile, const QString& filename, bool showDialogs, bool forceOverwrite)
+CardActionHandler::ImportResult CardActionHandler::importSave(PS2MemoryCard* card, const std::shared_ptr<PS2SaveFile>& saveFile, const QString& /*filename*/, bool showDialogs, bool forceOverwrite)
 {
 	if (!card)
 	{

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -17,6 +17,7 @@
 #include "Themes.h"
 #include "version.h"
 #include "BuildVersion.h"
+#include "QtUtils.h"
 #include <QDir>
 #include <QFileDialog>
 #include <QMessageBox>
@@ -166,8 +167,9 @@ MainWindow::MainWindow(Config* config, QWidget* parent)
 			return;
 		QString suggestedName = filenames[0];
 		QString filter = suggestedName.endsWith(QLatin1String(".max"), Qt::CaseInsensitive) ? tr("MAX Drive Format (*.max);;EMS/PSU Format (*.psu);;All Files (*.*)") : tr("EMS/PSU Format (*.psu);;MAX Drive Format (*.max);;All Files (*.*)");
+		const QString exportDir = QtUtils::resolveConfigFolderPath(m_config->getImportExportFolder());
 		QString path = QFileDialog::getSaveFileName(this, tr("Export Save"),
-			QDir::homePath() + QLatin1Char('/') + suggestedName, filter);
+			exportDir + QLatin1Char('/') + suggestedName, filter);
 		if (!path.isEmpty())
 			actionHandler->exportSave(memoryCard.get(), savePath, path);
 	});
@@ -176,10 +178,11 @@ MainWindow::MainWindow(Config* config, QWidget* parent)
 		if (!memoryCard)
 			return;
 
+		const QString exportDir = QtUtils::resolveConfigFolderPath(m_config->getImportExportFolder());
 		QString filename = QFileDialog::getSaveFileName(
 			this,
 			tr("Export File"),
-			fileName,
+			exportDir + QLatin1Char('/') + fileName,
 			tr("All Files (*.*)"));
 
 		if (!filename.isEmpty())
@@ -226,7 +229,8 @@ MainWindow::MainWindow(Config* config, QWidget* parent)
 	connect(ui->cardBrowser, &MemoryCardBrowser::importArbitraryFileRequested, this, [this](const QString& targetDir) {
 		if (!memoryCard)
 			return;
-		QString fileName = QFileDialog::getOpenFileName(this, tr("Import File"), "", tr("All Files (*.*)"));
+		const QString importDir = QtUtils::resolveConfigFolderPath(m_config->getImportExportFolder());
+		QString fileName = QFileDialog::getOpenFileName(this, tr("Import File"), importDir, tr("All Files (*.*)"));
 		if (!fileName.isEmpty())
 		{
 			importFileToCard(targetDir, fileName);
@@ -272,10 +276,11 @@ MainWindow::MainWindow(Config* config, QWidget* parent)
 			return;
 
 		QStringList filenames = nameDialog.getFilenames();
+		const QString exportDir = QtUtils::resolveConfigFolderPath(m_config->getImportExportFolder());
 		QString targetDir = QFileDialog::getExistingDirectory(
 			this,
 			tr("Export Selected Saves"),
-			QString());
+			exportDir);
 
 		if (targetDir.isEmpty())
 			return;
@@ -382,10 +387,11 @@ void MainWindow::changeEvent(QEvent* event)
 
 void MainWindow::onOpenMemoryCard()
 {
+	const QString memoryCardDir = QtUtils::resolveConfigFolderPath(m_config->getMemoryCardFolder());
 	QString filename = QFileDialog::getOpenFileName(
 		this,
 		tr("Open Memory Card"),
-		"",
+		memoryCardDir,
 		tr("All Memory Cards (*.ps2 *.vm2 *.vmc *.mc2 *.mcd *.bin *.mc);;"
 		   "PCSX2 Memory Card (*.ps2);;"
 		   "PS3 Virtual Memory Card (*.vm2 *.vmc);;"
@@ -435,10 +441,11 @@ void MainWindow::onCreateMemoryCard()
 	int sizeMB = optionsDialog.getCardSizeMB();
 	bool disableEcc = optionsDialog.getDisableEcc();
 
+	const QString memoryCardDir = QtUtils::resolveConfigFolderPath(m_config->getMemoryCardFolder());
 	QString filename = QFileDialog::getSaveFileName(
 		this,
 		tr("Create Memory Card"),
-		"Mcd001.ps2",
+		memoryCardDir + QStringLiteral("/Mcd001.ps2"),
 		tr("PCSX2 Memory Card (*.ps2);;MemCard PRO2 (*.mc2 *.mcd);;All Files (*.*)"));
 
 	if (filename.isEmpty())
@@ -486,10 +493,11 @@ void MainWindow::onImportSave()
 		return;
 	}
 
+	const QString importDir = QtUtils::resolveConfigFolderPath(m_config->getImportExportFolder());
 	QStringList filenames = QFileDialog::getOpenFileNames(
 		this,
 		tr("Import Save"),
-		"",
+		importDir,
 		tr("PS2 Save Files (*.psu *.max *.sps *.xps *.cbs *.psv);;EMS/PSU (*.psu);;MAX Drive (*.max);;SharkPort (*.sps);;X-Port (*.xps);;CodeBreaker (*.cbs);;PSV (*.psv);;All Files (*.*)"));
 
 	if (!filenames.isEmpty())
@@ -653,10 +661,11 @@ void MainWindow::onExportSave()
 		return;
 	}
 
+	const QString exportDir = QtUtils::resolveConfigFolderPath(m_config->getImportExportFolder());
 	QString filename = QFileDialog::getSaveFileName(
 		this,
 		tr("Export Save"),
-		"",
+		exportDir,
 		tr("EMS/PSU Format (*.psu);;MAX Drive Format (*.max);;All Files (*.*)"));
 
 	if (filename.isEmpty())
@@ -1079,10 +1088,11 @@ void MainWindow::onSaveAs()
 	if (!memoryCard)
 		return;
 
+	const QString memoryCardDir = QtUtils::resolveConfigFolderPath(m_config->getMemoryCardFolder());
 	QString filename = QFileDialog::getSaveFileName(
 		this,
 		tr("Save Memory Card As"),
-		QFileInfo(currentCardPath).baseName() + ".ps2",
+		memoryCardDir + QLatin1Char('/') + QFileInfo(currentCardPath).baseName() + ".ps2",
 		tr("PCSX2 Memory Card (*.ps2);;MemCard PRO2 (*.mc2 *.mcd);;All Files (*.*)"));
 
 	if (filename.isEmpty())
@@ -1218,10 +1228,11 @@ void MainWindow::onEccTool()
 
 	QString dialogTitle = hasEcc ? tr("Remove ECC and Save As...") : tr("Add ECC and Save As...");
 
+	const QString memoryCardDir = QtUtils::resolveConfigFolderPath(m_config->getMemoryCardFolder());
 	QString filename = QFileDialog::getSaveFileName(
 		this,
 		dialogTitle,
-		defaultName,
+		memoryCardDir + QLatin1Char('/') + defaultName,
 		tr("All Memory Cards (*.ps2 *.vm2 *.vmc *.mc2 *.mcd);;PCSX2 Memory Card (*.ps2);;PS3 Virtual Memory Card (*.vm2 *.vmc);;MemCard PRO2 (*.mc2 *.mcd);;All Files (*.*)"));
 
 	if (filename.isEmpty())

--- a/src/ui/QtUtils.h
+++ b/src/ui/QtUtils.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2025-2026 SternXD
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include <QString>
+#include <QDir>
+#include <QFileInfo>
+#include <string>
+
+namespace QtUtils
+{
+	inline QString resolveConfigFolderPath(const QString& configuredPath)
+	{
+		if (configuredPath.isEmpty())
+			return QDir::homePath();
+
+		const QFileInfo info(configuredPath);
+		if (info.isDir())
+			return info.absoluteFilePath();
+
+		return QDir::homePath();
+	}
+
+	inline QString resolveConfigFolderPath(const std::string& configuredPath)
+	{
+		if (configuredPath.empty())
+			return QDir::homePath();
+
+		return resolveConfigFolderPath(QString::fromStdString(configuredPath));
+	}
+} // namespace QtUtils

--- a/src/ui/Settings/FilesSettingsWidget.cpp
+++ b/src/ui/Settings/FilesSettingsWidget.cpp
@@ -5,9 +5,8 @@
 #include "SettingsWindow.h"
 #include "ui_FilesSettingsWidget.h"
 #include "Config.h"
+#include "QtUtils.h"
 #include <QFileDialog>
-#include <QListWidget>
-#include <QMessageBox>
 
 FilesSettingsWidget::FilesSettingsWidget(SettingsWindow* dialog, QWidget* parent)
 	: SettingsWidget(dialog, parent)
@@ -16,20 +15,15 @@ FilesSettingsWidget::FilesSettingsWidget(SettingsWindow* dialog, QWidget* parent
 	m_rootWidget = new QWidget(this);
 	ui->setupUi(m_rootWidget);
 
-	registerHelp(ui->memoryCardPathEdit, tr("Memory Card Directory"), tr("The default directory where memory card images are stored."));
+	registerHelp(ui->memoryCardPathEdit, tr("Memory Card Directory"), tr("The default directory where memory card images are stored. If not set, the home directory is used."));
 	registerHelp(ui->browseButton, tr("Browse Directory"), tr("Open a file dialog to select the memory card directory."));
-	registerHelp(ui->importExportPathEdit, tr("Import/Export Directory"), tr("The default directory for importing and exporting save files. If not set, the memory card directory is used."));
+	registerHelp(ui->importExportPathEdit, tr("Import/Export Directory"), tr("The default directory for importing and exporting save files. If not set, the home directory is used."));
 	registerHelp(ui->browseImportExportButton, tr("Browse Directory"), tr("Open a file dialog to select the import/export directory."));
-	registerHelp(ui->recentFilesList, tr("Recent Files"), tr("List of recently opened memory card files."));
-	registerHelp(ui->clearRecentButton, tr("Clear Recent Files"), tr("Remove all entries from the recent files list."));
 
 	connect(ui->browseButton, &QPushButton::clicked, this, &FilesSettingsWidget::onBrowseMemoryCardPath);
 	connect(ui->browseImportExportButton, &QPushButton::clicked, this, &FilesSettingsWidget::onBrowseImportExportPath);
-	connect(ui->clearRecentButton, &QPushButton::clicked, this, &FilesSettingsWidget::onClearRecentFiles);
 	connect(ui->memoryCardPathEdit, &QLineEdit::textChanged, this, &SettingsWidget::settingChanged);
 	connect(ui->importExportPathEdit, &QLineEdit::textChanged, this, &SettingsWidget::settingChanged);
-
-	ui->recentFilesList->setSelectionMode(QAbstractItemView::NoSelection);
 
 	addTab(tr("Files"), m_rootWidget);
 	loadSettings();
@@ -57,26 +51,6 @@ void FilesSettingsWidget::loadSettings()
 
 	ui->memoryCardPathEdit->setText(QString::fromStdString(config->getMemoryCardFolder()));
 	ui->importExportPathEdit->setText(QString::fromStdString(config->getImportExportFolder()));
-
-	// Load recent files from config
-	ui->recentFilesList->clear();
-	const auto& recentFiles = config->getRecentFiles();
-	for (const auto& file : recentFiles)
-	{
-		ui->recentFilesList->addItem(QString::fromStdString(file));
-	}
-
-	if (ui->recentFilesList->count() == 0)
-	{
-		ui->recentFilesList->addItem(tr("No recent files"));
-		ui->recentFilesList->setEnabled(false);
-		ui->clearRecentButton->setEnabled(false);
-	}
-	else
-	{
-		ui->recentFilesList->setEnabled(true);
-		ui->clearRecentButton->setEnabled(true);
-	}
 }
 
 void FilesSettingsWidget::saveSettings()
@@ -95,31 +69,11 @@ void FilesSettingsWidget::restoreDefaults()
 	ui->importExportPathEdit->clear();
 }
 
-void FilesSettingsWidget::onClearRecentFiles()
-{
-	Config* config = m_dialog->getConfig();
-	if (!config)
-		return;
-
-	QMessageBox::StandardButton reply = QMessageBox::question(this, tr("Clear Recent Files"),
-		tr("Are you sure you want to clear all recent files?"),
-		QMessageBox::Yes | QMessageBox::No);
-
-	if (reply == QMessageBox::Yes)
-	{
-		config->clearRecentFiles();
-		ui->recentFilesList->clear();
-		ui->recentFilesList->addItem(tr("No recent files"));
-		ui->recentFilesList->setEnabled(false);
-		ui->clearRecentButton->setEnabled(false);
-		emit settingChanged();
-	}
-}
-
 void FilesSettingsWidget::onBrowseImportExportPath()
 {
+	const QString startDir = QtUtils::resolveConfigFolderPath(ui->importExportPathEdit->text());
 	QString dir = QFileDialog::getExistingDirectory(this,
-		tr("Select Import/Export Folder"), ui->importExportPathEdit->text());
+		tr("Select Import/Export Folder"), startDir);
 	if (!dir.isEmpty())
 	{
 		ui->importExportPathEdit->setText(dir);
@@ -128,8 +82,9 @@ void FilesSettingsWidget::onBrowseImportExportPath()
 
 void FilesSettingsWidget::onBrowseMemoryCardPath()
 {
+	const QString startDir = QtUtils::resolveConfigFolderPath(ui->memoryCardPathEdit->text());
 	QString dir = QFileDialog::getExistingDirectory(this,
-		tr("Select Memory Card Folder"), ui->memoryCardPathEdit->text());
+		tr("Select Memory Card Folder"), startDir);
 	if (!dir.isEmpty())
 	{
 		ui->memoryCardPathEdit->setText(dir);

--- a/src/ui/Settings/FilesSettingsWidget.h
+++ b/src/ui/Settings/FilesSettingsWidget.h
@@ -5,11 +5,6 @@
 
 #include "SettingsWidget.h"
 
-class QLineEdit;
-class QPushButton;
-class QListWidget;
-class QGroupBox;
-
 class SettingsWindow;
 namespace Ui
 {
@@ -30,7 +25,6 @@ public:
 
 private slots:
 	void onBrowseMemoryCardPath();
-	void onClearRecentFiles();
 	void onBrowseImportExportPath();
 
 protected:

--- a/src/ui/Settings/FilesSettingsWidget.ui
+++ b/src/ui/Settings/FilesSettingsWidget.ui
@@ -95,25 +95,6 @@ https://github.com/PCSX2/pcsx2
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="recentFilesGroup">
-     <property name="title">
-      <string>Recent Files</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout2">
-      <item>
-       <widget class="QListWidget" name="recentFilesList"/>
-      </item>
-      <item>
-       <widget class="QPushButton" name="clearRecentButton">
-        <property name="text">
-         <string>Clear Recent Files</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Orientation::Vertical</enum>
@@ -133,8 +114,6 @@ https://github.com/PCSX2/pcsx2
   <tabstop>browseButton</tabstop>
   <tabstop>importExportPathEdit</tabstop>
   <tabstop>browseImportExportButton</tabstop>
-  <tabstop>recentFilesList</tabstop>
-  <tabstop>clearRecentButton</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/Settings/SettingsWindow.cpp
+++ b/src/ui/Settings/SettingsWindow.cpp
@@ -37,7 +37,7 @@ SettingsWindow::SettingsWindow(Config* config, QWidget* parent)
 
 	addSettingsWidget(new FilesSettingsWidget(this), tr("Files"),
 		QIcon::fromTheme("folder-open-line"),
-		tr("<strong>File Settings</strong><hr>Manage default paths for memory cards, import/export settings, and recent files."));
+		tr("<strong>File Settings</strong><hr>Manage default paths for memory cards and import/export."));
 
 	addSettingsWidget(new AdvancedSettingsWidget(this), tr("Advanced"),
 		QIcon::fromTheme("equalizer-line"),

--- a/src/ui/dialogs/ImportExportSavesDialog.cpp
+++ b/src/ui/dialogs/ImportExportSavesDialog.cpp
@@ -13,8 +13,8 @@ static const char* const MAX_EXT = ".max";
 
 ImportExportSavesDialog::ImportExportSavesDialog(const QStringList& savePaths, QWidget* parent)
 	: QDialog(parent)
-	, ui(new Ui::ImportExportSavesDialog)
 	, m_mode(Mode::Export)
+	, ui(new Ui::ImportExportSavesDialog)
 {
 	ui->setupUi(this);
 	setWindowTitle(tr("Export File Names"));
@@ -70,9 +70,9 @@ ImportExportSavesDialog::ImportExportSavesDialog(const QStringList& savePaths, Q
 
 ImportExportSavesDialog::ImportExportSavesDialog(QList<ImportItem>& importItems, QWidget* parent)
 	: QDialog(parent)
-	, ui(new Ui::ImportExportSavesDialog)
 	, m_mode(Mode::Import)
 	, m_importItems(&importItems)
+	, ui(new Ui::ImportExportSavesDialog)
 {
 	ui->setupUi(this);
 	setWindowTitle(tr("Import Saves"));

--- a/src/ui/ui.vcxproj
+++ b/src/ui/ui.vcxproj
@@ -78,6 +78,7 @@
     <QtMoc Include="Settings\FilesSettingsWidget.h" />
     <QtMoc Include="Settings\AdvancedSettingsWidget.h" />
     <QtMoc Include="TranslationManager.h" />
+    <ClInclude Include="QtUtils.h" />
   </ItemGroup>
   <ItemGroup>
     <QtUic Include="MainWindow.ui" />

--- a/src/ui/ui.vcxproj.filters
+++ b/src/ui/ui.vcxproj.filters
@@ -139,6 +139,9 @@
     <ClInclude Include="TranslationManager.h">
       <Filter>headers</Filter>
     </ClInclude>
+    <ClInclude Include="QtUtils.h">
+      <Filter>headers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="ui">


### PR DESCRIPTION
### Description of Changes
Makes file dialogs start in configured directories, removes the unused recent files feature

### Rationale behind Changes
Cleanup, and allow people to choose their memory card folder when they press open memory card. 

### Suggested Testing Steps
Configure directories in settings and make sure file dialogs start there.

### Related Issues / Links
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No