### PR TITLE
Qt/Formats: Redesign card creation dialog and auto detect ECC

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-	<code>myMCpp</code> is a PlayStation 2 memory card manager. It works with <code>.ps2</code> images (PCSX2) and <code>.mc2</code> files (MemCard PRO2).
+	<code>myMCpp</code> is a PlayStation 2 memory card manager for <code>.ps2</code>, <code>.mc2</code>, <code>.mcd</code>, <code>.vm2</code>, and raw VMC files.
 </p>
 
 <p align="center">
@@ -60,7 +60,7 @@ Global options:
 - `--version`: Show version information.
 - `-h`, `--help`: Show help.
 - `-i`, `--ignore-ecc`: Ignore ECC errors while reading.
-- `-e`, `--no-ecc`: Create without ECC (useful for virtual cards such as SD2PSX).
+- `-e`, `--no-ecc`: Create without ECC (also the default for raw formats).
 
 ## License
 

--- a/src/cli/ps2mc_cli.cpp
+++ b/src/cli/ps2mc_cli.cpp
@@ -41,7 +41,7 @@ void PS2McCommandLine::printHelp()
 			  << "   --version         Show version information\n"
 			  << "   -h, --help        Show this help message\n"
 			  << "   -i, --ignore-ecc  Ignore ECC errors while reading\n"
-			  << "   -e, --no-ecc      Create virtual memory card without ECC\n";
+			  << "   -e, --no-ecc      Create without ECC (default for raw formats)\n";
 }
 
 void PS2McCommandLine::printVersion()
@@ -137,7 +137,7 @@ int PS2McCommandLine::execute(int argc, char* argv[])
 		try
 		{
 			memoryCard = std::make_unique<PS2MemoryCard>();
-			memoryCard->open(memcardPath);
+			memoryCard->open(memcardPath, ignoreEcc);
 		}
 		catch (const std::exception& e)
 		{
@@ -597,7 +597,7 @@ int PS2McCommandLine::cmdFormat(const std::vector<std::string>& args)
 	try
 	{
 		auto mc = std::make_unique<PS2MemoryCard>();
-		mc->create(args[0], 8); // 8 MB default
+		mc->create(args[0], 8, noEcc || !PS2MemoryCard::usesEccForPath(args[0])); // 8 MB default
 		return 0;
 	}
 	catch (const std::exception& e)

--- a/src/core/formats/ps2mc.cpp
+++ b/src/core/formats/ps2mc.cpp
@@ -40,6 +40,40 @@ T readLE(const std::vector<uint8_t>& buf, size_t offset)
 	return value;
 }
 
+const std::vector<PS2MemoryCard::CardFormat>& PS2MemoryCard::getFormats()
+{
+	static const std::vector<CardFormat> formats = {
+		{"PCSX2", "PCSX2 (*.ps2)", "ps2", true},
+		{"MemCard PRO2", "MemCard PRO2 (*.mc2)", "mc2", false},
+		{"SD2PSX", "SD2PSX (*.mcd)", "mcd", false},
+		{"PS3 VMC", "PS3 VMC (*.vm2)", "vm2", true},
+		{"Raw VMC", "Raw VMC (*.bin)", "bin", false},
+		{"Raw VMC", "Raw VMC (*.vmc)", "vmc", false},
+		{"Raw VMC", "Raw VMC (*.mc)", "mc", false},
+	};
+	return formats;
+}
+
+bool PS2MemoryCard::usesEccForPath(const std::string& path, bool unknownFallback)
+{
+	std::filesystem::path p(path);
+	std::string ext = p.extension().string();
+	if (ext.empty())
+		return unknownFallback;
+
+	ext = ext.substr(1);
+
+	for (char& c : ext)
+		c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+
+	for (const CardFormat& format : getFormats())
+	{
+		if (ext == format.extension)
+			return format.usesEcc;
+	}
+	return unknownFallback;
+}
+
 static void renameReplace(const std::filesystem::path& target, const std::filesystem::path& tmp)
 {
 	std::error_code ec;
@@ -95,6 +129,10 @@ public:
 	std::map<uint32_t, std::vector<uint8_t>> fat_cluster_cache;
 
 	void calculate_derived();
+	void parse_superblock_fields(const std::vector<uint8_t>& page);
+	std::vector<uint8_t> load_superblock();
+	void apply_layout(bool ecc, std::vector<uint8_t> sb_page);
+	bool root_directory_ok();
 	void read_superblock();
 	std::vector<uint8_t> read_page(uint32_t page_num);
 	void write_page(uint32_t page_num, const std::vector<uint8_t>& data);
@@ -128,6 +166,55 @@ void PS2MemoryCard::Impl::calculate_derived()
 	entries_per_cluster = cluster_size / 4; // 4 bytes per FAT entry
 }
 
+void PS2MemoryCard::Impl::parse_superblock_fields(const std::vector<uint8_t>& page)
+{
+	page_size = readLE<uint16_t>(page, 40);
+	pages_per_cluster = readLE<uint16_t>(page, 42);
+	pages_per_erase_block = readLE<uint16_t>(page, 44);
+
+	if (page_size == 0 || pages_per_cluster == 0)
+	{
+		throw PS2McCorrupt("Invalid page/cluster size in superblock");
+	}
+
+	calculate_derived();
+
+	clusters_per_card = readLE<uint32_t>(page, 48);
+	allocatable_cluster_offset = readLE<uint32_t>(page, 52);
+	allocatable_cluster_end = readLE<uint32_t>(page, 56);
+	rootdir_fat_cluster = readLE<uint32_t>(page, 60);
+
+	for (int i = 0; i < 32; ++i)
+	{
+		indirect_fat_cluster_list[i] = readLE<uint32_t>(page, 80 + i * 4);
+	}
+
+	if (page.size() > 0x44 + 4)
+	{
+		backup_block1 = readLE<uint32_t>(page, 0x40);
+		backup_block2 = readLE<uint32_t>(page, 0x44);
+	}
+
+	if (page.size() > 0x151)
+	{
+		card_type = page[0x150];
+		card_flags = page[0x151];
+	}
+
+	if (page.size() > 0xD0 + 32 * 4)
+	{
+		for (int i = 0; i < 32; ++i)
+		{
+			bad_block_list[i] = readLE<uint32_t>(page, 0xD0 + i * 4);
+		}
+	}
+
+	if (allocatable_cluster_end == 0 || allocatable_cluster_end > 1000000)
+	{
+		allocatable_cluster_end = clusters_per_card;
+	}
+}
+
 std::vector<uint8_t> PS2MemoryCard::Impl::read_page(uint32_t page_num)
 {
 	if (!file.is_open())
@@ -156,7 +243,7 @@ std::vector<uint8_t> PS2MemoryCard::Impl::read_page(uint32_t page_num)
 		throw PS2McIOError("Failed to read complete page");
 	}
 
-	if (!ignore_ecc && spare_size > 0)
+	if (spare_size > 0)
 	{
 		std::vector<uint8_t> spare(spare_size);
 		file.read(reinterpret_cast<char*>(spare.data()), spare_size);
@@ -166,15 +253,10 @@ std::vector<uint8_t> PS2MemoryCard::Impl::read_page(uint32_t page_num)
 			throw PS2McIOError("Failed to read ECC spare data");
 		}
 
-		try
+		const int ecc_status = eccCheckPage(page_data, spare, page_size);
+		if (ecc_status == ECC_CHECK_FAILED && !ignore_ecc)
 		{
-			auto ecc_status = eccCheckPage(page_data, spare, page_size);
-			(void)ecc_status;
-		}
-		catch (...)
-		{
-			// If ECC check fails, we might be dealing with a non-ECC card
-			// Continue anyway
+			throw PS2McCorrupt("Unrecoverable ECC error (page " + std::to_string(page_num) + ")");
 		}
 	}
 
@@ -207,7 +289,7 @@ void PS2MemoryCard::Impl::write_page(uint32_t page_num, const std::vector<uint8_
 		throw PS2McIOError("Failed to write page");
 	}
 
-	if (!ignore_ecc && spare_size > 0)
+	if (spare_size > 0)
 	{
 		std::vector<uint8_t> spare(spare_size, 0);
 		try
@@ -335,9 +417,15 @@ void PS2MemoryCard::Impl::read_fat_from_card()
 	}
 }
 
-void PS2MemoryCard::Impl::read_superblock()
+std::vector<uint8_t> PS2MemoryCard::Impl::load_superblock()
 {
-	auto sb_page = read_page(0);
+	file.seekg(0, std::ios::beg);
+	std::vector<uint8_t> sb_page(page_size);
+	file.read(reinterpret_cast<char*>(sb_page.data()), page_size);
+	if (file.gcount() != static_cast<std::streamsize>(page_size))
+	{
+		throw PS2McIOError("Failed to read superblock");
+	}
 
 	const char* MAGIC = "Sony PS2 Memory Card Format ";
 	if (sb_page.size() < 28 || std::memcmp(sb_page.data(), MAGIC, 28) != 0)
@@ -345,77 +433,74 @@ void PS2MemoryCard::Impl::read_superblock()
 		throw PS2McCorrupt("Invalid memory card magic");
 	}
 
-	page_size = readLE<uint16_t>(sb_page, 40);
-	pages_per_cluster = readLE<uint16_t>(sb_page, 42);
-	pages_per_erase_block = readLE<uint16_t>(sb_page, 44);
+	parse_superblock_fields(sb_page);
+	return sb_page;
+}
 
-	if (page_size == 0 || pages_per_cluster == 0)
+void PS2MemoryCard::Impl::apply_layout(bool ecc, std::vector<uint8_t> sb_page)
+{
+	page_cache.clear();
+	fat_cluster_cache.clear();
+	parse_superblock_fields(sb_page);
+
+	if (ecc)
 	{
-		throw PS2McCorrupt("Invalid page/cluster size in superblock");
-	}
-
-	calculate_derived();
-
-	clusters_per_card = readLE<uint32_t>(sb_page, 48); // offset 48-51
-	allocatable_cluster_offset = readLE<uint32_t>(sb_page, 52); // offset 52-55
-	allocatable_cluster_end = readLE<uint32_t>(sb_page, 56); // offset 56-59
-	rootdir_fat_cluster = readLE<uint32_t>(sb_page, 60); // offset 60-63
-
-	for (int i = 0; i < 32; ++i)
-	{
-		indirect_fat_cluster_list[i] = readLE<uint32_t>(sb_page, 80 + i * 4);
-	}
-
-	if (sb_page.size() > 0x44 + 4)
-	{
-		backup_block1 = readLE<uint32_t>(sb_page, 0x40);
-		backup_block2 = readLE<uint32_t>(sb_page, 0x44);
-	}
-
-	if (sb_page.size() > 0x151)
-	{
-		card_type = sb_page[0x150];
-		card_flags = sb_page[0x151];
-
-		if ((card_flags & 0x01) == 0)
+		with_ecc = true;
+		if (spare_size > 0)
 		{
-			with_ecc = false;
+			std::vector<uint8_t> spare(spare_size);
+			file.seekg(page_size, std::ios::beg);
+			file.read(reinterpret_cast<char*>(spare.data()), spare_size);
+			if (file.gcount() == static_cast<std::streamsize>(spare_size))
+			{
+				std::vector<uint8_t> page = sb_page;
+				const int ecc_status = eccCheckPage(page, spare, static_cast<int>(page_size));
+				if (ecc_status != ECC_CHECK_FAILED)
+				{
+					sb_page = std::move(page);
+					if (ecc_status == ECC_CHECK_CORRECTED)
+						parse_superblock_fields(sb_page);
+				}
+			}
 		}
 	}
-
-	if (sb_page.size() > 0xD0 + 32 * 4)
+	else
 	{
-		for (int i = 0; i < 32; ++i)
-		{
-			bad_block_list[i] = readLE<uint32_t>(sb_page, 0xD0 + i * 4);
-		}
+		spare_size = 0;
+		raw_page_size = page_size;
+		with_ecc = false;
 	}
 
-	if (allocatable_cluster_end == 0 || allocatable_cluster_end > 1000000)
-	{
-		allocatable_cluster_end = clusters_per_card;
-	}
-
-	{
-		uint32_t total_pages = clusters_per_card * pages_per_cluster;
-		uint64_t expected_with_ecc = static_cast<uint64_t>(total_pages) * (page_size + spare_size);
-		uint64_t expected_no_ecc = static_cast<uint64_t>(total_pages) * page_size;
-
-		file.seekg(0, std::ios::end);
-		uint64_t file_size = static_cast<uint64_t>(file.tellg());
-		file.seekg(0, std::ios::beg);
-
-		if (file_size <= expected_no_ecc || file_size < expected_with_ecc)
-		{
-			spare_size = 0;
-			raw_page_size = page_size;
-			ignore_ecc = true;
-			with_ecc = false;
-			page_cache.clear();
-		}
-	}
-
+	page_cache[0] = std::move(sb_page);
 	read_fat_from_card();
+}
+
+bool PS2MemoryCard::Impl::root_directory_ok()
+{
+	const auto entries = read_dirents(rootdir_fat_cluster);
+	return entries.size() >= 2 &&
+	       entries[0].name == "." &&
+	       entries[1].name == ".." &&
+	       (entries[0].mode & DF_DIR) &&
+	       (entries[1].mode & DF_DIR);
+}
+
+void PS2MemoryCard::Impl::read_superblock()
+{
+	auto sb_page = load_superblock();
+
+	const uint32_t total_pages = clusters_per_card * pages_per_cluster;
+	const uint32_t ecc_spare = divRoundUp(page_size, 128) * 4;
+	const uint64_t expected_with_ecc = static_cast<uint64_t>(total_pages) * (page_size + ecc_spare);
+
+	file.seekg(0, std::ios::end);
+	const uint64_t file_size = static_cast<uint64_t>(file.tellg());
+
+	bool ecc = with_ecc;
+	if (file_size < expected_with_ecc)
+		ecc = false;
+
+	apply_layout(ecc, std::move(sb_page));
 }
 
 uint32_t PS2MemoryCard::Impl::lookup_fat(uint32_t cluster_num)
@@ -789,9 +874,10 @@ PS2MemoryCard::~PS2MemoryCard()
 	}
 }
 
-void PS2MemoryCard::open(const std::string& path)
+void PS2MemoryCard::open(const std::string& path, bool ignoreEcc)
 {
 	pImpl->filename = path;
+	pImpl->ignore_ecc = ignoreEcc;
 	pImpl->file.open(path, std::ios::in | std::ios::out | std::ios::binary);
 
 	if (!pImpl->file)
@@ -803,7 +889,35 @@ void PS2MemoryCard::open(const std::string& path)
 		}
 	}
 
-	pImpl->read_superblock();
+	auto sb_page = pImpl->load_superblock();
+
+	const uint32_t total_pages = pImpl->clusters_per_card * pImpl->pages_per_cluster;
+	const uint32_t ecc_spare = divRoundUp(pImpl->page_size, 128) * 4;
+	const uint64_t expected_with_ecc =
+		static_cast<uint64_t>(total_pages) * (pImpl->page_size + ecc_spare);
+
+	pImpl->file.seekg(0, std::ios::end);
+	const uint64_t file_size = static_cast<uint64_t>(pImpl->file.tellg());
+	const bool can_ecc = file_size >= expected_with_ecc;
+
+	auto try_layout = [this, &sb_page](bool ecc) {
+		pImpl->apply_layout(ecc, sb_page);
+		try
+		{
+			return pImpl->root_directory_ok();
+		}
+		catch (...)
+		{
+			return false;
+		}
+	};
+
+	if (can_ecc && try_layout(true))
+		return;
+	if (try_layout(false))
+		return;
+
+	throw PS2McCorrupt("Root directory damaged");
 }
 
 void PS2MemoryCard::close()
@@ -824,7 +938,6 @@ void PS2MemoryCard::Impl::init_card_parameters(int sizeInMB, bool disableEcc)
 	pages_per_erase_block = 16;
 	clusters_per_card = (sizeInMB * 1024 * 1024) / 1024;
 	with_ecc = !disableEcc;
-	ignore_ecc = disableEcc;
 
 	if (disableEcc)
 	{
@@ -914,6 +1027,8 @@ void PS2MemoryCard::Impl::write_superblock(uint32_t first_ifc, uint32_t indirect
 
 	sb[336] = 2;
 	sb[337] = with_ecc ? 0x2B : 0x2A;
+	card_type = 2;
+	card_flags = sb[337];
 
 	write_page(0, sb);
 
@@ -2229,7 +2344,6 @@ void PS2MemoryCard::saveAs(const std::string& filename, bool withEcc)
 	renameReplace(dest, tmpPath);
 
 	pImpl->with_ecc = withEcc;
-	pImpl->ignore_ecc = !withEcc;
 	if (withEcc)
 	{
 		pImpl->calculate_derived();

--- a/src/core/formats/ps2mc.h
+++ b/src/core/formats/ps2mc.h
@@ -80,6 +80,14 @@ public:
 class PS2MemoryCard
 {
 public:
+	struct CardFormat
+	{
+		const char* displayName;
+		const char* filterName;
+		const char* extension;
+		bool usesEcc;
+	};
+
 	struct CardInfo
 	{
 		uint64_t imageSizeBytes = 0;
@@ -107,7 +115,10 @@ public:
 	PS2MemoryCard();
 	~PS2MemoryCard();
 
-	void open(const std::string& filename);
+	static const std::vector<CardFormat>& getFormats();
+	static bool usesEccForPath(const std::string& path, bool unknownFallback = true);
+
+	void open(const std::string& filename, bool ignoreEcc = false);
 	void close();
 	void create(const std::string& filename, int sizeInMB = 8, bool disableEcc = false);
 

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -33,14 +33,11 @@ namespace
 	QString getCardTypeLabelFromPath(const QString& cardPath)
 	{
 		const QString ext = QFileInfo(cardPath).suffix().toLower();
-		if (ext == QStringLiteral("ps2"))
-			return QCoreApplication::translate("MainWindow", "PCSX2");
-		if (ext == QStringLiteral("mc2") || ext == QStringLiteral("mcd"))
-			return QCoreApplication::translate("MainWindow", "MemCard PRO2");
-		if (ext == QStringLiteral("vm2") || ext == QStringLiteral("vmc"))
-			return QCoreApplication::translate("MainWindow", "PS3 VMC");
-		if (ext == QStringLiteral("bin") || ext == QStringLiteral("mc"))
-			return QCoreApplication::translate("MainWindow", "Raw");
+		for (const PS2MemoryCard::CardFormat& format : PS2MemoryCard::getFormats())
+		{
+			if (ext == QLatin1String(format.extension))
+				return QCoreApplication::translate("CardFormats", format.displayName);
+		}
 		return QCoreApplication::translate("MainWindow", "Memory Card");
 	}
 
@@ -62,6 +59,36 @@ namespace
 		const QString pathA = QFileInfo(a).canonicalFilePath();
 		const QString pathB = QFileInfo(b).canonicalFilePath();
 		return !pathA.isEmpty() && pathA == pathB;
+	}
+
+	QString memoryCardOpenFilter()
+	{
+		QStringList patterns;
+		QStringList filters;
+		for (const PS2MemoryCard::CardFormat& format : PS2MemoryCard::getFormats())
+		{
+			patterns.append(QStringLiteral("*.") + QLatin1String(format.extension));
+			filters.append(QCoreApplication::translate("CardFormats", format.filterName));
+		}
+		filters.prepend(QCoreApplication::translate("MainWindow", "All Memory Cards (%1)").arg(patterns.join(QLatin1Char(' '))));
+		filters.append(QCoreApplication::translate("MainWindow", "All Files (*.*)"));
+		return filters.join(QStringLiteral(";;"));
+	}
+
+	QString memoryCardSaveFilter(const QString& preferredExt = {})
+	{
+		QStringList filters;
+		const QString preferred = preferredExt.toLower();
+		for (const PS2MemoryCard::CardFormat& format : PS2MemoryCard::getFormats())
+		{
+			const QString label = QCoreApplication::translate("CardFormats", format.filterName);
+			if (preferred == QLatin1String(format.extension))
+				filters.prepend(label);
+			else
+				filters.append(label);
+		}
+		filters.append(QCoreApplication::translate("MainWindow", "All Files (*.*)"));
+		return filters.join(QStringLiteral(";;"));
 	}
 } // namespace
 
@@ -672,12 +699,7 @@ void MainWindow::onOpenMemoryCard()
 		this,
 		tr("Open Memory Card"),
 		memoryCardDir,
-		tr("All Memory Cards (*.ps2 *.vm2 *.vmc *.mc2 *.mcd *.bin *.mc);;"
-		   "PCSX2 Memory Card (*.ps2);;"
-		   "PS3 Virtual Memory Card (*.vm2 *.vmc);;"
-		   "MemCard PRO2 (*.mc2 *.mcd);;"
-		   "Raw Memory Card (*.bin *.mc);;"
-		   "All Files (*.*)"));
+		memoryCardOpenFilter());
 
 	if (filename.isEmpty())
 	{
@@ -728,24 +750,26 @@ void MainWindow::onCreateMemoryCard()
 {
 	NewCardDialog optionsDialog(this);
 	if (optionsDialog.exec() != QDialog::Accepted)
-	{
 		return;
-	}
 
-	int sizeMB = optionsDialog.getCardSizeMB();
-	bool disableEcc = optionsDialog.getDisableEcc();
-
+	const int sizeMB = optionsDialog.getCardSizeMB();
+	const QString ext = optionsDialog.getCardExtension();
+	const bool disableEcc = !optionsDialog.usesEcc();
+	const QString fileName = optionsDialog.getFileName();
 	const QString memoryCardDir = QtUtils::resolveConfigFolderPath(m_config->getMemoryCardFolder());
+	QDir().mkpath(memoryCardDir);
+
 	QString filename = QFileDialog::getSaveFileName(
 		this,
 		tr("Create Memory Card"),
-		memoryCardDir + QStringLiteral("/Mcd001.ps2"),
-		tr("PCSX2 Memory Card (*.ps2);;MemCard PRO2 (*.mc2 *.mcd);;All Files (*.*)"));
+		QDir(memoryCardDir).filePath(fileName),
+		memoryCardSaveFilter(ext));
 
 	if (filename.isEmpty())
-	{
 		return;
-	}
+
+	if (QFileInfo(filename).suffix().isEmpty())
+		filename += QLatin1Char('.') + ext;
 
 	if (QFile::exists(filename))
 	{
@@ -760,9 +784,7 @@ void MainWindow::onCreateMemoryCard()
 			QMessageBox::No);
 
 		if (reply != QMessageBox::Yes)
-		{
 			return;
-		}
 	}
 
 	closeCard();
@@ -794,7 +816,7 @@ void MainWindow::onCreateMemoryCard()
 			m_discordRpc->setCardOpenContext(makeCardDisplayLabel(currentCardPath));
 		}
 
-		ui->statusBar->showMessage(tr("Created %1 MB memory card").arg(sizeMB), 5000);
+		ui->statusBar->showMessage(tr("Created %1").arg(QFileInfo(filename).fileName()), 5000);
 	}
 }
 
@@ -1421,7 +1443,7 @@ void MainWindow::onSaveAs()
 		this,
 		tr("Save Copy As..."),
 		defaultPath,
-		tr("PCSX2 Memory Card (*.ps2);;MemCard PRO2 (*.mc2 *.mcd);;All Files (*.*)"));
+		memoryCardSaveFilter());
 
 	if (filename.isEmpty())
 		return;
@@ -1569,7 +1591,7 @@ void MainWindow::onEccTool()
 		this,
 		dialogTitle,
 		defaultPath,
-		tr("All Memory Cards (*.ps2 *.vm2 *.vmc *.mc2 *.mcd);;PCSX2 Memory Card (*.ps2);;PS3 Virtual Memory Card (*.vm2 *.vmc);;MemCard PRO2 (*.mc2 *.mcd);;All Files (*.*)"));
+		memoryCardOpenFilter());
 
 	if (filename.isEmpty())
 		return;

--- a/src/ui/dialogs/NewCardDialog.cpp
+++ b/src/ui/dialogs/NewCardDialog.cpp
@@ -2,85 +2,108 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "NewCardDialog.h"
-#include <QButtonGroup>
+#include "ps2mc.h"
 #include <QIcon>
 #include <QPushButton>
+#include <QSignalBlocker>
 
 NewCardDialog::NewCardDialog(QWidget* parent)
 	: QDialog(parent)
 	, ui(new Ui::NewCardDialog)
 {
 	ui->setupUi(this);
-	ui->introIconLabel->setPixmap(QIcon::fromTheme(QStringLiteral("memcard-line")).pixmap(32, 32));
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
-	sizeGroup = new QButtonGroup(this);
-	sizeGroup->addButton(ui->size8MB, 8);
-	sizeGroup->addButton(ui->size16MB, 16);
-	sizeGroup->addButton(ui->size32MB, 32);
-	sizeGroup->addButton(ui->size64MB, 64);
+	ui->iconLabel->setPixmap(QIcon::fromTheme(QStringLiteral("memcard-line")).pixmap(ui->iconLabel->size()));
 
-	connect(sizeGroup, &QButtonGroup::idClicked, this, [this](int) {
-		updateSelectionDetails();
-	});
-	connect(ui->disableEccCheckbox, &QCheckBox::toggled, this, [this](bool) {
-		updateSelectionDetails();
-	});
+	ui->sizeButtonGroup->setId(ui->size8MB, 8);
+	ui->sizeButtonGroup->setId(ui->size16MB, 16);
+	ui->sizeButtonGroup->setId(ui->size32MB, 32);
+	ui->sizeButtonGroup->setId(ui->size64MB, 64);
 
+	connect(ui->nameEdit, &QLineEdit::textChanged, this, &NewCardDialog::nameTextChanged);
+
+	retranslateFormatCombo();
 	if (QPushButton* okButton = ui->buttonBox->button(QDialogButtonBox::Ok))
-	{
 		okButton->setText(tr("Continue..."));
-	}
 
-	updateSelectionDetails();
+	ui->nameEdit->setFocus();
+	updateState();
 }
 
-NewCardDialog::~NewCardDialog()
+NewCardDialog::~NewCardDialog() = default;
+
+void NewCardDialog::retranslateFormatCombo()
 {
+	const QString ext = ui->formatCombo->currentData().toString();
+	ui->formatCombo->clear();
+	for (const PS2MemoryCard::CardFormat& format : PS2MemoryCard::getFormats())
+		ui->formatCombo->addItem(QCoreApplication::translate("CardFormats", format.filterName), QLatin1String(format.extension));
+
+	const int idx = ui->formatCombo->findData(ext);
+	if (idx >= 0)
+		ui->formatCombo->setCurrentIndex(idx);
+}
+
+void NewCardDialog::nameTextChanged()
+{
+	QString name = ui->nameEdit->text();
+	const int cursorPos = ui->nameEdit->cursorPosition();
+	name.remove(QLatin1Char('.'));
+
+	QSignalBlocker sb(ui->nameEdit);
+	ui->nameEdit->setText(name);
+	ui->nameEdit->setCursorPosition(cursorPos);
+
+	updateState();
+}
+
+void NewCardDialog::updateState()
+{
+	if (QPushButton* okButton = ui->buttonBox->button(QDialogButtonBox::Ok))
+		okButton->setEnabled(!ui->nameEdit->text().trimmed().isEmpty());
 }
 
 void NewCardDialog::changeEvent(QEvent* event)
 {
-	if (event->type() == QEvent::LanguageChange)
+	if (event->type() == QEvent::LanguageChange && ui)
 	{
-		if (ui)
-		{
-			ui->retranslateUi(this);
-			updateSelectionDetails();
-		}
+		ui->retranslateUi(this);
+		retranslateFormatCombo();
+		if (QPushButton* okButton = ui->buttonBox->button(QDialogButtonBox::Ok))
+			okButton->setText(tr("Continue..."));
+		updateState();
 	}
 	QDialog::changeEvent(event);
 }
 
 int NewCardDialog::getCardSizeMB() const
 {
-	return sizeGroup->checkedId();
+	return ui->sizeButtonGroup->checkedId();
 }
 
-bool NewCardDialog::getDisableEcc() const
+QString NewCardDialog::getCardName() const
 {
-	return ui->disableEccCheckbox->isChecked();
+	return ui->nameEdit->text().trimmed();
 }
 
-void NewCardDialog::updateSelectionDetails()
+QString NewCardDialog::getCardExtension() const
 {
-	const int sizeMB = getCardSizeMB();
-	const bool disableEcc = getDisableEcc();
+	return ui->formatCombo->currentData().toString();
+}
 
-	QString sizeText;
-	if (sizeMB == 8)
-		sizeText = tr("Best compatibility");
-	else if (sizeMB == 16 || sizeMB == 32)
-		sizeText = tr("Good compatibility with most titles");
-	else
-		sizeText = tr("Lower compatibility in some games");
+bool NewCardDialog::usesEcc() const
+{
+	const QString ext = getCardExtension();
+	for (const PS2MemoryCard::CardFormat& format : PS2MemoryCard::getFormats())
+	{
+		if (ext == QLatin1String(format.extension))
+			return format.usesEcc;
+	}
+	return true;
+}
 
-	const QString eccText = disableEcc
-		? tr("ECC disabled (smaller raw image)")
-		: tr("ECC enabled (recommended default)");
-
-	ui->selectionSummaryLabel->setText(
-		tr("Current selection: %1 MB\n%2\n%3")
-			.arg(sizeMB)
-			.arg(sizeText)
-			.arg(eccText));
+QString NewCardDialog::getFileName() const
+{
+	return getCardName() + QLatin1Char('.') + getCardExtension();
 }

--- a/src/ui/dialogs/NewCardDialog.h
+++ b/src/ui/dialogs/NewCardDialog.h
@@ -9,9 +9,6 @@
 
 #include "ui_NewCardDialog.h"
 
-class QRadioButton;
-class QButtonGroup;
-
 class NewCardDialog : public QDialog
 {
 	Q_OBJECT
@@ -22,14 +19,18 @@ public:
 	~NewCardDialog();
 
 	int getCardSizeMB() const;
-	bool getDisableEcc() const;
+	QString getCardName() const;
+	QString getCardExtension() const;
+	bool usesEcc() const;
+	QString getFileName() const;
 
 protected:
 	void changeEvent(QEvent* event) override;
 
 private:
-	void updateSelectionDetails();
+	void retranslateFormatCombo();
+	void nameTextChanged();
+	void updateState();
 
 	std::unique_ptr<Ui::NewCardDialog> ui;
-	QButtonGroup* sizeGroup;
 };

--- a/src/ui/dialogs/NewCardDialog.ui
+++ b/src/ui/dialogs/NewCardDialog.ui
@@ -6,197 +6,254 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>460</width>
-    <height>540</height>
+    <width>480</width>
+    <height>507</height>
    </rect>
   </property>
-  <property name="minimumSize">
-   <size>
-    <width>430</width>
-    <height>0</height>
-   </size>
-  </property>
   <property name="windowTitle">
-   <string>Create New Memory Card</string>
+   <string>Create Memory Card</string>
   </property>
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="mainLayout">
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <property name="leftMargin">
+    <number>12</number>
+   </property>
+   <property name="topMargin">
+    <number>12</number>
+   </property>
+   <property name="rightMargin">
+    <number>12</number>
+   </property>
+   <property name="bottomMargin">
+    <number>12</number>
+   </property>
    <item>
-    <layout class="QHBoxLayout" name="headerLayout">
+    <layout class="QHBoxLayout" name="headerLayout" stretch="0,1">
+     <property name="spacing">
+      <number>10</number>
+     </property>
+     <property name="bottomMargin">
+      <number>10</number>
+     </property>
      <item>
-      <widget class="QLabel" name="introIconLabel">
+      <widget class="QLabel" name="iconLabel">
        <property name="minimumSize">
         <size>
-         <width>36</width>
-         <height>36</height>
+         <width>48</width>
+         <height>48</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>36</width>
-         <height>36</height>
+         <width>48</width>
+         <height>48</height>
         </size>
        </property>
-       <property name="text">
-        <string/>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QLabel" name="introLabel">
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Create Memory Card&lt;/span&gt;&lt;br/&gt;Pick a name, format, and size. 8 MB is safest for compatibility.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::TextFormat::RichText</enum>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+       </property>
        <property name="wordWrap">
         <bool>true</bool>
-       </property>
-       <property name="text">
-        <string>Choose the size and format for your new memory card. Smaller cards are usually the safest choice for game compatibility.</string>
        </property>
       </widget>
      </item>
     </layout>
    </item>
    <item>
-    <widget class="QGroupBox" name="sizeGroup">
-     <property name="title">
-      <string>Card Size Preset</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="QRadioButton" name="size8MB">
-        <property name="text">
-         <string>8 MB (Recommended)</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="size8Hint">
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Official size used by standard PS2 cards. Best overall compatibility.</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="size16MB">
-        <property name="text">
-         <string>16 MB</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="size16Hint">
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Expanded capacity with generally good compatibility in many titles.</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="size32MB">
-        <property name="text">
-         <string>32 MB</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="size32Hint">
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Larger third-party style size. Useful when you need extra space.</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="size64MB">
-        <property name="text">
-         <string>64 MB</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="size64Hint">
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Very large card size. Some games and tools may not handle this reliably.</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+    <layout class="QVBoxLayout" name="nameLayout">
+     <item>
+      <widget class="QLabel" name="nameLabel">
+       <property name="text">
+        <string>Memory Card Name:</string>
+       </property>
+       <property name="buddy">
+        <cstring>nameEdit</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="nameEdit"/>
+     </item>
+    </layout>
    </item>
    <item>
-    <widget class="QGroupBox" name="optionsGroup">
-     <property name="title">
-      <string>Options</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <widget class="QCheckBox" name="disableEccCheckbox">
-        <property name="toolTip">
-         <string>Create image data without error correction bytes.
-Useful for specific raw-image workflows.</string>
-        </property>
-        <property name="text">
-         <string>Create without ECC bytes</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="eccHintLabel">
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Keep ECC enabled unless you specifically need a raw image format.</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+    <layout class="QVBoxLayout" name="formatLayout">
+     <item>
+      <widget class="QLabel" name="formatLabel">
+       <property name="text">
+        <string>Format:</string>
+       </property>
+       <property name="buddy">
+        <cstring>formatCombo</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="formatCombo"/>
+     </item>
+    </layout>
    </item>
    <item>
-    <widget class="QGroupBox" name="selectionGroup">
-     <property name="title">
-      <string>Selection Summary</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_4">
-      <item>
-       <widget class="QLabel" name="selectionSummaryLabel">
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Current selection:</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+    <layout class="QVBoxLayout" name="size8Layout">
+     <item>
+      <widget class="QRadioButton" name="size8MB">
+       <property name="text">
+        <string>8 MB (Recommended)</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">sizeButtonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="size8Hint">
+       <property name="text">
+        <string>Official PS2 size. Best compatibility.</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="buddy">
+        <cstring>size8MB</cstring>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="size16Layout">
+     <item>
+      <widget class="QRadioButton" name="size16MB">
+       <property name="text">
+        <string>16 MB</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">sizeButtonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="size16Hint">
+       <property name="text">
+        <string>More space, still works with most games.</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="buddy">
+        <cstring>size16MB</cstring>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="size32Layout">
+     <item>
+      <widget class="QRadioButton" name="size32MB">
+       <property name="text">
+        <string>32 MB</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">sizeButtonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="size32Hint">
+       <property name="text">
+        <string>Extra space. Some games may not like it.</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="buddy">
+        <cstring>size32MB</cstring>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="size64Layout">
+     <item>
+      <widget class="QRadioButton" name="size64MB">
+       <property name="text">
+        <string>64 MB</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">sizeButtonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="size64Hint">
+       <property name="text">
+        <string>Very large. Compatibility can be spotty.</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="buddy">
+        <cstring>size64MB</cstring>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>nameEdit</tabstop>
+  <tabstop>formatCombo</tabstop>
+  <tabstop>size8MB</tabstop>
+  <tabstop>size16MB</tabstop>
+  <tabstop>size32MB</tabstop>
+  <tabstop>size64MB</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>
@@ -232,4 +289,7 @@ Useful for specific raw-image workflows.</string>
    </hints>
   </connection>
  </connections>
+ <buttongroups>
+  <buttongroup name="sizeButtonGroup"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
### Description of Changes
- Determines ECC from new memcard wizard selection and card state
- Redesigned the new card dialog to let you pick a name and format before file picker.
- Auto detects ECC or non ECC layouts when opening cards.
- Generates file filters dynamically.

### Rationale behind Changes
Prevents accidentally making cards with incorrect ECC settings (ex: someone wanting to use a card for real hardware compared to emulation), and makes loading corrupted files fail early instead of returning garbage.

### Suggested Testing Steps
Create a `.ps2` (ECC) and a `.mc2` (no ECC) card and check that both open and save copies correctly.

### Related Issues / Links
Fixes #77 

### Did you use AI to help find, test, or implement this issue or feature?
No