### PR TITLE
Qt/Vulkan: Add graphics adapter selection and fix some vk issues

### DIFF
--- a/src/common/Config.cpp
+++ b/src/common/Config.cpp
@@ -112,6 +112,23 @@ void Config::setRenderer(const std::string& renderer)
 	m_config["graphics"]["renderer"] = renderer;
 }
 
+std::string Config::getAdapter() const
+{
+	try
+	{
+		return m_config["graphics"]["adapter"].get<std::string>();
+	}
+	catch (...)
+	{
+		return "";
+	}
+}
+
+void Config::setAdapter(const std::string& adapter)
+{
+	m_config["graphics"]["adapter"] = adapter;
+}
+
 bool Config::getAnimateIcons() const
 {
 	try
@@ -537,6 +554,7 @@ void Config::createDefaults()
 {
 	m_config = {
 		{"graphics", {{"renderer", "vulkan"},
+						 {"adapter", ""},
 						 {"vsync", true},
 						 {"swap_interval", 1},
 						 {"antialiasing", 4},
@@ -582,6 +600,8 @@ void Config::ensureKeys()
 
 	if (!m_config["graphics"].contains("renderer"))
 		m_config["graphics"]["renderer"] = "vulkan";
+	if (!m_config["graphics"].contains("adapter"))
+		m_config["graphics"]["adapter"] = "";
 	if (!m_config["graphics"].contains("vsync"))
 		m_config["graphics"]["vsync"] = true;
 	if (!m_config["graphics"].contains("swap_interval"))

--- a/src/common/Config.h
+++ b/src/common/Config.h
@@ -25,6 +25,9 @@ public:
 	std::string getRenderer() const;
 	void setRenderer(const std::string& renderer);
 
+	std::string getAdapter() const;
+	void setAdapter(const std::string& adapter);
+
 	bool getAnimateIcons() const;
 	void setAnimateIcons(bool enabled);
 	std::string getLightingMode() const;

--- a/src/core/renderer/Renderer.cpp
+++ b/src/core/renderer/Renderer.cpp
@@ -4,6 +4,7 @@
 #include "Renderer.h"
 #if defined(ENABLE_VULKAN)
 #include "Vulkan/VulkanRenderer.h"
+#include "Vulkan/VulkanDevice.h"
 #endif
 #include "OpenGL/OpenGLRenderer.h"
 #if defined(__APPLE__)
@@ -100,5 +101,21 @@ void RendererFactory::applyVSyncToAll(bool enabled)
 		{
 			renderer->setVSync(enabled);
 		}
+	}
+}
+
+std::vector<std::string> RendererFactory::getAvailableAdapters(RendererType type)
+{
+	// Chose switch because in the near future I plan to have D3D renderers.
+	switch (type)
+	{
+		case RendererType::Vulkan:
+#if defined(ENABLE_VULKAN)
+			return VulkanDevice::getAvailableAdapters();
+#else
+			return {};
+#endif
+		default:
+			return {};
 	}
 }

--- a/src/core/renderer/Renderer.h
+++ b/src/core/renderer/Renderer.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
+#include <string>
 #include "../../common/Error.h"
 #include "WindowInfo.h"
 
@@ -106,6 +107,7 @@ public:
 	static void registerRenderer(Renderer* renderer);
 	static void unregisterRenderer(Renderer* renderer);
 	static void applyVSyncToAll(bool enabled);
+	static std::vector<std::string> getAvailableAdapters(RendererType type);
 
 private:
 	static std::vector<Renderer*> s_activeRenderers;

--- a/src/core/renderer/Vulkan/VulkanDevice.cpp
+++ b/src/core/renderer/Vulkan/VulkanDevice.cpp
@@ -44,7 +44,7 @@ VulkanDevice::~VulkanDevice()
 	destroy();
 }
 
-bool VulkanDevice::create(const WindowInfo& windowInfo)
+bool VulkanDevice::create(const WindowInfo& windowInfo, const std::string& preferredAdapter)
 {
 	m_error.Clear();
 	if (!createInstance())
@@ -54,7 +54,7 @@ bool VulkanDevice::create(const WindowInfo& windowInfo)
 		destroy();
 		return false;
 	}
-	if (!selectPhysicalDevice())
+	if (!selectPhysicalDevice(preferredAdapter))
 	{
 		destroy();
 		return false;
@@ -65,6 +65,44 @@ bool VulkanDevice::create(const WindowInfo& windowInfo)
 		return false;
 	}
 	return true;
+}
+
+std::vector<std::string> VulkanDevice::getAvailableAdapters()
+{
+	std::vector<std::string> adapterNames;
+
+	VkApplicationInfo appInfo{};
+	appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+	appInfo.pApplicationName = "myMCpp";
+	appInfo.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
+	appInfo.pEngineName = "myMCpp";
+	appInfo.engineVersion = VK_MAKE_VERSION(1, 0, 0);
+	appInfo.apiVersion = VK_API_VERSION_1_1;
+
+	VkInstanceCreateInfo createInfo{};
+	createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+	createInfo.pApplicationInfo = &appInfo;
+
+	VkInstance tempInstance = VK_NULL_HANDLE;
+	if (vkCreateInstance(&createInfo, nullptr, &tempInstance) == VK_SUCCESS)
+	{
+		uint32_t deviceCount = 0;
+		vkEnumeratePhysicalDevices(tempInstance, &deviceCount, nullptr);
+		if (deviceCount > 0)
+		{
+			std::vector<VkPhysicalDevice> devices(deviceCount);
+			vkEnumeratePhysicalDevices(tempInstance, &deviceCount, devices.data());
+			for (const auto& device : devices)
+			{
+				VkPhysicalDeviceProperties props;
+				vkGetPhysicalDeviceProperties(device, &props);
+				adapterNames.push_back(props.deviceName);
+			}
+		}
+		vkDestroyInstance(tempInstance, nullptr);
+	}
+
+	return adapterNames;
 }
 
 void VulkanDevice::destroy()
@@ -313,7 +351,7 @@ bool VulkanDevice::createSurface(const WindowInfo& windowInfo)
 #endif
 }
 
-bool VulkanDevice::selectPhysicalDevice()
+bool VulkanDevice::selectPhysicalDevice(const std::string& preferredAdapter)
 {
 	uint32_t deviceCount = 0;
 	vkEnumeratePhysicalDevices(m_instance, &deviceCount, nullptr);
@@ -324,13 +362,11 @@ bool VulkanDevice::selectPhysicalDevice()
 	std::vector<VkPhysicalDevice> devices(deviceCount);
 	vkEnumeratePhysicalDevices(m_instance, &deviceCount, devices.data());
 
-	for (const auto& device : devices)
-	{
-		VkPhysicalDeviceProperties2 props2{};
-		props2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
-		vkGetPhysicalDeviceProperties2(device, &props2);
-		const VkPhysicalDeviceProperties& props = props2.properties;
+	VkPhysicalDevice selectedDevice = VK_NULL_HANDLE;
+	uint32_t selectedQueueFamily = 0;
+	std::string selectedDeviceName;
 
+	auto isDeviceSuitable = [&](VkPhysicalDevice device, uint32_t& queueFamilyIndex) {
 		uint32_t queueFamilyCount = 0;
 		vkGetPhysicalDeviceQueueFamilyProperties2(device, &queueFamilyCount, nullptr);
 
@@ -347,17 +383,49 @@ bool VulkanDevice::selectPhysicalDevice()
 			if (queueFamilies[i].queueFamilyProperties.queueFlags & VK_QUEUE_GRAPHICS_BIT)
 			{
 				VkBool32 presentSupport = false;
-				vkGetPhysicalDeviceSurfaceSupportKHR(device, i, m_surface, &presentSupport);
-
-				if (presentSupport)
+				if (vkGetPhysicalDeviceSurfaceSupportKHR(device, i, m_surface, &presentSupport) == VK_SUCCESS && presentSupport)
 				{
-					m_physicalDevice = device;
-					m_graphicsQueueFamily = i;
-					Logger::info("VK: Using device: {}", props.deviceName);
+					queueFamilyIndex = i;
 					return true;
 				}
 			}
 		}
+		return false;
+	};
+
+	for (const auto& device : devices)
+	{
+		VkPhysicalDeviceProperties2 props2{};
+		props2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+		vkGetPhysicalDeviceProperties2(device, &props2);
+
+		uint32_t queueFamily = 0;
+		if (isDeviceSuitable(device, queueFamily))
+		{
+			std::string name = props2.properties.deviceName;
+			if (!preferredAdapter.empty() && name == preferredAdapter)
+			{
+				selectedDevice = device;
+				selectedQueueFamily = queueFamily;
+				selectedDeviceName = name;
+				break;
+			}
+
+			if (selectedDevice == VK_NULL_HANDLE)
+			{
+				selectedDevice = device;
+				selectedQueueFamily = queueFamily;
+				selectedDeviceName = name;
+			}
+		}
+	}
+
+	if (selectedDevice != VK_NULL_HANDLE)
+	{
+		m_physicalDevice = selectedDevice;
+		m_graphicsQueueFamily = selectedQueueFamily;
+		Logger::info("VK: Using device: {}", selectedDeviceName);
+		return true;
 	}
 
 	return m_error.Fail("VK: No suitable device found");

--- a/src/core/renderer/Vulkan/VulkanDevice.h
+++ b/src/core/renderer/Vulkan/VulkanDevice.h
@@ -6,6 +6,8 @@
 #include <vulkan/vulkan.h>
 #include <vk_mem_alloc.h>
 #include <cstdint>
+#include <vector>
+#include <string>
 #include "../../../common/Error.h"
 
 struct WindowInfo;
@@ -19,8 +21,10 @@ public:
 	VulkanDevice(const VulkanDevice&) = delete;
 	VulkanDevice& operator=(const VulkanDevice&) = delete;
 
-	bool create(const WindowInfo& windowInfo);
+	bool create(const WindowInfo& windowInfo, const std::string& preferredAdapter = "");
 	void destroy();
+
+	static std::vector<std::string> getAvailableAdapters();
 
 	const Error& GetError() const { return m_error; }
 
@@ -38,7 +42,7 @@ public:
 private:
 	bool createInstance();
 	bool createSurface(const WindowInfo& windowInfo);
-	bool selectPhysicalDevice();
+	bool selectPhysicalDevice(const std::string& preferredAdapter = "");
 	bool createLogicalDevice();
 
 	Error m_error;

--- a/src/core/renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/core/renderer/Vulkan/VulkanRenderer.cpp
@@ -68,7 +68,7 @@ bool VulkanRenderer::initialize()
 	CocoaTools::SetDrawableSize(&m_windowInfo, m_width, m_height);
 #endif
 
-	if (!m_vulkanDevice.create(m_windowInfo))
+	if (!m_vulkanDevice.create(m_windowInfo, m_config ? m_config->getAdapter() : ""))
 		return m_error.Assign(m_vulkanDevice.GetError());
 
 	if (!m_vulkanSwapchain.create(m_vulkanDevice, m_width, m_height, m_config ? m_config->getVSync() : true))

--- a/src/core/renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/core/renderer/Vulkan/VulkanRenderer.cpp
@@ -71,7 +71,7 @@ bool VulkanRenderer::initialize()
 	if (!m_vulkanDevice.create(m_windowInfo))
 		return m_error.Assign(m_vulkanDevice.GetError());
 
-	if (!m_vulkanSwapchain.create(m_vulkanDevice, m_width, m_height))
+	if (!m_vulkanSwapchain.create(m_vulkanDevice, m_width, m_height, m_config ? m_config->getVSync() : true))
 		return m_error.Assign(m_vulkanSwapchain.GetError());
 
 	VkRenderPass renderPass = m_vulkanSwapchain.getRenderPass();
@@ -801,10 +801,7 @@ bool VulkanRenderer::recordCommandBuffer(uint32_t imageIndex)
 	scissor.offset = {0, 0};
 	scissor.extent = extent;
 
-	VkSubpassBeginInfo subpassBegin{};
-	subpassBegin.sType = VK_STRUCTURE_TYPE_SUBPASS_BEGIN_INFO;
-	subpassBegin.contents = VK_SUBPASS_CONTENTS_INLINE;
-	vkCmdBeginRenderPass2(cmd, &renderPassInfo, &subpassBegin);
+	vkCmdBeginRenderPass(cmd, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
 
 	VkBuffer bgBuffer = m_vulkanResources.getBackgroundVertexBuffer();
 	if (m_background.shouldRender && m_vulkanPipeline.getBackgroundPipeline() != VK_NULL_HANDLE && bgBuffer != VK_NULL_HANDLE)
@@ -848,9 +845,7 @@ bool VulkanRenderer::recordCommandBuffer(uint32_t imageIndex)
 		vkCmdDraw(cmd, m_vertexCount, 1, 0, 0);
 	}
 
-	VkSubpassEndInfo subpassEnd{};
-	subpassEnd.sType = VK_STRUCTURE_TYPE_SUBPASS_END_INFO;
-	vkCmdEndRenderPass2(cmd, &subpassEnd);
+	vkCmdEndRenderPass(cmd);
 
 	if (vkEndCommandBuffer(cmd) != VK_SUCCESS)
 	{

--- a/src/core/renderer/Vulkan/VulkanSwapchain.cpp
+++ b/src/core/renderer/Vulkan/VulkanSwapchain.cpp
@@ -14,9 +14,11 @@ VulkanSwapchain::VulkanSwapchain() = default;
 
 VulkanSwapchain::~VulkanSwapchain() = default;
 
-bool VulkanSwapchain::create(VulkanDevice& device, uint32_t width, uint32_t height)
+bool VulkanSwapchain::create(VulkanDevice& device, uint32_t width, uint32_t height, bool vsync)
 {
 	m_error.Clear();
+
+	m_presentMode = vsync ? VK_PRESENT_MODE_FIFO_KHR : VK_PRESENT_MODE_MAILBOX_KHR;
 
 	if (!createSwapchain(device, width, height))
 		return false;
@@ -111,12 +113,16 @@ bool VulkanSwapchain::createSwapchain(VulkanDevice& device, uint32_t width, uint
 	VkSwapchainKHR oldSwapchain)
 {
 	VkSurfaceCapabilitiesKHR capabilities;
-	vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device.getPhysicalDevice(), device.getSurface(), &capabilities);
+	if (vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device.getPhysicalDevice(), device.getSurface(), &capabilities) != VK_SUCCESS)
+		return m_error.Fail("VK: Failed to get physical device surface capabilities");
 
 	uint32_t formatCount = 0;
-	vkGetPhysicalDeviceSurfaceFormatsKHR(device.getPhysicalDevice(), device.getSurface(), &formatCount, nullptr);
+	if (vkGetPhysicalDeviceSurfaceFormatsKHR(device.getPhysicalDevice(), device.getSurface(), &formatCount, nullptr) != VK_SUCCESS || formatCount == 0)
+		return m_error.Fail("VK: Failed to get physical device surface formats or none supported");
+
 	std::vector<VkSurfaceFormatKHR> formats(formatCount);
-	vkGetPhysicalDeviceSurfaceFormatsKHR(device.getPhysicalDevice(), device.getSurface(), &formatCount, formats.data());
+	if (vkGetPhysicalDeviceSurfaceFormatsKHR(device.getPhysicalDevice(), device.getSurface(), &formatCount, formats.data()) != VK_SUCCESS || formats.empty())
+		return m_error.Fail("VK: Failed to retrieve physical device surface formats");
 
 	VkSurfaceFormatKHR surfaceFormat = formats[0];
 	for (const auto& fmt : formats)
@@ -129,36 +135,46 @@ bool VulkanSwapchain::createSwapchain(VulkanDevice& device, uint32_t width, uint
 	}
 
 	uint32_t presentModeCount = 0;
-	vkGetPhysicalDeviceSurfacePresentModesKHR(device.getPhysicalDevice(), device.getSurface(), &presentModeCount, nullptr);
+	if (vkGetPhysicalDeviceSurfacePresentModesKHR(device.getPhysicalDevice(), device.getSurface(), &presentModeCount, nullptr) != VK_SUCCESS || presentModeCount == 0)
+		return m_error.Fail("VK: Failed to get physical device surface present modes or none supported");
+
 	std::vector<VkPresentModeKHR> presentModes(presentModeCount);
-	vkGetPhysicalDeviceSurfacePresentModesKHR(device.getPhysicalDevice(), device.getSurface(), &presentModeCount, presentModes.data());
+	if (vkGetPhysicalDeviceSurfacePresentModesKHR(device.getPhysicalDevice(), device.getSurface(), &presentModeCount, presentModes.data()) != VK_SUCCESS || presentModes.empty())
+		return m_error.Fail("VK: Failed to retrieve physical device surface present modes");
 
 	VkPresentModeKHR presentMode = m_presentMode;
-	if (oldSwapchain == VK_NULL_HANDLE)
+	bool supported = false;
+	for (const auto& mode : presentModes)
 	{
-		presentMode = VK_PRESENT_MODE_FIFO_KHR;
-		for (const auto& mode : presentModes)
+		if (mode == presentMode)
 		{
-			if (mode == VK_PRESENT_MODE_FIFO_KHR)
-			{
-				presentMode = mode;
-				break;
-			}
+			supported = true;
+			break;
 		}
 	}
-	else
+	if (!supported)
 	{
-		bool supported = false;
-		for (const auto& mode : presentModes)
+		if (presentMode == VK_PRESENT_MODE_MAILBOX_KHR)
 		{
-			if (mode == m_presentMode)
+			for (const auto& mode : presentModes)
 			{
-				supported = true;
-				break;
+				// If mailbox is not supported, try immediate.
+				if (mode == VK_PRESENT_MODE_IMMEDIATE_KHR)
+				{
+					presentMode = mode;
+					supported = true;
+					Logger::warn("VK: Mailbox present mode not supported, falling back to immediate");
+					break;
+				}
 			}
 		}
+		// If mailbox and immediate are not supported, use fifo.
 		if (!supported)
+		{
+			if (m_presentMode != VK_PRESENT_MODE_FIFO_KHR)
+				Logger::warn("VK: Requested present mode not supported, falling back to FIFO");
 			presentMode = VK_PRESENT_MODE_FIFO_KHR;
+		}
 	}
 
 	m_presentMode = presentMode;
@@ -335,8 +351,7 @@ bool VulkanSwapchain::createDepthResources(VulkanDevice& device)
 
 bool VulkanSwapchain::createRenderPass(VkDevice device)
 {
-	std::array<VkAttachmentDescription2, 2> attachments{};
-	attachments[0].sType = VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2;
+	std::array<VkAttachmentDescription, 2> attachments{};
 	attachments[0].format = m_format;
 	attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
 	attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
@@ -346,7 +361,6 @@ bool VulkanSwapchain::createRenderPass(VkDevice device)
 	attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 	attachments[0].finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
-	attachments[1].sType = VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2;
 	attachments[1].format = m_depthFormat;
 	attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
 	attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
@@ -356,45 +370,47 @@ bool VulkanSwapchain::createRenderPass(VkDevice device)
 	attachments[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 	attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
-	VkAttachmentReference2 colorRef{};
-	colorRef.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
+	VkAttachmentReference colorRef{};
 	colorRef.attachment = 0;
 	colorRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-	colorRef.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-	VkAttachmentReference2 depthRef{};
-	depthRef.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
+	VkAttachmentReference depthRef{};
 	depthRef.attachment = 1;
 	depthRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-	depthRef.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
 
-	VkSubpassDescription2 subpass{};
-	subpass.sType = VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2;
+	VkSubpassDescription subpass{};
 	subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
 	subpass.colorAttachmentCount = 1;
 	subpass.pColorAttachments = &colorRef;
 	subpass.pDepthStencilAttachment = &depthRef;
 
-	VkSubpassDependency2 dependency{};
-	dependency.sType = VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2;
-	dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
-	dependency.dstSubpass = 0;
-	dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
-	dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
-	dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-	dependency.dependencyFlags = 0;
-	dependency.viewOffset = 0;
+	std::array<VkSubpassDependency, 2> dependencies{};
+	dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
+	dependencies[0].dstSubpass = 0;
+	dependencies[0].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+	dependencies[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+	dependencies[0].srcAccessMask = 0;
+	dependencies[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+	dependencies[0].dependencyFlags = 0;
 
-	VkRenderPassCreateInfo2 renderPassInfo{};
-	renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2;
+	dependencies[1].srcSubpass = 0;
+	dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
+	dependencies[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+	dependencies[1].dstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+	dependencies[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+	dependencies[1].dstAccessMask = 0;
+	dependencies[1].dependencyFlags = 0;
+
+	VkRenderPassCreateInfo renderPassInfo{};
+	renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
 	renderPassInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
 	renderPassInfo.pAttachments = attachments.data();
 	renderPassInfo.subpassCount = 1;
 	renderPassInfo.pSubpasses = &subpass;
-	renderPassInfo.dependencyCount = 1;
-	renderPassInfo.pDependencies = &dependency;
+	renderPassInfo.dependencyCount = static_cast<uint32_t>(dependencies.size());
+	renderPassInfo.pDependencies = dependencies.data();
 
-	if (vkCreateRenderPass2(device, &renderPassInfo, nullptr, &m_renderPass) != VK_SUCCESS)
+	if (vkCreateRenderPass(device, &renderPassInfo, nullptr, &m_renderPass) != VK_SUCCESS)
 		return m_error.Fail("VK: Failed to create render pass");
 
 	return true;

--- a/src/core/renderer/Vulkan/VulkanSwapchain.h
+++ b/src/core/renderer/Vulkan/VulkanSwapchain.h
@@ -20,7 +20,7 @@ public:
 	VulkanSwapchain(const VulkanSwapchain&) = delete;
 	VulkanSwapchain& operator=(const VulkanSwapchain&) = delete;
 
-	bool create(VulkanDevice& device, uint32_t width, uint32_t height);
+	bool create(VulkanDevice& device, uint32_t width, uint32_t height, bool vsync = true);
 	void destroy(VkDevice device, VmaAllocator allocator);
 	bool recreate(VulkanDevice& device, uint32_t width, uint32_t height);
 

--- a/src/ui/Settings/GraphicsSettingsWidget.cpp
+++ b/src/ui/Settings/GraphicsSettingsWidget.cpp
@@ -16,6 +16,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	ui->setupUi(m_rootWidget);
 
 	registerHelp(ui->rendererCombo, tr("Renderer"), tr("Select the graphics API used for rendering the 3D icons."));
+	registerHelp(ui->adapterCombo, tr("Graphics Adapter"), tr("Select the graphics adapter (GPU) to use for rendering."));
 	registerHelp(ui->cameraCombo, tr("Camera Angle"), tr("Change the camera angle used to view the 3D icons."));
 	registerHelp(ui->lightingCombo, tr("Lighting Mode"), tr("Select how the icons are lit."));
 	registerHelp(ui->thumbnailSizeSpinner, tr("Thumbnail Size"), tr("Adjust the size of the save icons in the main view."));
@@ -31,6 +32,16 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	ui->rendererCombo->addItem(tr("OpenGL"), "opengl");
 #if defined(__APPLE__)
 	ui->rendererCombo->addItem(tr("Metal"), "metal");
+#endif
+
+	ui->adapterCombo->clear();
+	ui->adapterCombo->addItem(tr("Default Adapter"), "");
+#if defined(ENABLE_VULKAN)
+	std::vector<std::string> vulkanAdapters = RendererFactory::getAvailableAdapters(RendererFactory::RendererType::Vulkan);
+	for (const auto& name : vulkanAdapters)
+	{
+		ui->adapterCombo->addItem(QString::fromStdString(name), QString::fromStdString(name));
+	}
 #endif
 
 	ui->cameraCombo->clear();
@@ -52,6 +63,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
 	ui->antialiasingCombo->addItem(tr("8x MSAA"), 8);
 
 	connect(ui->rendererCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &GraphicsSettingsWidget::onRendererChanged);
+	connect(ui->adapterCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsWidget::settingChanged);
 	connect(ui->cameraCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsWidget::settingChanged);
 	connect(ui->lightingCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsWidget::settingChanged);
 	connect(ui->thumbnailSizeSpinner, QOverload<int>::of(&QSpinBox::valueChanged), this, &SettingsWidget::settingChanged);
@@ -83,7 +95,16 @@ void GraphicsSettingsWidget::onRendererChanged(int index)
 	if (index < 0)
 		return;
 
+	updateAdapterComboState();
 	emit settingChanged();
+}
+
+void GraphicsSettingsWidget::updateAdapterComboState()
+{
+	QString currentRenderer = ui->rendererCombo->currentData().toString().toLower();
+	bool isGL = (currentRenderer == "opengl");
+	ui->adapterLabel->setVisible(!isGL);
+	ui->adapterCombo->setVisible(!isGL);
 }
 
 void GraphicsSettingsWidget::loadSettings()
@@ -96,6 +117,15 @@ void GraphicsSettingsWidget::loadSettings()
 	int rIdxData = ui->rendererCombo->findData(r);
 	if (rIdxData >= 0)
 		ui->rendererCombo->setCurrentIndex(rIdxData);
+
+	QString adapter = QString::fromStdString(config->getAdapter());
+	int adapterIdx = ui->adapterCombo->findData(adapter);
+	if (adapterIdx >= 0)
+		ui->adapterCombo->setCurrentIndex(adapterIdx);
+	else
+		ui->adapterCombo->setCurrentIndex(0);
+
+	updateAdapterComboState();
 
 	QString c = QString::fromStdString(config->getCameraMode()).toLower();
 	int cIdx = ui->cameraCombo->findData(c);
@@ -125,6 +155,7 @@ void GraphicsSettingsWidget::saveSettings()
 		return;
 
 	config->setRenderer(ui->rendererCombo->currentData().toString().toStdString());
+	config->setAdapter(ui->adapterCombo->currentData().toString().toStdString());
 	config->setCameraMode(ui->cameraCombo->currentData().toString().toStdString());
 	config->setLightingMode(ui->lightingCombo->currentData().toString().toStdString());
 	config->setThumbnailSize(ui->thumbnailSizeSpinner->value());
@@ -137,6 +168,7 @@ void GraphicsSettingsWidget::saveSettings()
 void GraphicsSettingsWidget::restoreDefaults()
 {
 	ui->rendererCombo->setCurrentIndex(0);
+	ui->adapterCombo->setCurrentIndex(0);
 	ui->cameraCombo->setCurrentIndex(0);
 	ui->lightingCombo->setCurrentIndex(0);
 	ui->thumbnailSizeSpinner->setValue(64);

--- a/src/ui/Settings/GraphicsSettingsWidget.h
+++ b/src/ui/Settings/GraphicsSettingsWidget.h
@@ -35,6 +35,8 @@ protected:
 	void changeEvent(QEvent* event) override;
 
 private:
+	void updateAdapterComboState();
+
 	std::unique_ptr<Ui::GraphicsSettingsWidget> ui;
 	QWidget* m_rootWidget = nullptr;
 };

--- a/src/ui/Settings/GraphicsSettingsWidget.ui
+++ b/src/ui/Settings/GraphicsSettingsWidget.ui
@@ -49,6 +49,19 @@ https://github.com/PCSX2/pcsx2
        <widget class="QComboBox" name="rendererCombo"/>
       </item>
       <item row="1" column="0">
+       <widget class="QLabel" name="adapterLabel">
+        <property name="text">
+         <string>Graphics Adapter:</string>
+        </property>
+        <property name="buddy">
+         <cstring>adapterCombo</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="adapterCombo"/>
+      </item>
+      <item row="2" column="0">
        <widget class="QLabel" name="cameraLabel">
         <property name="text">
          <string>Camera Angle:</string>
@@ -58,10 +71,10 @@ https://github.com/PCSX2/pcsx2
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QComboBox" name="cameraCombo"/>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="lightingLabel">
         <property name="text">
          <string>Lighting Mode:</string>
@@ -71,7 +84,7 @@ https://github.com/PCSX2/pcsx2
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QComboBox" name="lightingCombo"/>
       </item>
      </layout>
@@ -160,6 +173,9 @@ https://github.com/PCSX2/pcsx2
        <layout class="QHBoxLayout" name="horizontalLayout2">
         <item>
          <widget class="QSpinBox" name="fpsLimitSpinner">
+          <property name="specialValueText">
+           <string>Unlimited</string>
+          </property>
           <property name="minimum">
            <number>0</number>
           </property>
@@ -168,9 +184,6 @@ https://github.com/PCSX2/pcsx2
           </property>
           <property name="singleStep">
            <number>5</number>
-          </property>
-          <property name="specialValueText">
-           <string>Unlimited</string>
           </property>
           <property name="value">
            <number>30</number>
@@ -242,6 +255,7 @@ https://github.com/PCSX2/pcsx2
  </widget>
  <tabstops>
   <tabstop>rendererCombo</tabstop>
+  <tabstop>adapterCombo</tabstop>
   <tabstop>cameraCombo</tabstop>
   <tabstop>lightingCombo</tabstop>
   <tabstop>thumbnailSizeSpinner</tabstop>

--- a/src/ui/widgets/IconWidget.cpp
+++ b/src/ui/widgets/IconWidget.cpp
@@ -293,22 +293,18 @@ void IconWidget::startRendering()
 	m_renderLoopEnabled = true;
 
 	int maxFps = m_config ? m_config->getMaxFPS() : 30;
-	float rate;
+	int interval;
 
 	if (maxFps <= 0)
 	{
-		rate = getRefreshRate(this);
-		if (rate < 30.0f)
-			rate = 60.0f;
+		interval = 0;
 	}
 	else
 	{
-		rate = static_cast<float>(maxFps);
+		interval = static_cast<int>(1000.0f / static_cast<float>(maxFps));
+		if (interval <= 0)
+			interval = 1;
 	}
-
-	int interval = static_cast<int>(1000.0f / rate);
-	if (interval <= 0)
-		interval = 16;
 
 	m_renderTimer.start(interval, this);
 	renderFrame();
@@ -412,6 +408,15 @@ bool IconWidget::ensureRenderer()
 		{
 #if defined(ENABLE_VULKAN)
 			m_renderer = RendererFactory::createVulkanRenderer(wi, m_config, &rendererError);
+			if (!m_renderer)
+			{
+				Logger::warn("IconWidget: Vulkan initialization failed, falling back to OpenGL: {}",
+					rendererError.IsValid() ? rendererError.GetDescription() : "Unknown error");
+				rendererError.Clear();
+				m_renderer = RendererFactory::createOpenGLRenderer(wi, m_config, &rendererError);
+			}
+#else
+			m_renderer = RendererFactory::createOpenGLRenderer(wi, m_config, &rendererError);
 #endif
 		}
 
@@ -461,6 +466,9 @@ void IconWidget::recreateRenderer()
 
 void IconWidget::renderFrame()
 {
+	if (!isVisible())
+		return;
+
 	ensureRenderer();
 	if (!m_renderer)
 		return;
@@ -578,6 +586,12 @@ void IconWidget::showEvent(QShowEvent* event)
 	{
 		startRendering();
 	}
+}
+
+void IconWidget::hideEvent(QHideEvent* event)
+{
+	QWidget::hideEvent(event);
+	stopRendering();
 }
 
 QPaintEngine* IconWidget::paintEngine() const

--- a/src/ui/widgets/IconWidget.h
+++ b/src/ui/widgets/IconWidget.h
@@ -54,6 +54,7 @@ protected:
 	void timerEvent(QTimerEvent* event) override;
 	void resizeEvent(QResizeEvent* event) override;
 	void showEvent(QShowEvent* event) override;
+	void hideEvent(QHideEvent* event) override;
 	QPaintEngine* paintEngine() const override;
 	void mousePressEvent(QMouseEvent* event) override;
 	void mouseMoveEvent(QMouseEvent* event) override;

--- a/src/ui/widgets/SaveDetailsPanel.cpp
+++ b/src/ui/widgets/SaveDetailsPanel.cpp
@@ -229,9 +229,15 @@ void SaveDetailsPanel::createIconWidget()
 
 	iconWidget = new IconWidget(m_config, this);
 	if (m_config)
+	{
 		m_lastRendererType = m_config->getRenderer();
+		m_lastAdapter = m_config->getAdapter();
+	}
 	else
+	{
 		m_lastRendererType = "vulkan";
+		m_lastAdapter = "";
+	}
 
 	iconWidget->setMinimumSize(128, 128);
 	QSizePolicy sp(QSizePolicy::Expanding, QSizePolicy::MinimumExpanding);
@@ -246,7 +252,8 @@ void SaveDetailsPanel::createIconWidget()
 void SaveDetailsPanel::refreshConfig()
 {
 	std::string currentRenderer = m_config ? m_config->getRenderer() : "vulkan";
-	if (!iconWidget || currentRenderer != m_lastRendererType)
+	std::string currentAdapter = m_config ? m_config->getAdapter() : "";
+	if (!iconWidget || currentRenderer != m_lastRendererType || currentAdapter != m_lastAdapter)
 	{
 		createIconWidget();
 	}

--- a/src/ui/widgets/SaveDetailsPanel.h
+++ b/src/ui/widgets/SaveDetailsPanel.h
@@ -42,6 +42,7 @@ private:
 	QString currentModified;
 
 	std::string m_lastRendererType;
+	std::string m_lastAdapter;
 
 	std::unique_ptr<Ui::SaveDetailsPanel> ui;
 };


### PR DESCRIPTION
### Description of Changes
Added a GPU selection settings dropdown, fixed rendering sync validation errors, initialized the swapchain with the correct VSync config on startup, and stopped background rendering when the preview panel is closed.

### Rationale behind Changes
Fixes crashes on older Vulkan drivers/loaders, resolves validation hazards, and saves GPU usage when idle.

### Suggested Testing Steps
Change GPU adapter in settings, and make sure GPU usage drops when the preview widget is hidden.

### Related Issues / Links
Possibly Fixes #65

### Did you use AI to help find, test, or implement this issue or feature?
No