### PR TITLE
Build: Remove GCC from Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,16 +21,6 @@ jobs:
       compiler: clang
     secrets: inherit
 
-  build_linux_x64_gcc:
-    name: "🐧 Linux x64 (GCC)"
-    uses: ./.github/workflows/linux_build.yml
-    with:
-      jobName: "Linux x64 GCC Build"
-      artifactPrefixName: "myMCpp-linux-x64-gcc"
-      platform: x64
-      compiler: gcc
-    secrets: inherit
-
   build_linux_arm64_clang:
     name: "🐧 Linux ARM64 (Clang)"
     uses: ./.github/workflows/linux_build.yml
@@ -40,17 +30,6 @@ jobs:
       os: ubuntu-24.04-arm
       platform: arm64
       compiler: clang
-    secrets: inherit
-
-  build_linux_arm64_gcc:
-    name: "🐧 Linux ARM64 (GCC)"
-    uses: ./.github/workflows/linux_build.yml
-    with:
-      jobName: "Linux ARM64 GCC Build"
-      artifactPrefixName: "myMCpp-linux-arm64-gcc"
-      os: ubuntu-24.04-arm
-      platform: arm64
-      compiler: gcc
     secrets: inherit
 
   build_macos:

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -95,7 +95,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y install \
-            build-essential \
             ccache \
             clang \
             lld \
@@ -147,43 +146,21 @@ jobs:
         run: |
           if [ "${{ inputs.buildType }}" = "Debug" ]; then
             if [ "${{ inputs.platform }}" = "arm64" ]; then
-              PRESET="linux-arm64-dbg"
+              PRESET="linux-clang-arm64-dbg"
             else
-              PRESET="linux-x64-dbg"
+              PRESET="linux-clang-x64-dbg"
             fi
           else
             if [ "${{ inputs.platform }}" = "arm64" ]; then
-              PRESET="linux-arm64-rel"
+              PRESET="linux-clang-arm64-rel"
             else
-              PRESET="linux-x64-rel"
+              PRESET="linux-clang-x64-rel"
             fi
           fi
           echo "PRESET=$PRESET" >> $GITHUB_ENV
           cmake --preset $PRESET \
             -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
             -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            ${{ inputs.cmakeFlags }}
-
-      - name: Configure CMake (GCC)
-        if: inputs.compiler == 'gcc'
-        run: |
-          if [ "${{ inputs.buildType }}" = "Debug" ]; then
-            if [ "${{ inputs.platform }}" = "arm64" ]; then
-              PRESET="linux-arm64-gcc-dbg"
-            else
-              PRESET="linux-x64-gcc-dbg"
-            fi
-          else
-            if [ "${{ inputs.platform }}" = "arm64" ]; then
-              PRESET="linux-arm64-gcc-rel"
-            else
-              PRESET="linux-x64-gcc-rel"
-            fi
-          fi
-          echo "PRESET=$PRESET" >> $GITHUB_ENV
-          cmake --preset $PRESET \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             ${{ inputs.cmakeFlags }}

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -79,19 +79,6 @@ jobs:
       fetchTags: true
     secrets: inherit
 
-  build_linux_x64_gcc:
-    if: github.repository == 'PCSX2/myMCpp'
-    name: '🐧 Linux x64 (GCC, Nightly)'
-    needs: cut_release
-    uses: ./.github/workflows/linux_build.yml
-    with:
-      jobName: 'Linux x64 GCC Nightly Build'
-      artifactPrefixName: 'myMCpp-nightly-linux-x64-gcc'
-      platform: x64
-      compiler: gcc
-      fetchTags: true
-    secrets: inherit
-
   build_linux_arm64_clang:
     if: github.repository == 'PCSX2/myMCpp'
     name: '🐧 Linux ARM64 (Clang, Nightly)'
@@ -103,20 +90,6 @@ jobs:
       os: ubuntu-24.04-arm
       platform: arm64
       compiler: clang
-      fetchTags: true
-    secrets: inherit
-
-  build_linux_arm64_gcc:
-    if: github.repository == 'PCSX2/myMCpp'
-    name: '🐧 Linux ARM64 (GCC, Nightly)'
-    needs: cut_release
-    uses: ./.github/workflows/linux_build.yml
-    with:
-      jobName: 'Linux ARM64 GCC Nightly Build'
-      artifactPrefixName: 'myMCpp-nightly-linux-arm64-gcc'
-      os: ubuntu-24.04-arm
-      platform: arm64
-      compiler: gcc
       fetchTags: true
     secrets: inherit
 
@@ -192,9 +165,7 @@ jobs:
     needs:
       - cut_release
       - build_linux_x64_clang
-      - build_linux_x64_gcc
       - build_linux_arm64_clang
-      - build_linux_arm64_gcc
       - build_macos
       - build_windows_x64_clang
       - build_windows_x64_msvc

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -72,11 +72,11 @@
             }
         },
         {
-            "name": "linux-x64-rel",
+            "name": "linux-clang-x64-rel",
             "displayName": "Linux x64 Release",
             "description": "Release build for Linux x64 with Clang and Ninja",
             "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/linux-x64-rel",
+            "binaryDir": "${sourceDir}/build/linux-clang-x64-rel",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "MinSizeRel",
                 "CMAKE_C_COMPILER": "clang",
@@ -85,11 +85,11 @@
             }
         },
         {
-            "name": "linux-x64-dbg",
+            "name": "linux-clang-x64-dbg",
             "displayName": "Linux x64 Debug",
             "description": "Debug build for Linux x64 with Clang and Ninja",
             "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/linux-x64-dbg",
+            "binaryDir": "${sourceDir}/build/linux-clang-x64-dbg",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_C_COMPILER": "clang",
@@ -98,37 +98,11 @@
             }
         },
         {
-            "name": "linux-x64-gcc-rel",
-            "displayName": "Linux x64 GCC Release",
-            "description": "Release build for Linux x64 with GCC and Ninja",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/linux-x64-gcc-rel",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "MinSizeRel",
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++",
-                "ENABLE_VULKAN": "ON"
-            }
-        },
-        {
-            "name": "linux-x64-gcc-dbg",
-            "displayName": "Linux x64 GCC Debug",
-            "description": "Debug build for Linux x64 with GCC and Ninja",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/linux-x64-gcc-dbg",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++",
-                "ENABLE_VULKAN": "ON"
-            }
-        },
-        {
-            "name": "linux-arm64-rel",
+            "name": "linux-clang-arm64-rel",
             "displayName": "Linux ARM64 Release",
             "description": "Release build for Linux ARM64 with Clang and Ninja",
             "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/linux-arm64-rel",
+            "binaryDir": "${sourceDir}/build/linux-clang-arm64-rel",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "MinSizeRel",
                 "CMAKE_C_COMPILER": "clang",
@@ -137,41 +111,15 @@
             }
         },
         {
-            "name": "linux-arm64-dbg",
+            "name": "linux-clang-arm64-dbg",
             "displayName": "Linux ARM64 Debug",
             "description": "Debug build for Linux ARM64 with Clang and Ninja",
             "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/linux-arm64-dbg",
+            "binaryDir": "${sourceDir}/build/linux-clang-arm64-dbg",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
-                "ENABLE_VULKAN": "ON"
-            }
-        },
-        {
-            "name": "linux-arm64-gcc-rel",
-            "displayName": "Linux ARM64 GCC Release",
-            "description": "Release build for Linux ARM64 with GCC and Ninja",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/linux-arm64-gcc-rel",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "MinSizeRel",
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++",
-                "ENABLE_VULKAN": "ON"
-            }
-        },
-        {
-            "name": "linux-arm64-gcc-dbg",
-            "displayName": "Linux ARM64 GCC Debug",
-            "description": "Debug build for Linux ARM64 with GCC and Ninja",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/linux-arm64-gcc-dbg",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++",
                 "ENABLE_VULKAN": "ON"
             }
         },
@@ -236,43 +184,23 @@
             "jobs": 0
         },
         {
-            "name": "linux-x64-rel",
-            "configurePreset": "linux-x64-rel",
+            "name": "linux-clang-x64-rel",
+            "configurePreset": "linux-clang-x64-rel",
             "jobs": 0
         },
         {
-            "name": "linux-x64-dbg",
-            "configurePreset": "linux-x64-dbg",
+            "name": "linux-clang-x64-dbg",
+            "configurePreset": "linux-clang-x64-dbg",
             "jobs": 0
         },
         {
-            "name": "linux-x64-gcc-rel",
-            "configurePreset": "linux-x64-gcc-rel",
+            "name": "linux-clang-arm64-rel",
+            "configurePreset": "linux-clang-arm64-rel",
             "jobs": 0
         },
         {
-            "name": "linux-x64-gcc-dbg",
-            "configurePreset": "linux-x64-gcc-dbg",
-            "jobs": 0
-        },
-        {
-            "name": "linux-arm64-rel",
-            "configurePreset": "linux-arm64-rel",
-            "jobs": 0
-        },
-        {
-            "name": "linux-arm64-dbg",
-            "configurePreset": "linux-arm64-dbg",
-            "jobs": 0
-        },
-        {
-            "name": "linux-arm64-gcc-rel",
-            "configurePreset": "linux-arm64-gcc-rel",
-            "jobs": 0
-        },
-        {
-            "name": "linux-arm64-gcc-dbg",
-            "configurePreset": "linux-arm64-gcc-dbg",
+            "name": "linux-clang-arm64-dbg",
+            "configurePreset": "linux-clang-arm64-dbg",
             "jobs": 0
         },
         {


### PR DESCRIPTION
### Description of Changes
Remove GCC from Linux builds

### Rationale behind Changes
We don’t need both and it may confuse users. If someone wants to use GCC they can but I don’t want to provide builds for both

### Suggested Testing Steps
N/A

### Related Issues / Links
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No