### PR TITLE
Formats: Fix RLE decompression for Keroro icons

### DIFF
--- a/docs/icon.md
+++ b/docs/icon.md
@@ -346,10 +346,8 @@ Compressed textures use a **simple RLE (Run-Length Encoding)** algorithm.
 #### Compression Layout
 
 - The first **u32** value specifies the **size of the compressed texture data**
-- The remaining data consists of repeating pairs:
-  - **u16 rle_code**
-  - **u16 rle_data**
-- These pairs continue until the compressed data size is exhausted
+- The remaining data consists of a **u16 rle_code** followed by variable data based on the rules below.
+- This continues until the compressed data size is exhausted.
 
 ---
 
@@ -360,12 +358,12 @@ Each RLE entry represents **x copies of rle_data repeated y times**.
 
 | Condition                      | x (data count)           | y (repeat count) |
 |--------------------------------|--------------------------|------------------|
-| `rle_code < 0xFF00`            | 1                        | `rle_code`      |
-| `rle_code >= 0xFF00`           | `0x10000 - rle_code`     | 1                |
+| `(rle_code & 0x8000) == 0`     | 1                        | `rle_code`       |
+| `(rle_code & 0x8000) != 0`     | `0x10000 - rle_code`     | 1                |
 
 In other words:
-- **Small rle_code** -> repeat a single value many times
-- **Large rle_code** -> copy multiple values once
+- **Small rle_code (MSB is 0)** -> repeat a single value many times (skipped if 0)
+- **Large rle_code (MSB is 1)** -> copy multiple values once
 
 ---
 

--- a/src/core/formats/ps2icon.cpp
+++ b/src/core/formats/ps2icon.cpp
@@ -331,7 +331,7 @@ namespace PS2Icon
 			uint16_t rleCode = readLE<uint16_t>(data, offset + rleOffset);
 			rleOffset += 2;
 
-			if ((rleCode & 0xFF00) == 0xFF00)
+			if ((rleCode & 0x8000) != 0)
 			{
 				uint32_t subLength = (0x10000 - rleCode);
 
@@ -355,23 +355,26 @@ namespace PS2Icon
 			{
 				uint32_t rep = rleCode;
 
-				if (compressedSize < rleOffset + 2)
+				if (rep > 0)
 				{
-					Logger::warn("PS2Icon: Compressed texture data too short (Repeat).");
-					break;
-				}
+					if (compressedSize < rleOffset + 2)
+					{
+						Logger::warn("PS2Icon: Compressed texture data too short (Repeat).");
+						break;
+					}
 
-				if (texOffset + rep > texture.size())
-				{
-					throw std::runtime_error("Decompressed texture exceeds size");
-				}
+					if (texOffset + rep > texture.size())
+					{
+						throw std::runtime_error("Decompressed texture exceeds size");
+					}
 
-				uint16_t value = readLE<uint16_t>(data, offset + rleOffset);
-				rleOffset += 2;
+					uint16_t value = readLE<uint16_t>(data, offset + rleOffset);
+					rleOffset += 2;
 
-				for (uint32_t i = 0; i < rep; ++i)
-				{
-					texture[texOffset++] = value;
+					for (uint32_t i = 0; i < rep; ++i)
+					{
+						texture[texOffset++] = value;
+					}
 				}
 			}
 		}

--- a/src/ui/widgets/SaveDetailsPanel.cpp
+++ b/src/ui/widgets/SaveDetailsPanel.cpp
@@ -218,7 +218,7 @@ void SaveDetailsPanel::updatePlayPauseButton()
 
 	const bool animating = iconWidget->isAnimationEnabled();
 	ui->playPauseButton->setIcon(
-		QIcon::fromTheme(animating ? QStringLiteral("pause-line") : QStringLiteral("play-line")));
+		QIcon::fromTheme(animating ? QStringLiteral("pause-line") : QStringLiteral("play-fill")));
 	ui->playPauseButton->setToolTip(
 		animating ? tr("Pause animation") : tr("Play animation"));
 }


### PR DESCRIPTION
### Description of Changes
Fixes the PS2 icon RLE decompression by using the correct MSB mask (`0x8000`) for literal runs and skipping pixel reads when `rep` is 0.

### Rationale behind Changes
Fixes runtime errors and loading failures when parsing/loading icons that are RLE compressed (like Keroro saves).

### Suggested Testing Steps
Check that Keroro save icons load correctly.

### Related Issues / Links
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No