### PR TITLE
Qt/Formats: Save Copy As, overwrite warnings, and saveAs fixes

### DIFF
--- a/src/core/formats/ps2mc.cpp
+++ b/src/core/formats/ps2mc.cpp
@@ -18,11 +18,7 @@
 #include <memory>
 #include <algorithm>
 #include <ctime>
-
-#ifdef _WIN32
-#define NOMINMAX
-#include <Windows.h>
-#endif
+#include <filesystem>
 
 template <typename T>
 void writeLE(std::vector<uint8_t>& buf, size_t offset, T value)
@@ -42,6 +38,23 @@ T readLE(const std::vector<uint8_t>& buf, size_t offset)
 		value |= (static_cast<T>(buf[offset + i]) << (i * 8));
 	}
 	return value;
+}
+
+static void renameReplace(const std::filesystem::path& target, const std::filesystem::path& tmp)
+{
+	std::error_code ec;
+	std::filesystem::rename(tmp, target, ec);
+	if (ec)
+	{
+		ec.clear();
+		std::filesystem::remove(target, ec);
+		ec.clear();
+		std::filesystem::rename(tmp, target, ec);
+	}
+	if (ec)
+	{
+		throw PS2McIOError("Failed to replace memory card file: " + ec.message());
+	}
 }
 
 class PS2MemoryCard::Impl
@@ -797,8 +810,11 @@ void PS2MemoryCard::close()
 {
 	if (pImpl->file.is_open())
 	{
+		pImpl->file.flush();
 		pImpl->file.close();
 	}
+	pImpl->page_cache.clear();
+	pImpl->fat_cluster_cache.clear();
 }
 
 void PS2MemoryCard::Impl::init_card_parameters(int sizeInMB, bool disableEcc)
@@ -897,7 +913,7 @@ void PS2MemoryCard::Impl::write_superblock(uint32_t first_ifc, uint32_t indirect
 	}
 
 	sb[336] = 2;
-	sb[337] = 0x2B;
+	sb[337] = with_ecc ? 0x2B : 0x2A;
 
 	write_page(0, sb);
 
@@ -2082,71 +2098,156 @@ void PS2MemoryCard::saveAs(const std::string& filename, bool withEcc)
 		throw PS2McError("Memory card not open");
 	}
 
-	if (withEcc == pImpl->with_ecc)
+	std::error_code ec;
+	bool sameFile = std::filesystem::equivalent(
+		std::filesystem::path(pImpl->filename), std::filesystem::path(filename), ec);
+	if (ec)
 	{
-		pImpl->file.seekg(0, std::ios::end);
-		size_t fileSize = pImpl->file.tellg();
-		pImpl->file.seekg(0, std::ios::beg);
+		sameFile = false;
+	}
 
-		std::ofstream outFile(filename, std::ios::binary);
-		if (!outFile)
-		{
-			throw PS2McError("Failed to create file: " + filename);
-		}
+	if (pImpl->modified)
+	{
+		pImpl->write_fat_to_card();
+	}
+	pImpl->file.flush();
 
-		std::vector<char> buffer(fileSize);
-		pImpl->file.read(buffer.data(), fileSize);
-		outFile.write(buffer.data(), fileSize);
-		outFile.close();
+	if (sameFile && withEcc == pImpl->with_ecc)
+	{
 		return;
 	}
 
-	PS2MemoryCard newCard;
-	newCard.create(filename, 8);
+	const std::filesystem::path dest(sameFile ? pImpl->filename : filename);
 
-	uint32_t pageCount = pImpl->clusters_per_card * pImpl->pages_per_cluster;
-
-	newCard.close();
-
-	std::ofstream outFile(filename, std::ios::binary);
-	if (!outFile)
+	if (withEcc == pImpl->with_ecc)
 	{
-		throw PS2McError("Failed to create file: " + filename);
+		pImpl->file.close();
+		pImpl->page_cache.clear();
+		pImpl->fat_cluster_cache.clear();
+
+		std::filesystem::copy_file(pImpl->filename, dest,
+			std::filesystem::copy_options::overwrite_existing, ec);
+		if (ec)
+		{
+			pImpl->file.open(pImpl->filename, std::ios::in | std::ios::out | std::ios::binary);
+			if (!pImpl->file)
+			{
+				pImpl->file.open(pImpl->filename, std::ios::in | std::ios::binary);
+			}
+			throw PS2McIOError("Failed to copy memory card file: " + ec.message());
+		}
+
+		pImpl->file.open(pImpl->filename, std::ios::in | std::ios::out | std::ios::binary);
+		if (!pImpl->file)
+		{
+			pImpl->file.open(pImpl->filename, std::ios::in | std::ios::binary);
+		}
+		if (!pImpl->file)
+		{
+			throw PS2McIOError("Failed to reopen memory card after save");
+		}
+		pImpl->read_superblock();
+		return;
 	}
 
-	if (withEcc && !pImpl->with_ecc)
+	const uint32_t pageCount = pImpl->clusters_per_card * pImpl->pages_per_cluster;
+	const std::filesystem::path tmpPath = dest.string() + ".tmp";
+	std::filesystem::remove(tmpPath, ec);
+
+	std::ofstream out(tmpPath, std::ios::binary);
+	if (!out)
 	{
-		for (uint32_t i = 0; i < pageCount; ++i)
+		throw PS2McError("Failed to create file: " + tmpPath.string());
+	}
+
+	for (uint32_t i = 0; i < pageCount; ++i)
+	{
+		auto pageData = pImpl->read_page(i);
+		if (pageData.size() > pImpl->page_size)
 		{
-			auto pageData = pImpl->read_page(i);
-			if (pageData.size() < pImpl->page_size)
-			{
-				pageData.resize(pImpl->page_size, 0);
-			}
-
-			outFile.write(reinterpret_cast<const char*>(pageData.data()), pImpl->page_size);
-
-			auto spare = eccCalculatePage(pageData, static_cast<int>(pImpl->page_size));
-			outFile.write(reinterpret_cast<const char*>(spare.data()), spare.size());
+			pageData.resize(pImpl->page_size);
 		}
+		else if (pageData.size() < pImpl->page_size)
+		{
+			pageData.resize(pImpl->page_size, 0);
+		}
+
+		const char* MAGIC = "Sony PS2 Memory Card Format ";
+		if (pageData.size() >= 28 && std::memcmp(pageData.data(), MAGIC, 28) == 0)
+		{
+			if (pageData.size() > 0x151)
+			{
+				if (withEcc)
+				{
+					pageData[0x151] |= 0x01;
+				}
+				else
+				{
+					pageData[0x151] &= ~0x01;
+				}
+			}
+		}
+
+		out.write(reinterpret_cast<const char*>(pageData.data()),
+			static_cast<std::streamsize>(pImpl->page_size));
+		if (!out)
+		{
+			std::filesystem::remove(tmpPath, ec);
+			throw PS2McIOError("Failed to write memory card file");
+		}
+
+		if (withEcc && !pImpl->with_ecc)
+		{
+			uint32_t targetSpareSize = divRoundUp(pImpl->page_size, 128) * 4;
+			std::vector<uint8_t> spareBytes(targetSpareSize, 0);
+			auto ecc = eccCalculatePage(pageData, static_cast<int>(pImpl->page_size));
+			for (size_t j = 0; j < ecc.size() && j < targetSpareSize; ++j)
+			{
+				spareBytes[j] = ecc[j];
+			}
+			out.write(reinterpret_cast<const char*>(spareBytes.data()),
+				static_cast<std::streamsize>(targetSpareSize));
+			if (!out)
+			{
+				std::filesystem::remove(tmpPath, ec);
+				throw PS2McIOError("Failed to write memory card file");
+			}
+		}
+	}
+
+	out.close();
+
+	if (!sameFile)
+	{
+		renameReplace(dest, tmpPath);
+		return;
+	}
+
+	pImpl->file.close();
+	pImpl->page_cache.clear();
+	pImpl->fat_cluster_cache.clear();
+	renameReplace(dest, tmpPath);
+
+	pImpl->with_ecc = withEcc;
+	pImpl->ignore_ecc = !withEcc;
+	if (withEcc)
+	{
+		pImpl->calculate_derived();
 	}
 	else
 	{
-		for (uint32_t i = 0; i < pageCount; ++i)
-		{
-			auto pageData = pImpl->read_page(i);
-			if (pageData.size() > pImpl->page_size)
-			{
-				pageData.resize(pImpl->page_size);
-			}
-			else if (pageData.size() < pImpl->page_size)
-			{
-				pageData.resize(pImpl->page_size, 0);
-			}
-
-			outFile.write(reinterpret_cast<const char*>(pageData.data()), pImpl->page_size);
-		}
+		pImpl->spare_size = 0;
+		pImpl->raw_page_size = pImpl->page_size;
 	}
 
-	outFile.close();
+	pImpl->file.open(pImpl->filename, std::ios::in | std::ios::out | std::ios::binary);
+	if (!pImpl->file)
+	{
+		pImpl->file.open(pImpl->filename, std::ios::in | std::ios::binary);
+	}
+	if (!pImpl->file)
+	{
+		throw PS2McIOError("Failed to reopen memory card after save");
+	}
+	pImpl->read_superblock();
 }

--- a/src/core/formats/ps2mc_ecc.cpp
+++ b/src/core/formats/ps2mc_ecc.cpp
@@ -155,8 +155,11 @@ int eccCheckPage(std::vector<uint8_t>& page, std::vector<uint8_t>& spare, int pa
 			chunk.resize(128, 0);
 		}
 
-		std::array<uint8_t, 3> ecc;
-		std::copy(spare.begin() + i * 3, spare.begin() + i * 3 + 3, ecc.begin());
+		std::array<uint8_t, 3> ecc = {0, 0, 0};
+		if (spare.size() >= static_cast<size_t>(i * 3 + 3))
+		{
+			std::copy(spare.begin() + i * 3, spare.begin() + i * 3 + 3, ecc.begin());
+		}
 
 		int check_result = eccCheck(chunk, ecc);
 		if (check_result != ECC_CHECK_OK)

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -53,6 +53,16 @@ namespace
 			QFileInfo(cardPath).fileName(),
 			getCardTypeLabelFromPath(cardPath));
 	}
+
+	bool samePath(const QString& a, const QString& b)
+	{
+		if (a.isEmpty() || b.isEmpty())
+			return false;
+
+		const QString pathA = QFileInfo(a).canonicalFilePath();
+		const QString pathB = QFileInfo(b).canonicalFilePath();
+		return !pathA.isEmpty() && pathA == pathB;
+	}
 } // namespace
 
 MainWindow::MainWindow(Config* config, QWidget* parent)
@@ -404,6 +414,8 @@ void MainWindow::onOpenMemoryCard()
 		return;
 	}
 
+	const bool reloading = memoryCard && !currentCardPath.isEmpty() && samePath(currentCardPath, filename);
+
 	closeCard();
 
 	auto card = actionHandler->openCard(filename);
@@ -417,6 +429,11 @@ void MainWindow::onOpenMemoryCard()
 		ui->actionClose->setEnabled(true);
 		ui->actionSaveAs->setEnabled(true);
 		ui->actionCardInfo->setEnabled(true);
+		const bool hasEcc = memoryCard->hasEcc();
+		ui->actionEccTool->setText(hasEcc ? tr("Remove ECC and Save &Copy As...") : tr("Add ECC and Save &Copy As..."));
+		ui->actionEccTool->setStatusTip(hasEcc ?
+											tr("Remove ECC from the memory card and save a copy to another file") :
+											tr("Add ECC to the memory card and save a copy to another file"));
 		ui->actionEccTool->setEnabled(true);
 		ui->actionImport->setEnabled(true);
 		ui->actionExport->setEnabled(true);
@@ -426,6 +443,13 @@ void MainWindow::onOpenMemoryCard()
 		if (m_discordRpc)
 		{
 			m_discordRpc->setCardOpenContext(makeCardDisplayLabel(currentCardPath));
+		}
+
+		if (reloading)
+		{
+			ui->statusBar->showMessage(
+				tr("Reloaded %1").arg(QFileInfo(filename).fileName()),
+				5000);
 		}
 	}
 }
@@ -453,6 +477,24 @@ void MainWindow::onCreateMemoryCard()
 		return;
 	}
 
+	if (QFile::exists(filename))
+	{
+		const auto reply = QMessageBox::warning(
+			this,
+			tr("Create Memory Card"),
+			tr("'%1' already exists.\n\n"
+			   "Creating a memory card here will overwrite that file and erase any saves on it.\n\n"
+			   "Continue?")
+				.arg(QDir::toNativeSeparators(filename)),
+			QMessageBox::Yes | QMessageBox::No,
+			QMessageBox::No);
+
+		if (reply != QMessageBox::Yes)
+		{
+			return;
+		}
+	}
+
 	closeCard();
 
 	auto card = actionHandler->createCard(filename, sizeMB, disableEcc);
@@ -466,6 +508,11 @@ void MainWindow::onCreateMemoryCard()
 		ui->actionClose->setEnabled(true);
 		ui->actionSaveAs->setEnabled(true);
 		ui->actionCardInfo->setEnabled(true);
+		const bool hasEcc = memoryCard->hasEcc();
+		ui->actionEccTool->setText(hasEcc ? tr("Remove ECC and Save &Copy As...") : tr("Add ECC and Save &Copy As..."));
+		ui->actionEccTool->setStatusTip(hasEcc ?
+											tr("Remove ECC from the memory card and save a copy to another file") :
+											tr("Add ECC to the memory card and save a copy to another file"));
 		ui->actionEccTool->setEnabled(true);
 		ui->actionImport->setEnabled(true);
 		ui->actionExport->setEnabled(true);
@@ -626,7 +673,7 @@ void MainWindow::importSaveFiles(const QStringList& paths)
 		QMessageBox::warning(this, tr("Import"),
 			tr("Imported %1 save(s); %2 failed:\n%3").arg(ok).arg(failed).arg(failedNames.join("\n")));
 	}
-	else
+	else if (ok > 0)
 	{
 		if (skipped > 0)
 		{
@@ -640,7 +687,12 @@ void MainWindow::importSaveFiles(const QStringList& paths)
 		}
 	}
 
-	ui->statusBar->showMessage(failed == 0 ? tr("Imported %1 saves").arg(ok) : tr("Imported %1, %2 failed").arg(ok).arg(failed), 5000);
+	if (failed > 0)
+		ui->statusBar->showMessage(tr("Imported %1, %2 failed").arg(ok).arg(failed), 8000);
+	else if (ok > 0)
+		ui->statusBar->showMessage(tr("Imported %1 save(s)").arg(ok), 8000);
+	else
+		ui->statusBar->showMessage(tr("No saves imported"), 8000);
 
 	if (m_discordRpc && ok > 0)
 	{
@@ -1089,25 +1141,39 @@ void MainWindow::onSaveAs()
 		return;
 
 	const QString memoryCardDir = QtUtils::resolveConfigFolderPath(m_config->getMemoryCardFolder());
+	const QFileInfo cardInfo(currentCardPath);
+	const QString suffix = cardInfo.suffix().isEmpty() ? "ps2" : cardInfo.suffix();
+	const QString defaultPath = memoryCardDir + QLatin1Char('/') + cardInfo.completeBaseName() + "_copy." + suffix;
+
 	QString filename = QFileDialog::getSaveFileName(
 		this,
-		tr("Save Memory Card As"),
-		memoryCardDir + QLatin1Char('/') + QFileInfo(currentCardPath).baseName() + ".ps2",
+		tr("Save Copy As..."),
+		defaultPath,
 		tr("PCSX2 Memory Card (*.ps2);;MemCard PRO2 (*.mc2 *.mcd);;All Files (*.*)"));
 
 	if (filename.isEmpty())
 		return;
 
+	if (samePath(currentCardPath, filename))
+	{
+		QMessageBox::information(
+			this,
+			tr("Save Copy As"),
+			tr("That file is already open.\n\n"
+			   "Pick another name if you want a copy."));
+		return;
+	}
+
 	try
 	{
-		memoryCard->saveAs(filename.toStdString(), true);
+		memoryCard->saveAs(filename.toStdString(), memoryCard->hasEcc());
 		if (m_discordRpc)
 		{
 			m_discordRpc->setTemporaryPresence(
 				tr("Card: %1").arg(makeCardDisplayLabel(currentCardPath)),
-				tr("Saved As: %1").arg(QFileInfo(filename).fileName()));
+				tr("Copy saved: %1").arg(QFileInfo(filename).fileName()));
 		}
-		ui->statusBar->showMessage(tr("Saved to %1").arg(filename), 5000);
+		ui->statusBar->showMessage(tr("Copy saved to %1").arg(filename), 5000);
 	}
 	catch (const std::exception& e)
 	{
@@ -1220,23 +1286,31 @@ void MainWindow::onEccTool()
 
 	bool hasEcc = memoryCard->hasEcc();
 
-	QString defaultName;
-	if (hasEcc)
-		defaultName = "NoECC_" + QFileInfo(currentCardPath).fileName();
-	else
-		defaultName = "ECC_" + QFileInfo(currentCardPath).fileName();
-
-	QString dialogTitle = hasEcc ? tr("Remove ECC and Save As...") : tr("Add ECC and Save As...");
-
 	const QString memoryCardDir = QtUtils::resolveConfigFolderPath(m_config->getMemoryCardFolder());
+	const QFileInfo cardInfo(currentCardPath);
+	const QString prefix = hasEcc ? "NoECC_" : "ECC_";
+	const QString defaultPath = memoryCardDir + QLatin1Char('/') + prefix + cardInfo.fileName();
+
+	QString dialogTitle = hasEcc ? tr("Remove ECC and Save Copy As...") : tr("Add ECC and Save Copy As...");
+
 	QString filename = QFileDialog::getSaveFileName(
 		this,
 		dialogTitle,
-		memoryCardDir + QLatin1Char('/') + defaultName,
+		defaultPath,
 		tr("All Memory Cards (*.ps2 *.vm2 *.vmc *.mc2 *.mcd);;PCSX2 Memory Card (*.ps2);;PS3 Virtual Memory Card (*.vm2 *.vmc);;MemCard PRO2 (*.mc2 *.mcd);;All Files (*.*)"));
 
 	if (filename.isEmpty())
 		return;
+
+	if (samePath(currentCardPath, filename))
+	{
+		QMessageBox::information(
+			this,
+			dialogTitle,
+			tr("That file is already open.\n\n"
+			   "Pick another name for the ECC copy."));
+		return;
+	}
 
 	try
 	{
@@ -1247,7 +1321,7 @@ void MainWindow::onEccTool()
 				tr("Card: %1").arg(makeCardDisplayLabel(currentCardPath)),
 				hasEcc ? tr("Removed ECC") : tr("Added ECC"));
 		}
-		ui->statusBar->showMessage(tr("Saved to %1").arg(filename), 5000);
+		ui->statusBar->showMessage(tr("ECC copy saved to %1").arg(filename), 5000);
 	}
 	catch (const std::exception& e)
 	{

--- a/src/ui/MainWindow.ui
+++ b/src/ui/MainWindow.ui
@@ -52,7 +52,7 @@
      <x>0</x>
      <y>0</y>
      <width>900</width>
-     <height>27</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -64,8 +64,8 @@
     <addaction name="actionClose"/>
     <addaction name="separator"/>
     <addaction name="actionSaveAs"/>
-    <addaction name="actionCardInfo"/>
     <addaction name="actionEccTool"/>
+    <addaction name="actionCardInfo"/>
     <addaction name="separator"/>
     <addaction name="actionExit"/>
    </widget>
@@ -111,11 +111,11 @@
    <addaction name="menuHelp"/>
   </widget>
   <widget class="QToolBar" name="mainToolBar">
+   <property name="contextMenuPolicy">
+    <enum>Qt::ContextMenuPolicy::NoContextMenu</enum>
+   </property>
    <property name="windowTitle">
     <string>Main Toolbar</string>
-   </property>
-   <property name="contextMenuPolicy">
-    <enum>Qt::NoContextMenu</enum>
    </property>
    <property name="toolButtonStyle">
     <enum>Qt::ToolButtonStyle::ToolButtonTextBesideIcon</enum>
@@ -150,11 +150,11 @@
    </property>
   </action>
   <action name="actionCreate">
-   <property name="text">
-    <string>&amp;Create Memory Card...</string>
-   </property>
    <property name="icon">
     <iconset theme="memcard-new"/>
+   </property>
+   <property name="text">
+    <string>&amp;Create Memory Card...</string>
    </property>
    <property name="statusTip">
     <string>Create a new PS2 memory card image</string>
@@ -184,14 +184,14 @@
    <property name="enabled">
     <bool>false</bool>
    </property>
-   <property name="text">
-    <string>&amp;Save As...</string>
-   </property>
-   <property name="statusTip">
-    <string>Save the memory card to a new file</string>
-   </property>
    <property name="icon">
     <iconset theme="save-fill"/>
+   </property>
+   <property name="text">
+    <string>Save &amp;Copy As...</string>
+   </property>
+   <property name="statusTip">
+    <string>Save a copy to another file</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+S</string>
@@ -201,9 +201,9 @@
    <property name="enabled">
     <bool>false</bool>
    </property>
-  <property name="icon">
+   <property name="icon">
     <iconset theme="file-info-fill"/>
-  </property>
+   </property>
    <property name="text">
     <string>Card &amp;Info...</string>
    </property>
@@ -212,9 +212,9 @@
    </property>
   </action>
   <action name="actionExit">
-  <property name="icon">
-   <iconset theme="close-circle-fill"/>
-  </property>
+   <property name="icon">
+    <iconset theme="close-circle-fill"/>
+   </property>
    <property name="text">
     <string>E&amp;xit</string>
    </property>
@@ -229,11 +229,11 @@
    <property name="enabled">
     <bool>false</bool>
    </property>
-   <property name="text">
-    <string>Select &amp;All</string>
-   </property>
    <property name="icon">
     <iconset theme="list-unordered"/>
+   </property>
+   <property name="text">
+    <string>Select &amp;All</string>
    </property>
    <property name="statusTip">
     <string>Select all saves</string>
@@ -253,7 +253,7 @@
     <string>&amp;Import Save...</string>
    </property>
    <property name="statusTip">
-    <string>Import a save file to the memory card</string>
+    <string>Import a save file to the open memory card</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+I</string>
@@ -315,13 +315,13 @@
     <iconset theme="save-fill"/>
    </property>
    <property name="text">
-    <string>Remove &amp;ECC and Save As...</string>
+    <string>Save ECC &amp;Copy As...</string>
    </property>
    <property name="statusTip">
-    <string>Add or remove ECC from the memory card and save to a new file</string>
+    <string>Add or remove ECC from the memory card and save a copy to another file</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+S</string>
+    <string>Ctrl+Shift+E</string>
    </property>
   </action>
   <action name="actionAscii">
@@ -364,11 +364,11 @@
    </property>
   </action>
   <action name="actionPreferences">
-   <property name="text">
-    <string>&amp;Preferences...</string>
-   </property>
    <property name="icon">
     <iconset theme="settings-fill"/>
+   </property>
+   <property name="text">
+    <string>&amp;Preferences...</string>
    </property>
    <property name="statusTip">
     <string>Configure application settings</string>

--- a/src/ui/dialogs/ImportExportSavesDialog.cpp
+++ b/src/ui/dialogs/ImportExportSavesDialog.cpp
@@ -76,7 +76,9 @@ ImportExportSavesDialog::ImportExportSavesDialog(QList<ImportItem>& importItems,
 {
 	ui->setupUi(this);
 	setWindowTitle(tr("Import Saves"));
-	ui->introLabel->setText(tr("Review and select saves to import:"));
+	ui->introLabel->setText(tr(
+		"Review and select saves to import.\n"
+		"Imports are saved to the open memory card file."));
 
 	// Hide the format selection layout since it is only for export
 	ui->formatLabel->hide();


### PR DESCRIPTION
### Description of Changes
- Renamed "Save As" to "Save Copy As".
- Prompt before overwriting an existing card during creation.
- Fixed `saveAs` ECC format conversion bugs (there were some broken flags in superblock and missing spare padding).
- Don't delete `.tmp` files on rename error so we don't lose saves.
- Added bounds check to `eccCheckPage` to avoid crashes.

### Rationale behind Changes
Fixes format conversion corruption, prevents data loss, and makes the UI labels match what they actually do.

### Suggested Testing Steps
Try to save copies with/without ECC, make sure they reopen fine. Try creating a card on top of an existing one.

### Related Issues / Links
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No