### PR TITLE
Qt: Fix native widget refresh glitch on GNOME Wayland

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,10 +104,11 @@ endif()
 
 if(UNIX AND NOT APPLE)
     add_custom_command(TARGET myMCpp POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E echo "Copying resources folder to output directory..."
         COMMAND ${CMAKE_COMMAND} -E copy_directory
         ${CMAKE_SOURCE_DIR}/resources
         $<TARGET_FILE_DIR:myMCpp>/resources
-        COMMENT "Copying resources folder to output directory..."
+        VERBATIM
     )
 endif()
 

--- a/src/ui/MainWindow.ui
+++ b/src/ui/MainWindow.ui
@@ -41,7 +41,7 @@
         </property>
        </column>
       </widget>
-      <widget class="SaveDetailsPanel" name="detailsPanel" native="true"/>
+      <widget class="SaveDetailsPanel" name="detailsPanel"/>
      </widget>
     </item>
    </layout>

--- a/src/ui/QtMain.cpp
+++ b/src/ui/QtMain.cpp
@@ -35,6 +35,10 @@ static void initResourcePath(Config& config)
 
 int runQtMainApp(int argc, char* argv[], Config& config)
 {
+	// Workaround for QTBUG-133919: native widgets break refresh on GNOME/Weston Wayland.
+	QGuiApplication::setAttribute(Qt::AA_NativeWindows, false);
+	QGuiApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings, true);
+
 	QApplication app(argc, argv);
 	initResourcePath(config);
 	app.setApplicationName(MYMCpp_APP_NAME);

--- a/src/ui/widgets/SaveDetailsPanel.ui
+++ b/src/ui/widgets/SaveDetailsPanel.ui
@@ -18,7 +18,7 @@
      </property>
      <layout class="QVBoxLayout" name="iconLayout">
       <item>
-       <widget class="QWidget" name="iconContainer" native="true">
+       <widget class="QWidget" name="iconContainer">
         <property name="minimumSize">
          <size>
           <width>256</width>


### PR DESCRIPTION
### Description of Changes
Seems that we hit the same issue as pcsx2 #12333 (https://qt-project.atlassian.net/browse/QTBUG-133919)

### Rationale behind Changes
Because Wayland on GNOME was broke

### Suggested Testing Steps
Test if the icon is broken on macOS, Windows, or other Linux environments 

### Related Issues / Links
Fixes #85 

### Did you use AI to help find, test, or implement this issue or feature?
No