### PR TITLE
Formats/Qt/CLI: Switch memory card and save errors to Error

### DIFF
--- a/src/cli/ps2mc_cli.cpp
+++ b/src/cli/ps2mc_cli.cpp
@@ -11,6 +11,8 @@
 #include <iomanip>
 #include <fstream>
 #include <filesystem>
+#include <charconv>
+#include <string_view>
 
 namespace fs = std::filesystem;
 
@@ -134,72 +136,60 @@ int PS2McCommandLine::execute(int argc, char* argv[])
 
 	if (!memcardPath.empty() && command != "format")
 	{
-		try
+		memoryCard = std::make_unique<PS2MemoryCard>();
+		if (!memoryCard->open(memcardPath, ignoreEcc))
 		{
-			memoryCard = std::make_unique<PS2MemoryCard>();
-			memoryCard->open(memcardPath, ignoreEcc);
-		}
-		catch (const std::exception& e)
-		{
-			Logger::error("Error opening memory card: {}", e.what());
+			Logger::error("Error opening memory card: {}", memoryCard->GetError().GetDescription());
 			return 1;
 		}
 	}
 
-	try
+	if (command == "ls")
+		return cmdLs(cmdArgs);
+	else if (command == "dir")
+		return cmdDir(cmdArgs);
+	else if (command == "extract")
+		return cmdExtract(cmdArgs);
+	else if (command == "add")
+		return cmdAdd(cmdArgs);
+	else if (command == "import")
+		return cmdImport(cmdArgs);
+	else if (command == "export")
+		return cmdExport(cmdArgs);
+	else if (command == "delete")
+		return cmdDelete(cmdArgs);
+	else if (command == "remove")
+		return cmdRemove(cmdArgs);
+	else if (command == "mkdir")
+		return cmdMkdir(cmdArgs);
+	else if (command == "format")
 	{
-		if (command == "ls")
-			return cmdLs(cmdArgs);
-		else if (command == "dir")
-			return cmdDir(cmdArgs);
-		else if (command == "extract")
-			return cmdExtract(cmdArgs);
-		else if (command == "add")
-			return cmdAdd(cmdArgs);
-		else if (command == "import")
-			return cmdImport(cmdArgs);
-		else if (command == "export")
-			return cmdExport(cmdArgs);
-		else if (command == "delete")
-			return cmdDelete(cmdArgs);
-		else if (command == "remove")
-			return cmdRemove(cmdArgs);
-		else if (command == "mkdir")
-			return cmdMkdir(cmdArgs);
-		else if (command == "format")
+		if (memcardPath.empty())
 		{
-			if (memcardPath.empty())
-			{
-				Logger::error("Memory card path required for format");
-				return 1;
-			}
-			return cmdFormat({memcardPath});
-		}
-		else if (command == "check")
-			return cmdCheck(cmdArgs);
-		else if (command == "df")
-			return cmdDf(cmdArgs);
-		else if (command == "clear")
-			return cmdClear(cmdArgs);
-		else if (command == "set")
-			return cmdSet(cmdArgs);
-		else if (command == "ecc_check")
-			return cmdEccCheck(cmdArgs);
-		else if (command == "gui")
-		{
-			Logger::error("GUI mode not available in CLI build");
+			Logger::error("Memory card path required for format");
 			return 1;
 		}
-		else
-		{
-			Logger::error("Unknown command: {}", command);
-			printHelp();
-			return 1;
-		}
+		return cmdFormat({memcardPath});
 	}
-	catch (const std::exception& e)
+	else if (command == "check")
+		return cmdCheck(cmdArgs);
+	else if (command == "df")
+		return cmdDf(cmdArgs);
+	else if (command == "clear")
+		return cmdClear(cmdArgs);
+	else if (command == "set")
+		return cmdSet(cmdArgs);
+	else if (command == "ecc_check")
+		return cmdEccCheck(cmdArgs);
+	else if (command == "gui")
 	{
-		Logger::error("Error: {}", e.what());
+		Logger::error("GUI mode not available in CLI build");
+		return 1;
+	}
+	else
+	{
+		Logger::error("Unknown command: {}", command);
+		printHelp();
 		return 1;
 	}
 }
@@ -213,42 +203,39 @@ int PS2McCommandLine::cmdLs(const std::vector<std::string>& args)
 	}
 
 	std::string path = args.empty() ? "/" : args[0];
-	try
+	auto entries = memoryCard->listDir(path);
+	if (memoryCard->GetError().IsValid())
 	{
-		auto entries = memoryCard->listDir(path);
-
-		const char* modeChars = "rwxpfdD81C+KPH4";
-
-		for (const auto& ent : entries)
-		{
-			if (!(ent.mode & 0x8000))
-				continue; // DF_EXISTS
-
-			// Print mode
-			for (int b = 0; b < 15; ++b)
-			{
-				std::cout << ((ent.mode & (1 << b)) ? modeChars[b] : '-');
-			}
-			std::cout << " ";
-
-			std::cout << std::setw(7) << ent.length << " ";
-
-			std::cout << std::setfill('0')
-					  << std::setw(4) << (1900 + ent.modified.year) << "-"
-					  << std::setw(2) << (int)ent.modified.month << "-"
-					  << std::setw(2) << (int)ent.modified.mday << " "
-					  << std::setw(2) << (int)ent.modified.hour << ":"
-					  << std::setw(2) << (int)ent.modified.min << ":"
-					  << std::setw(2) << (int)ent.modified.sec << " "
-					  << std::setfill(' ') << ent.name << "\n";
-		}
-		return 0;
-	}
-	catch (const std::exception& e)
-	{
-		Logger::error("Error: {}", e.what());
+		Logger::error("Error: {}", memoryCard->GetError().GetDescription());
 		return 1;
 	}
+
+	const char* modeChars = "rwxpfdD81C+KPH4";
+
+	for (const auto& ent : entries)
+	{
+		if (!(ent.mode & 0x8000))
+			continue; // DF_EXISTS
+
+		// Print mode
+		for (int b = 0; b < 15; ++b)
+		{
+			std::cout << ((ent.mode & (1 << b)) ? modeChars[b] : '-');
+		}
+		std::cout << " ";
+
+		std::cout << std::setw(7) << ent.length << " ";
+
+		std::cout << std::setfill('0')
+				  << std::setw(4) << (1900 + ent.modified.year) << "-"
+				  << std::setw(2) << (int)ent.modified.month << "-"
+				  << std::setw(2) << (int)ent.modified.mday << " "
+				  << std::setw(2) << (int)ent.modified.hour << ":"
+				  << std::setw(2) << (int)ent.modified.min << ":"
+				  << std::setw(2) << (int)ent.modified.sec << " "
+				  << std::setfill(' ') << ent.name << "\n";
+	}
+	return 0;
 }
 
 int PS2McCommandLine::cmdDir(const std::vector<std::string>& args)
@@ -260,101 +247,96 @@ int PS2McCommandLine::cmdDir(const std::vector<std::string>& args)
 		return 1;
 	}
 
-	try
+	auto entries = memoryCard->listDir("/");
+	if (memoryCard->GetError().IsValid())
 	{
-		auto entries = memoryCard->listDir("/");
+		Logger::error("Error: {}", memoryCard->GetError().GetDescription());
+		return 1;
+	}
 
-		for (const auto& ent : entries)
+	for (const auto& ent : entries)
+	{
+		if (!(ent.mode & DF_DIR) || (ent.mode & DF_HIDDEN))
+			continue;
+		if (ent.name == "." || ent.name == "..")
+			continue;
+
+		std::string dirPath = "/" + ent.name;
+
+		std::string title, subtitle;
+		if (ent.mode & DF_PSX)
 		{
-			if (!(ent.mode & DF_DIR) || (ent.mode & DF_HIDDEN))
-				continue;
-			if (ent.name == "." || ent.name == "..")
-				continue;
-
-			std::string dirPath = "/" + ent.name;
-
-			std::string title, subtitle;
-			try
-			{
-				if (ent.mode & DF_PSX)
-				{
-					title = memoryCard->getPsxTitle(dirPath);
-					if (title.empty())
-						title = "Corrupt";
-				}
-				else
-				{
-					title = memoryCard->getSaveTitle(dirPath);
-					if (title.empty())
-						title = "Corrupt";
-					subtitle = memoryCard->getSaveSubtitle(dirPath);
-				}
-			}
-			catch (...)
-			{
+			title = memoryCard->getPsxTitle(dirPath);
+			if (title.empty())
 				title = "Corrupt";
-			}
-
-			uint32_t sizeBytes = memoryCard->getSaveSize(dirPath);
-			uint32_t sizeKB = sizeBytes / 1024;
-
-			std::string protection;
-			uint16_t protBits = ent.mode & (DF_PROTECTED | DF_WRITE);
-			if (protBits == 0)
-				protection = "Delete Protected";
-			else if (protBits == DF_WRITE)
-				protection = "Not Protected";
-			else if (protBits == DF_PROTECTED)
-				protection = "Copy & Delete Protected";
-			else
-				protection = "Copy Protected";
-
-			// Check for PSX/PocketStation type
-			if (ent.mode & DF_PSX)
-			{
-				if (ent.mode & DF_POCKETSTN)
-					protection = "PocketStation";
-				else
-					protection = "PlayStation";
-			}
-
-			// Print first line: dirname  title
-			std::cout << std::left << std::setw(32) << ent.name << " " << title << "\n";
-
-			// Print second line: size  protection  subtitle
-			std::cout << std::right << std::setw(4) << sizeKB << "KB "
-					  << std::left << std::setw(25) << protection << " " << subtitle << "\n";
-
-			std::cout << "\n";
-		}
-
-		// Print free space summary
-		uint32_t freeSpace = memoryCard->getFreeSpace() / 1024;
-		std::string freeStr;
-		if (freeSpace > 999999)
-		{
-			freeStr = std::to_string(freeSpace / 1000000) + "," +
-			          std::to_string((freeSpace / 1000) % 1000) + "," +
-			          std::to_string(freeSpace % 1000);
-		}
-		else if (freeSpace > 999)
-		{
-			freeStr = std::to_string(freeSpace / 1000) + "," +
-			          std::to_string(freeSpace % 1000);
 		}
 		else
 		{
-			freeStr = std::to_string(freeSpace);
+			title = memoryCard->getSaveTitle(dirPath);
+			if (title.empty())
+				title = "Corrupt";
+			subtitle = memoryCard->getSaveSubtitle(dirPath);
 		}
-		std::cout << freeStr << " KB Free\n";
 
-		return 0;
+		uint32_t sizeBytes = memoryCard->getSaveSize(dirPath);
+		uint32_t sizeKB = sizeBytes / 1024;
+
+		std::string protection;
+		uint16_t protBits = ent.mode & (DF_PROTECTED | DF_WRITE);
+		if (protBits == 0)
+			protection = "Delete Protected";
+		else if (protBits == DF_WRITE)
+			protection = "Not Protected";
+		else if (protBits == DF_PROTECTED)
+			protection = "Copy & Delete Protected";
+		else
+			protection = "Copy Protected";
+
+		// Check for PSX/PocketStation type
+		if (ent.mode & DF_PSX)
+		{
+			if (ent.mode & DF_POCKETSTN)
+				protection = "PocketStation";
+			else
+				protection = "PlayStation";
+		}
+
+		// Print first line: dirname  title
+		std::cout << std::left << std::setw(32) << ent.name << " " << title << "\n";
+
+		// Print second line: size  protection  subtitle
+		std::cout << std::right << std::setw(4) << sizeKB << "KB "
+				  << std::left << std::setw(25) << protection << " " << subtitle << "\n";
+
+		std::cout << "\n";
 	}
-	catch (const std::exception& e)
+
+	// Print free space summary
+	uint32_t freeSpace = memoryCard->getFreeSpace() / 1024;
+	if (memoryCard->GetError().IsValid())
 	{
-		Logger::error("Error: {}", e.what());
+		Logger::error("Error: {}", memoryCard->GetError().GetDescription());
 		return 1;
 	}
+	std::string freeStr;
+	if (freeSpace > 999999)
+	{
+		freeStr = std::to_string(freeSpace / 1000000) + "," +
+		          std::to_string((freeSpace / 1000) % 1000) + "," +
+		          std::to_string(freeSpace % 1000);
+	}
+	else if (freeSpace > 999)
+	{
+		freeStr = std::to_string(freeSpace / 1000) + "," +
+		          std::to_string(freeSpace % 1000);
+	}
+	else
+	{
+		freeStr = std::to_string(freeSpace);
+	}
+	std::cout << freeStr << " KB Free\n";
+
+	return 0;
 }
 
 int PS2McCommandLine::cmdExtract(const std::vector<std::string>& args)
@@ -365,20 +347,27 @@ int PS2McCommandLine::cmdExtract(const std::vector<std::string>& args)
 		return 1;
 	}
 
-	try
+	auto data = memoryCard->readFile(args[0]);
+	if (memoryCard->GetError().IsValid())
 	{
-		auto data = memoryCard->readFile(args[0]);
-		std::string outFile = args.size() > 1 ? args[1] : fs::path(args[0]).filename().string();
-
-		std::ofstream out(outFile, std::ios::binary);
-		out.write(reinterpret_cast<const char*>(data.data()), data.size());
-		return 0;
-	}
-	catch (const std::exception& e)
-	{
-		Logger::error("Error: {}", e.what());
+		Logger::error("Error: {}", memoryCard->GetError().GetDescription());
 		return 1;
 	}
+	std::string outFile = args.size() > 1 ? args[1] : fs::path(args[0]).filename().string();
+
+	std::ofstream out(outFile, std::ios::binary);
+	if (!out)
+	{
+		Logger::error("Error: Failed to create output file: {}", outFile);
+		return 1;
+	}
+	out.write(reinterpret_cast<const char*>(data.data()), data.size());
+	if (!out)
+	{
+		Logger::error("Error: Failed to write output file: {}", outFile);
+		return 1;
+	}
+	return 0;
 }
 
 int PS2McCommandLine::cmdAdd(const std::vector<std::string>& args)
@@ -389,30 +378,26 @@ int PS2McCommandLine::cmdAdd(const std::vector<std::string>& args)
 		return 1;
 	}
 
-	try
+	for (const auto& filepath : args)
 	{
-		for (const auto& filepath : args)
+		std::ifstream in(filepath, std::ios::binary);
+		if (!in)
 		{
-			std::ifstream in(filepath, std::ios::binary);
-			if (!in)
-			{
-				Logger::error("Cannot open file: {}", filepath);
-				return 1;
-			}
-
-			std::vector<uint8_t> data((std::istreambuf_iterator<char>(in)),
-				std::istreambuf_iterator<char>());
-
-			std::string fname = fs::path(filepath).filename().string();
-			memoryCard->writeFile("/" + fname, data);
+			Logger::error("Cannot open file: {}", filepath);
+			return 1;
 		}
-		return 0;
+
+		std::vector<uint8_t> data((std::istreambuf_iterator<char>(in)),
+			std::istreambuf_iterator<char>());
+
+		std::string fname = fs::path(filepath).filename().string();
+		if (!memoryCard->writeFile("/" + fname, data))
+		{
+			Logger::error("Error: {}", memoryCard->GetError().GetDescription());
+			return 1;
+		}
 	}
-	catch (const std::exception& e)
-	{
-		Logger::error("Error: {}", e.what());
-		return 1;
-	}
+	return 0;
 }
 
 int PS2McCommandLine::cmdImport(const std::vector<std::string>& args)
@@ -423,65 +408,66 @@ int PS2McCommandLine::cmdImport(const std::vector<std::string>& args)
 		return 1;
 	}
 
-	try
+	int imported = 0;
+	int skipped = 0;
+
+	for (const auto& filepath : args)
 	{
-		int imported = 0;
-		int skipped = 0;
-
-		for (const auto& filepath : args)
+		PS2SaveFile save;
+		if (!save.load(filepath))
 		{
-			PS2SaveFile save;
-			save.load(filepath);
+			Logger::error("Error loading save {}: {}", filepath, save.GetError().GetDescription());
+			return 1;
+		}
 
-			std::string saveName = save.getTitle();
+		std::string saveName = save.getTitle();
+		if (saveName.empty())
+		{
+			// Get directory name from first entry if it's a directory
+			const auto& entries = save.getEntries();
+			if (!entries.empty())
+			{
+				const bool hasDir = (entries[0].dirEntry.mode & DF_DIR) != 0;
+				saveName = hasDir ? entries[0].dirEntry.name : "";
+			}
 			if (saveName.empty())
 			{
-				// Get directory name from first entry if it's a directory
-				const auto& entries = save.getEntries();
-				if (!entries.empty())
-				{
-					const bool hasDir = (entries[0].dirEntry.mode & DF_DIR) != 0;
-					saveName = hasDir ? entries[0].dirEntry.name : "";
-				}
-				if (saveName.empty())
-				{
-					saveName = fs::path(filepath).stem().string();
-				}
-			}
-
-			std::cout << "Importing " << filepath << " to /" << saveName << "...";
-
-			bool result = memoryCard->importSaveFile(save, false, "");
-
-			if (result)
-			{
-				std::cout << " OK\n";
-				imported++;
-			}
-			else
-			{
-				std::cout << " SKIPPED (already exists)\n";
-				skipped++;
+				saveName = fs::path(filepath).stem().string();
 			}
 		}
 
-		if (imported > 0)
+		std::cout << "Importing " << filepath << " to /" << saveName << "...";
+
+		bool result = memoryCard->importSaveFile(save, false, "");
+
+		if (result)
 		{
-			std::cout << "\nImported " << imported << " save(s)";
-			if (skipped > 0)
-			{
-				std::cout << ", skipped " << skipped;
-			}
-			std::cout << ".\n";
+			std::cout << " OK\n";
+			imported++;
 		}
+		else
+		{
+			if (memoryCard->GetError().IsValid())
+			{
+				std::cout << " FAILED: " << memoryCard->GetError().GetDescription() << "\n";
+				return 1;
+			}
+			std::cout << " SKIPPED (already exists)\n";
+			skipped++;
+		}
+	}
 
-		return 0;
-	}
-	catch (const std::exception& e)
+	if (imported > 0)
 	{
-		Logger::error("Error: {}", e.what());
-		return 1;
+		std::cout << "\nImported " << imported << " save(s)";
+		if (skipped > 0)
+		{
+			std::cout << ", skipped " << skipped;
+		}
+		std::cout << ".\n";
 	}
+
+	return 0;
 }
 
 int PS2McCommandLine::cmdExport(const std::vector<std::string>& args)
@@ -492,50 +478,50 @@ int PS2McCommandLine::cmdExport(const std::vector<std::string>& args)
 		return 1;
 	}
 
-	try
+	int exported = 0;
+
+	for (const auto& savePath : args)
 	{
-		int exported = 0;
-
-		for (const auto& savePath : args)
+		// Ensure path starts with /
+		std::string path = savePath;
+		if (path.empty() || path[0] != '/')
 		{
-			// Ensure path starts with /
-			std::string path = savePath;
-			if (path.empty() || path[0] != '/')
-			{
-				path = "/" + path;
-			}
-
-			PS2SaveFile save;
-			memoryCard->exportSaveFile(path, save);
-
-			std::string basename = path;
-			if (basename[0] == '/')
-			{
-				basename = basename.substr(1);
-			}
-
-			std::string outFilename = basename + ".psu";
-
-			std::cout << "Exporting " << path << " to " << outFilename << "...";
-
-			save.save(outFilename, SaveFormat::EMS);
-
-			std::cout << " OK\n";
-			exported++;
+			path = "/" + path;
 		}
 
-		if (exported > 0)
+		PS2SaveFile save;
+		if (!memoryCard->exportSaveFile(path, save))
 		{
-			std::cout << "\nExported " << exported << " save(s).\n";
+			Logger::error("Error exporting {}: {}", path, memoryCard->GetError().GetDescription());
+			return 1;
 		}
 
-		return 0;
+		std::string basename = path;
+		if (basename[0] == '/')
+		{
+			basename = basename.substr(1);
+		}
+
+		std::string outFilename = basename + ".psu";
+
+		std::cout << "Exporting " << path << " to " << outFilename << "...";
+
+		if (!save.save(outFilename, SaveFormat::EMS))
+		{
+			Logger::error("Error saving {}: {}", outFilename, save.GetError().GetDescription());
+			return 1;
+		}
+
+		std::cout << " OK\n";
+		exported++;
 	}
-	catch (const std::exception& e)
+
+	if (exported > 0)
 	{
-		Logger::error("Error: {}", e.what());
-		return 1;
+		std::cout << "\nExported " << exported << " save(s).\n";
 	}
+
+	return 0;
 }
 
 int PS2McCommandLine::cmdDelete(const std::vector<std::string>& args)
@@ -546,16 +532,12 @@ int PS2McCommandLine::cmdDelete(const std::vector<std::string>& args)
 		return 1;
 	}
 
-	try
+	if (!memoryCard->remove(args[0]))
 	{
-		memoryCard->remove(args[0]);
-		return 0;
-	}
-	catch (const std::exception& e)
-	{
-		Logger::error("Error: {}", e.what());
+		Logger::error("Error: {}", memoryCard->GetError().GetDescription());
 		return 1;
 	}
+	return 0;
 }
 
 int PS2McCommandLine::cmdRemove(const std::vector<std::string>& args)
@@ -571,19 +553,15 @@ int PS2McCommandLine::cmdMkdir(const std::vector<std::string>& args)
 		return 1;
 	}
 
-	try
+	for (const auto& path : args)
 	{
-		for (const auto& path : args)
+		if (!memoryCard->makeDir(path))
 		{
-			memoryCard->makeDir(path);
+			Logger::error("Error: {}", memoryCard->GetError().GetDescription());
+			return 1;
 		}
-		return 0;
 	}
-	catch (const std::exception& e)
-	{
-		Logger::error("Error: {}", e.what());
-		return 1;
-	}
+	return 0;
 }
 
 int PS2McCommandLine::cmdFormat(const std::vector<std::string>& args)
@@ -594,17 +572,13 @@ int PS2McCommandLine::cmdFormat(const std::vector<std::string>& args)
 		return 1;
 	}
 
-	try
+	auto mc = std::make_unique<PS2MemoryCard>();
+	if (!mc->create(args[0], 8, noEcc || !PS2MemoryCard::usesEccForPath(args[0]))) // 8 MB default
 	{
-		auto mc = std::make_unique<PS2MemoryCard>();
-		mc->create(args[0], 8, noEcc || !PS2MemoryCard::usesEccForPath(args[0])); // 8 MB default
-		return 0;
-	}
-	catch (const std::exception& e)
-	{
-		Logger::error("Error: {}", e.what());
+		Logger::error("Error: {}", mc->GetError().GetDescription());
 		return 1;
 	}
+	return 0;
 }
 
 int PS2McCommandLine::cmdCheck(const std::vector<std::string>& args)
@@ -616,23 +590,22 @@ int PS2McCommandLine::cmdCheck(const std::vector<std::string>& args)
 		return 1;
 	}
 
-	try
+	bool result = memoryCard->check();
+	if (result)
 	{
-		bool result = memoryCard->check();
-		if (result)
+		std::cout << "No errors found.\n";
+		return 0;
+	}
+	else
+	{
+		if (memoryCard->GetError().IsValid())
 		{
-			std::cout << "No errors found.\n";
-			return 0;
+			std::cout << "Errors found in file system: " << memoryCard->GetError().GetDescription() << "\n";
 		}
 		else
 		{
 			std::cout << "Errors found in file system.\n";
-			return 1;
 		}
-	}
-	catch (const std::exception& e)
-	{
-		Logger::error("Error: {}", e.what());
 		return 1;
 	}
 }
@@ -646,17 +619,14 @@ int PS2McCommandLine::cmdDf(const std::vector<std::string>& args)
 		return 1;
 	}
 
-	try
+	uint32_t free = memoryCard->getFreeSpace();
+	if (memoryCard->GetError().IsValid())
 	{
-		uint32_t free = memoryCard->getFreeSpace();
-		std::cout << "Free space: " << free << " bytes\n";
-		return 0;
-	}
-	catch (const std::exception& e)
-	{
-		Logger::error("Error: {}", e.what());
+		Logger::error("Error: {}", memoryCard->GetError().GetDescription());
 		return 1;
 	}
+	std::cout << "Free space: " << free << " bytes\n";
+	return 0;
 }
 
 int PS2McCommandLine::cmdClear(const std::vector<std::string>& args)
@@ -667,60 +637,61 @@ int PS2McCommandLine::cmdClear(const std::vector<std::string>& args)
 		return 1;
 	}
 
-	try
+	// Parse flags to clear // Restoring context
+	uint16_t clear_mask = 0;
+	std::vector<std::string> paths;
+
+	for (const auto& arg : args)
 	{
-		// Parse flags to clear // Restoring context
-		uint16_t clear_mask = 0;
-		std::vector<std::string> paths;
-
-		for (const auto& arg : args)
-		{
-			if (arg == "--read")
-				clear_mask |= DF_READ;
-			else if (arg == "--write")
-				clear_mask |= DF_WRITE;
-			else if (arg == "--execute")
-				clear_mask |= DF_EXECUTE;
-			else if (arg == "--protected")
-				clear_mask |= DF_PROTECTED;
-			else if (arg == "--psx")
-				clear_mask |= DF_PSX;
-			else if (arg == "--pocketstation")
-				clear_mask |= DF_POCKETSTN;
-			else if (arg == "--hidden")
-				clear_mask |= DF_HIDDEN;
-			else if (!arg.empty() && arg[0] != '-')
-				paths.push_back(arg);
-		}
-
-		if (clear_mask == 0)
-		{
-			Logger::error("Error: At least one flag must be specified to clear");
-			return 1;
-		}
-
-		if (paths.empty())
-		{
-			Logger::error("Error: At least one path must be specified");
-			return 1;
-		}
-
-		// Clear flags for each path
-		for (const auto& path : paths)
-		{
-			uint16_t current_mode = memoryCard->getMode(path);
-			uint16_t new_mode = current_mode & ~clear_mask;
-			memoryCard->setMode(path, new_mode);
-			std::cout << "Cleared flags for: " << path << " (0x" << std::hex << current_mode << " -> 0x" << new_mode << std::dec << ")\n";
-		}
-
-		return 0;
+		if (arg == "--read")
+			clear_mask |= DF_READ;
+		else if (arg == "--write")
+			clear_mask |= DF_WRITE;
+		else if (arg == "--execute")
+			clear_mask |= DF_EXECUTE;
+		else if (arg == "--protected")
+			clear_mask |= DF_PROTECTED;
+		else if (arg == "--psx")
+			clear_mask |= DF_PSX;
+		else if (arg == "--pocketstation")
+			clear_mask |= DF_POCKETSTN;
+		else if (arg == "--hidden")
+			clear_mask |= DF_HIDDEN;
+		else if (!arg.empty() && arg[0] != '-')
+			paths.push_back(arg);
 	}
-	catch (const std::exception& e)
+
+	if (clear_mask == 0)
 	{
-		Logger::error("Error: {}", e.what());
+		Logger::error("Error: At least one flag must be specified to clear");
 		return 1;
 	}
+
+	if (paths.empty())
+	{
+		Logger::error("Error: At least one path must be specified");
+		return 1;
+	}
+
+	// Clear flags for each path
+	for (const auto& path : paths)
+	{
+		uint16_t current_mode = memoryCard->getMode(path);
+		if (memoryCard->GetError().IsValid())
+		{
+			Logger::error("Error: {}", memoryCard->GetError().GetDescription());
+			return 1;
+		}
+		uint16_t new_mode = current_mode & ~clear_mask;
+		if (!memoryCard->setMode(path, new_mode))
+		{
+			Logger::error("Error: {}", memoryCard->GetError().GetDescription());
+			return 1;
+		}
+		std::cout << "Cleared flags for: " << path << " (0x" << std::hex << current_mode << " -> 0x" << new_mode << std::dec << ")\n";
+	}
+
+	return 0;
 }
 
 int PS2McCommandLine::cmdSet(const std::vector<std::string>& args)
@@ -731,142 +702,138 @@ int PS2McCommandLine::cmdSet(const std::vector<std::string>& args)
 		return 1;
 	}
 
-	try
+	// Parse flags to set
+	uint16_t set_mask = 0;
+	uint16_t clear_mask = 0xFFFF;
+	std::vector<std::string> paths;
+	std::string hex_value;
+	bool use_hex = false;
+
+	for (size_t i = 0; i < args.size(); ++i)
 	{
-		// Parse flags to set
-		uint16_t set_mask = 0;
-		uint16_t clear_mask = 0xFFFF;
-		std::vector<std::string> paths;
-		std::string hex_value;
-		bool use_hex = false;
+		const auto& arg = args[i];
 
-		for (size_t i = 0; i < args.size(); ++i)
+		if (arg == "--read")
 		{
-			const auto& arg = args[i];
-
-			if (arg == "--read")
-			{
-				set_mask |= DF_READ;
-				clear_mask &= ~DF_READ;
-			}
-			else if (arg == "--write")
-			{
-				set_mask |= DF_WRITE;
-				clear_mask &= ~DF_WRITE;
-			}
-			else if (arg == "--execute")
-			{
-				set_mask |= DF_EXECUTE;
-				clear_mask &= ~DF_EXECUTE;
-			}
-			else if (arg == "--protected")
-			{
-				set_mask |= DF_PROTECTED;
-				clear_mask &= ~DF_PROTECTED;
-			}
-			else if (arg == "--psx")
-			{
-				set_mask |= DF_PSX;
-				clear_mask &= ~DF_PSX;
-			}
-			else if (arg == "--pocketstation")
-			{
-				set_mask |= DF_POCKETSTN;
-				clear_mask &= ~DF_POCKETSTN;
-			}
-			else if (arg == "--hidden")
-			{
-				set_mask |= DF_HIDDEN;
-				clear_mask &= ~DF_HIDDEN;
-			}
-			else if (arg == "-x" || arg == "--hex")
-			{
-				if (i + 1 < args.size())
-				{
-					hex_value = args[++i];
-					use_hex = true;
-				}
-				else
-				{
-					Logger::error("Error: -x requires a value");
-					return 1;
-				}
-			}
-			else if (!arg.empty() && arg[0] != '-')
-			{
-				paths.push_back(arg);
-			}
+			set_mask |= DF_READ;
+			clear_mask &= ~DF_READ;
 		}
-
-		if (paths.empty())
+		else if (arg == "--write")
 		{
-			Logger::error("Error: At least one path must be specified");
-			return 1;
+			set_mask |= DF_WRITE;
+			clear_mask &= ~DF_WRITE;
 		}
-
-		// Determine mode value
-		uint16_t mode_value = 0;
-		bool use_direct_value = false;
-
-		if (use_hex)
+		else if (arg == "--execute")
 		{
-			if (set_mask != 0 || clear_mask != 0xFFFF)
-			{
-				Logger::error("Error: -x cannot be combined with flag options");
-				return 1;
-			}
-
-			// Parse hex value
-			try
-			{
-				if (hex_value.substr(0, 2) == "0x" || hex_value.substr(0, 2) == "0X")
-				{
-					mode_value = static_cast<uint16_t>(std::stoul(hex_value.substr(2), nullptr, 16));
-				}
-				else
-				{
-					mode_value = static_cast<uint16_t>(std::stoul(hex_value, nullptr, 16));
-				}
-				use_direct_value = true;
-			}
-			catch (...)
-			{
-				Logger::error("Error: Invalid hex value: {}", hex_value);
-				return 1;
-			}
+			set_mask |= DF_EXECUTE;
+			clear_mask &= ~DF_EXECUTE;
 		}
-		else if (set_mask == 0 && clear_mask == 0xFFFF)
+		else if (arg == "--protected")
 		{
-			Logger::error("Error: At least one flag must be specified (or use -x for hex value)");
-			return 1;
+			set_mask |= DF_PROTECTED;
+			clear_mask &= ~DF_PROTECTED;
 		}
-
-		// Set mode for each path
-		for (const auto& path : paths)
+		else if (arg == "--psx")
 		{
-			uint16_t current_mode = memoryCard->getMode(path);
-			uint16_t new_mode;
-
-			if (use_direct_value)
+			set_mask |= DF_PSX;
+			clear_mask &= ~DF_PSX;
+		}
+		else if (arg == "--pocketstation")
+		{
+			set_mask |= DF_POCKETSTN;
+			clear_mask &= ~DF_POCKETSTN;
+		}
+		else if (arg == "--hidden")
+		{
+			set_mask |= DF_HIDDEN;
+			clear_mask &= ~DF_HIDDEN;
+		}
+		else if (arg == "-x" || arg == "--hex")
+		{
+			if (i + 1 < args.size())
 			{
-				new_mode = mode_value;
+				hex_value = args[++i];
+				use_hex = true;
 			}
 			else
 			{
-				new_mode = (current_mode & clear_mask) | set_mask;
+				Logger::error("Error: -x requires a value");
+				return 1;
 			}
-
-			memoryCard->setMode(path, new_mode);
-			std::cout << "Set mode for: " << path << " (0x" << std::hex << current_mode << " -> 0x" << new_mode << std::dec << ")\n";
 		}
-
-		return 0;
+		else if (!arg.empty() && arg[0] != '-')
+		{
+			paths.push_back(arg);
+		}
 	}
-	catch (const std::exception& e)
+
+	if (paths.empty())
 	{
-		Logger::error("Error: {}", e.what());
+		Logger::error("Error: At least one path must be specified");
 		return 1;
 	}
+
+	// Determine mode value
+	uint16_t mode_value = 0;
+	bool use_direct_value = false;
+
+	if (use_hex)
+	{
+		if (set_mask != 0 || clear_mask != 0xFFFF)
+		{
+			Logger::error("Error: -x cannot be combined with flag options");
+			return 1;
+		}
+
+		// Parse hex value
+		std::string_view hex_view = hex_value;
+		if (hex_view.starts_with("0x") || hex_view.starts_with("0X"))
+		{
+			hex_view.remove_prefix(2);
+		}
+		auto [ptr, ec] = std::from_chars(hex_view.data(), hex_view.data() + hex_view.size(), mode_value, 16);
+		if (ec != std::errc{} || ptr != hex_view.data() + hex_view.size())
+		{
+			Logger::error("Error: Invalid hex value: {}", hex_value);
+			return 1;
+		}
+		use_direct_value = true;
+	}
+	else if (set_mask == 0 && clear_mask == 0xFFFF)
+	{
+		Logger::error("Error: At least one flag must be specified (or use -x for hex value)");
+		return 1;
+	}
+
+	// Set mode for each path
+	for (const auto& path : paths)
+	{
+		uint16_t current_mode = memoryCard->getMode(path);
+		if (memoryCard->GetError().IsValid())
+		{
+			Logger::error("Error: {}", memoryCard->GetError().GetDescription());
+			return 1;
+		}
+		uint16_t new_mode;
+
+		if (use_direct_value)
+		{
+			new_mode = mode_value;
+		}
+		else
+		{
+			new_mode = (current_mode & clear_mask) | set_mask;
+		}
+
+		if (!memoryCard->setMode(path, new_mode))
+		{
+			Logger::error("Error: {}", memoryCard->GetError().GetDescription());
+			return 1;
+		}
+		std::cout << "Set mode for: " << path << " (0x" << std::hex << current_mode << " -> 0x" << new_mode << std::dec << ")\n";
+	}
+
+	return 0;
 }
 
 int PS2McCommandLine::cmdEccCheck(const std::vector<std::string>& args)
@@ -878,39 +845,38 @@ int PS2McCommandLine::cmdEccCheck(const std::vector<std::string>& args)
 		return 1;
 	}
 
-	try
+	bool hasEcc = memoryCard->hasEcc();
+
+	std::cout << "Memory card: " << currentMemCardPath << "\n";
+	std::cout << "ECC status: " << (hasEcc ? "Enabled" : "Disabled") << "\n";
+
+	if (hasEcc)
 	{
-		bool hasEcc = memoryCard->hasEcc();
-
-		std::cout << "Memory card: " << currentMemCardPath << "\n";
-		std::cout << "ECC status: " << (hasEcc ? "Enabled" : "Disabled") << "\n";
-
-		if (hasEcc)
+		std::cout << "Running file system check with ECC validation...\n";
+		bool result = memoryCard->check();
+		if (result)
 		{
-			std::cout << "Running file system check with ECC validation...\n";
-			bool result = memoryCard->check();
-			if (result)
+			std::cout << "No errors found.\n";
+			return 0;
+		}
+		else
+		{
+			if (memoryCard->GetError().IsValid())
 			{
-				std::cout << "No errors found.\n";
-				return 0;
+				std::cout << "Errors detected in file system: " << memoryCard->GetError().GetDescription() << "\n";
 			}
 			else
 			{
 				std::cout << "Errors detected in file system.\n";
-				return 1;
 			}
+			return 1;
 		}
-		else
-		{
-			std::cout << "Note: This card has no ECC data to validate.\n";
-			std::cout << "Use 'check' command to verify file system integrity.\n";
-		}
-
-		return 0;
 	}
-	catch (const std::exception& e)
+	else
 	{
-		Logger::error("Error: {}", e.what());
-		return 1;
+		std::cout << "Note: This card has no ECC data to validate.\n";
+		std::cout << "Use 'check' command to verify file system integrity.\n";
 	}
+
+	return 0;
 }

--- a/src/core/formats/ps2mc.cpp
+++ b/src/core/formats/ps2mc.cpp
@@ -74,7 +74,7 @@ bool PS2MemoryCard::usesEccForPath(const std::string& path, bool unknownFallback
 	return unknownFallback;
 }
 
-static void renameReplace(const std::filesystem::path& target, const std::filesystem::path& tmp)
+static bool renameReplace(const std::filesystem::path& target, const std::filesystem::path& tmp, Error& error)
 {
 	std::error_code ec;
 	std::filesystem::rename(tmp, target, ec);
@@ -87,13 +87,15 @@ static void renameReplace(const std::filesystem::path& target, const std::filesy
 	}
 	if (ec)
 	{
-		throw PS2McIOError("Failed to replace memory card file: " + ec.message());
+		return error.Fail("Failed to replace memory card file: " + ec.message());
 	}
+	return true;
 }
 
 class PS2MemoryCard::Impl
 {
 public:
+	Error& m_error;
 	std::fstream file;
 	std::string filename;
 
@@ -128,34 +130,39 @@ public:
 	std::map<uint32_t, std::vector<uint8_t>> page_cache;
 	std::map<uint32_t, std::vector<uint8_t>> fat_cluster_cache;
 
+	explicit Impl(Error& error)
+		: m_error(error)
+	{
+	}
+
 	void calculate_derived();
-	void parse_superblock_fields(const std::vector<uint8_t>& page);
+	bool parse_superblock_fields(const std::vector<uint8_t>& page);
 	std::vector<uint8_t> load_superblock();
-	void apply_layout(bool ecc, std::vector<uint8_t> sb_page);
+	bool apply_layout(bool ecc, std::vector<uint8_t> sb_page);
 	bool root_directory_ok();
-	void read_superblock();
+	bool read_superblock();
 	std::vector<uint8_t> read_page(uint32_t page_num);
-	void write_page(uint32_t page_num, const std::vector<uint8_t>& data);
+	bool write_page(uint32_t page_num, const std::vector<uint8_t>& data);
 	std::vector<uint8_t> read_cluster(uint32_t cluster_num);
-	void write_cluster(uint32_t cluster_num, const std::vector<uint8_t>& data);
+	bool write_cluster(uint32_t cluster_num, const std::vector<uint8_t>& data);
 	std::vector<uint32_t> read_fat_cluster(uint32_t fat_cluster_num);
-	void read_fat_from_card();
-	void write_fat_to_card();
+	bool read_fat_from_card();
+	bool write_fat_to_card();
 	uint32_t lookup_fat(uint32_t cluster_num);
-	PS2McDirEntry find_entry(const std::string& path, uint32_t& parent_cluster);
+	bool find_entry(const std::string& path, uint32_t& parent_cluster, PS2McDirEntry& out_entry, bool* path_not_found = nullptr, bool quiet = false);
 	std::vector<PS2McDirEntry> read_dirents(uint32_t dir_cluster);
-	void write_dirents(uint32_t dir_cluster, const std::vector<PS2McDirEntry>& entries);
-	void syncParentDirectoryEntryLength(uint32_t child_dir_cluster);
+	bool write_dirents(uint32_t dir_cluster, const std::vector<PS2McDirEntry>& entries);
+	bool syncParentDirectoryEntryLength(uint32_t child_dir_cluster);
 	uint32_t allocate_cluster();
 	std::vector<uint32_t> allocate_clusters(uint32_t count);
 	void free_cluster_chain(uint32_t start_cluster);
 
 	void init_card_parameters(int sizeInMB, bool disableEcc);
 	void calculate_fat_layout(uint32_t& first_ifc, uint32_t& indirect_fat_clusters, uint32_t& fat_clusters);
-	void create_empty_card_file(const std::string& filename, uint64_t totalBytes);
-	void write_superblock(uint32_t first_ifc, uint32_t indirect_fat_clusters, uint32_t good_block1, uint32_t good_block2);
-	void init_indirect_fat_clusters(uint32_t first_ifc, uint32_t indirect_fat_clusters, uint32_t epc);
-	void init_root_directory();
+	bool create_empty_card_file(const std::string& filename, uint64_t totalBytes);
+	bool write_superblock(uint32_t first_ifc, uint32_t indirect_fat_clusters, uint32_t good_block1, uint32_t good_block2);
+	bool init_indirect_fat_clusters(uint32_t first_ifc, uint32_t indirect_fat_clusters, uint32_t epc);
+	bool init_root_directory();
 };
 
 void PS2MemoryCard::Impl::calculate_derived()
@@ -166,7 +173,7 @@ void PS2MemoryCard::Impl::calculate_derived()
 	entries_per_cluster = cluster_size / 4; // 4 bytes per FAT entry
 }
 
-void PS2MemoryCard::Impl::parse_superblock_fields(const std::vector<uint8_t>& page)
+bool PS2MemoryCard::Impl::parse_superblock_fields(const std::vector<uint8_t>& page)
 {
 	page_size = readLE<uint16_t>(page, 40);
 	pages_per_cluster = readLE<uint16_t>(page, 42);
@@ -174,7 +181,7 @@ void PS2MemoryCard::Impl::parse_superblock_fields(const std::vector<uint8_t>& pa
 
 	if (page_size == 0 || pages_per_cluster == 0)
 	{
-		throw PS2McCorrupt("Invalid page/cluster size in superblock");
+		return m_error.Fail("Invalid page/cluster size in superblock");
 	}
 
 	calculate_derived();
@@ -213,13 +220,15 @@ void PS2MemoryCard::Impl::parse_superblock_fields(const std::vector<uint8_t>& pa
 	{
 		allocatable_cluster_end = clusters_per_card;
 	}
+	return true;
 }
 
 std::vector<uint8_t> PS2MemoryCard::Impl::read_page(uint32_t page_num)
 {
 	if (!file.is_open())
 	{
-		throw PS2McIOError("Memory card not open");
+		m_error.Fail("Memory card not open");
+		return {};
 	}
 
 	if (page_cache.count(page_num))
@@ -232,7 +241,8 @@ std::vector<uint8_t> PS2MemoryCard::Impl::read_page(uint32_t page_num)
 	file.seekg(offset);
 	if (!file)
 	{
-		throw PS2McIOError("Seek failed");
+		m_error.Fail("Seek failed");
+		return {};
 	}
 
 	std::vector<uint8_t> page_data(page_size);
@@ -240,7 +250,8 @@ std::vector<uint8_t> PS2MemoryCard::Impl::read_page(uint32_t page_num)
 
 	if (file.gcount() != static_cast<std::streamsize>(page_size))
 	{
-		throw PS2McIOError("Failed to read complete page");
+		m_error.Fail("Failed to read complete page");
+		return {};
 	}
 
 	if (spare_size > 0)
@@ -250,13 +261,15 @@ std::vector<uint8_t> PS2MemoryCard::Impl::read_page(uint32_t page_num)
 
 		if (file.gcount() != static_cast<std::streamsize>(spare_size))
 		{
-			throw PS2McIOError("Failed to read ECC spare data");
+			m_error.Fail("Failed to read ECC spare data");
+			return {};
 		}
 
 		const int ecc_status = eccCheckPage(page_data, spare, page_size);
 		if (ecc_status == ECC_CHECK_FAILED && !ignore_ecc)
 		{
-			throw PS2McCorrupt("Unrecoverable ECC error (page " + std::to_string(page_num) + ")");
+			m_error.Fail("Unrecoverable ECC error (page " + std::to_string(page_num) + ")");
+			return {};
 		}
 	}
 
@@ -264,51 +277,49 @@ std::vector<uint8_t> PS2MemoryCard::Impl::read_page(uint32_t page_num)
 	return page_data;
 }
 
-void PS2MemoryCard::Impl::write_page(uint32_t page_num, const std::vector<uint8_t>& data)
+bool PS2MemoryCard::Impl::write_page(uint32_t page_num, const std::vector<uint8_t>& data)
 {
 	if (!file.is_open())
 	{
-		throw PS2McIOError("Memory card not open");
+		return m_error.Fail("Memory card not open");
 	}
 
 	if (data.size() != page_size)
 	{
-		throw PS2McIOError("Invalid page data size");
+		return m_error.Fail("Invalid page data size");
 	}
 
 	uint64_t offset = static_cast<uint64_t>(page_num) * raw_page_size;
 	file.seekp(offset);
 	if (!file)
 	{
-		throw PS2McIOError("Seek failed");
+		return m_error.Fail("Seek failed");
 	}
 
 	file.write(reinterpret_cast<const char*>(data.data()), page_size);
 	if (!file)
 	{
-		throw PS2McIOError("Failed to write page");
+		return m_error.Fail("Failed to write page");
 	}
 
 	if (spare_size > 0)
 	{
 		std::vector<uint8_t> spare(spare_size, 0);
-		try
+		auto ecc_data = eccCalculatePage(data, page_size);
+		for (size_t i = 0; i < ecc_data.size() && i < spare_size; ++i)
 		{
-			auto ecc_data = eccCalculatePage(data, page_size);
-			for (size_t i = 0; i < ecc_data.size() && i < spare_size; ++i)
-			{
-				spare[i] = ecc_data[i];
-			}
-		}
-		catch (...)
-		{
-			// If ECC calculation fails, just write zeros
+			spare[i] = ecc_data[i];
 		}
 		file.write(reinterpret_cast<const char*>(spare.data()), spare_size);
+		if (!file)
+		{
+			return m_error.Fail("Failed to write page");
+		}
 	}
 
 	modified = true;
 	page_cache[page_num] = data;
+	return true;
 }
 
 std::vector<uint8_t> PS2MemoryCard::Impl::read_cluster(uint32_t cluster_num)
@@ -320,17 +331,21 @@ std::vector<uint8_t> PS2MemoryCard::Impl::read_cluster(uint32_t cluster_num)
 	{
 		uint32_t page_num = cluster_num * pages_per_cluster + i;
 		auto page_data = read_page(page_num);
+		if (page_data.empty())
+		{
+			return {};
+		}
 		result.insert(result.end(), page_data.begin(), page_data.end());
 	}
 
 	return result;
 }
 
-void PS2MemoryCard::Impl::write_cluster(uint32_t cluster_num, const std::vector<uint8_t>& data)
+bool PS2MemoryCard::Impl::write_cluster(uint32_t cluster_num, const std::vector<uint8_t>& data)
 {
 	if (data.size() != cluster_size)
 	{
-		throw PS2McIOError("Invalid cluster data size");
+		return m_error.Fail("Invalid cluster data size");
 	}
 
 	for (uint32_t i = 0; i < pages_per_cluster; ++i)
@@ -339,8 +354,12 @@ void PS2MemoryCard::Impl::write_cluster(uint32_t cluster_num, const std::vector<
 		std::vector<uint8_t> page_data(
 			data.begin() + static_cast<size_t>(i) * page_size,
 			data.begin() + static_cast<size_t>(i + 1) * page_size);
-		write_page(page_num, page_data);
+		if (!write_page(page_num, page_data))
+		{
+			return false;
+		}
 	}
+	return true;
 }
 
 std::vector<uint32_t> PS2MemoryCard::Impl::read_fat_cluster(uint32_t fat_cluster_num)
@@ -357,6 +376,10 @@ std::vector<uint32_t> PS2MemoryCard::Impl::read_fat_cluster(uint32_t fat_cluster
 	}
 
 	auto cluster_data = read_cluster(fat_cluster_num);
+	if (cluster_data.empty())
+	{
+		return {};
+	}
 	std::vector<uint32_t> result(entries_per_cluster);
 	for (uint32_t i = 0; i < entries_per_cluster; ++i)
 	{
@@ -367,7 +390,7 @@ std::vector<uint32_t> PS2MemoryCard::Impl::read_fat_cluster(uint32_t fat_cluster
 	return result;
 }
 
-void PS2MemoryCard::Impl::read_fat_from_card()
+bool PS2MemoryCard::Impl::read_fat_from_card()
 {
 	fat.clear();
 	fat.resize(allocatable_cluster_end, PS2MC_FAT_CHAIN_END_UNALLOC);
@@ -383,38 +406,39 @@ void PS2MemoryCard::Impl::read_fat_from_card()
 			continue;
 		}
 
-		try
+		auto indirect_data = read_cluster(indirect_cluster);
+		if (indirect_data.empty())
 		{
-			auto indirect_data = read_cluster(indirect_cluster);
+			return false;
+		}
 
-			for (uint32_t indirect_offset = 0; indirect_offset < entries_per_cluster && fat_entry < fat.size(); ++indirect_offset)
+		for (uint32_t indirect_offset = 0; indirect_offset < entries_per_cluster && fat_entry < fat.size(); ++indirect_offset)
+		{
+			uint32_t fat_cluster_ptr = readLE<uint32_t>(indirect_data, indirect_offset * 4);
+
+			if (fat_cluster_ptr == 0 || fat_cluster_ptr == 0xFFFFFFFF)
 			{
-				uint32_t fat_cluster_ptr = readLE<uint32_t>(indirect_data, indirect_offset * 4);
+				continue;
+			}
 
-				if (fat_cluster_ptr == 0 || fat_cluster_ptr == 0xFFFFFFFF)
+			auto fat_cluster = read_fat_cluster(fat_cluster_ptr);
+			if (fat_cluster.empty())
+			{
+				return false;
+			}
+
+			for (uint32_t j = 0; j < fat_cluster.size(); ++j)
+			{
+				if (fat_entry >= fat.size())
 				{
-					continue;
+					break;
 				}
-
-				auto fat_cluster = read_fat_cluster(fat_cluster_ptr);
-
-				for (uint32_t j = 0; j < fat_cluster.size(); ++j)
-				{
-					if (fat_entry >= fat.size())
-					{
-						break;
-					}
-					fat[fat_entry] = fat_cluster[j];
-					fat_entry++;
-				}
+				fat[fat_entry] = fat_cluster[j];
+				fat_entry++;
 			}
 		}
-		catch (...)
-		{
-			// Skip bad clusters and continue
-			continue;
-		}
 	}
+	return true;
 }
 
 std::vector<uint8_t> PS2MemoryCard::Impl::load_superblock()
@@ -424,24 +448,32 @@ std::vector<uint8_t> PS2MemoryCard::Impl::load_superblock()
 	file.read(reinterpret_cast<char*>(sb_page.data()), page_size);
 	if (file.gcount() != static_cast<std::streamsize>(page_size))
 	{
-		throw PS2McIOError("Failed to read superblock");
+		m_error.Fail("Failed to read superblock");
+		return {};
 	}
 
 	const char* MAGIC = "Sony PS2 Memory Card Format ";
 	if (sb_page.size() < 28 || std::memcmp(sb_page.data(), MAGIC, 28) != 0)
 	{
-		throw PS2McCorrupt("Invalid memory card magic");
+		m_error.Fail("Invalid memory card magic");
+		return {};
 	}
 
-	parse_superblock_fields(sb_page);
+	if (!parse_superblock_fields(sb_page))
+	{
+		return {};
+	}
 	return sb_page;
 }
 
-void PS2MemoryCard::Impl::apply_layout(bool ecc, std::vector<uint8_t> sb_page)
+bool PS2MemoryCard::Impl::apply_layout(bool ecc, std::vector<uint8_t> sb_page)
 {
 	page_cache.clear();
 	fat_cluster_cache.clear();
-	parse_superblock_fields(sb_page);
+	if (!parse_superblock_fields(sb_page))
+	{
+		return false;
+	}
 
 	if (ecc)
 	{
@@ -459,7 +491,10 @@ void PS2MemoryCard::Impl::apply_layout(bool ecc, std::vector<uint8_t> sb_page)
 				{
 					sb_page = std::move(page);
 					if (ecc_status == ECC_CHECK_CORRECTED)
-						parse_superblock_fields(sb_page);
+						if (!parse_superblock_fields(sb_page))
+						{
+							return false;
+						}
 				}
 			}
 		}
@@ -472,7 +507,7 @@ void PS2MemoryCard::Impl::apply_layout(bool ecc, std::vector<uint8_t> sb_page)
 	}
 
 	page_cache[0] = std::move(sb_page);
-	read_fat_from_card();
+	return read_fat_from_card();
 }
 
 bool PS2MemoryCard::Impl::root_directory_ok()
@@ -485,9 +520,13 @@ bool PS2MemoryCard::Impl::root_directory_ok()
 	       (entries[1].mode & DF_DIR);
 }
 
-void PS2MemoryCard::Impl::read_superblock()
+bool PS2MemoryCard::Impl::read_superblock()
 {
 	auto sb_page = load_superblock();
+	if (sb_page.empty())
+	{
+		return false;
+	}
 
 	const uint32_t total_pages = clusters_per_card * pages_per_cluster;
 	const uint32_t ecc_spare = divRoundUp(page_size, 128) * 4;
@@ -500,20 +539,26 @@ void PS2MemoryCard::Impl::read_superblock()
 	if (file_size < expected_with_ecc)
 		ecc = false;
 
-	apply_layout(ecc, std::move(sb_page));
+	return apply_layout(ecc, std::move(sb_page));
 }
 
 uint32_t PS2MemoryCard::Impl::lookup_fat(uint32_t cluster_num)
 {
 	if (cluster_num >= fat.size())
 	{
-		throw PS2McIOError("FAT index out of range");
+		m_error.Fail("FAT index out of range");
+		return PS2MC_FAT_CHAIN_END;
 	}
 	return fat[cluster_num];
 }
 
-PS2McDirEntry PS2MemoryCard::Impl::find_entry(const std::string& path, uint32_t& parent_cluster)
+bool PS2MemoryCard::Impl::find_entry(const std::string& path, uint32_t& parent_cluster, PS2McDirEntry& out_entry, bool* path_not_found, bool quiet)
 {
+	if (path_not_found)
+	{
+		*path_not_found = false;
+	}
+
 	std::vector<std::string> parts;
 	if (path != "/")
 	{
@@ -533,17 +578,29 @@ PS2McDirEntry PS2MemoryCard::Impl::find_entry(const std::string& path, uint32_t&
 		}
 	}
 
+	if (parts.empty())
+	{
+		out_entry = {};
+		out_entry.mode = DF_DIR | DF_EXISTS;
+		out_entry.name = "/";
+		out_entry.cluster = rootdir_fat_cluster;
+		return true;
+	}
+
 	uint32_t current_cluster = rootdir_fat_cluster;
 	parent_cluster = current_cluster;
+	PS2McDirEntry found_entry{};
 
 	for (size_t i = 0; i < parts.size(); ++i)
 	{
 		const auto& part = parts[i];
 		auto entries = read_dirents(current_cluster);
+		if (m_error.IsValid())
+		{
+			return false;
+		}
 
-		PS2McDirEntry found_entry;
 		bool found = false;
-
 		for (const auto& e : entries)
 		{
 			if (e.name == part)
@@ -556,45 +613,44 @@ PS2McDirEntry PS2MemoryCard::Impl::find_entry(const std::string& path, uint32_t&
 
 		if (!found)
 		{
-			throw PS2McPathNotFound(path);
+			if (path_not_found)
+			{
+				*path_not_found = true;
+			}
+			if (!quiet)
+			{
+				m_error.Fail("Path not found: " + path);
+			}
+			return false;
 		}
 
 		if (i < parts.size() - 1)
 		{
 			if (!(found_entry.mode & DF_DIR))
 			{
-				throw PS2McIOError("Path component is not a directory");
+				if (!quiet)
+				{
+					m_error.Fail("Path component is not a directory");
+				}
+				return false;
 			}
-		}
-
-		parent_cluster = current_cluster;
-		current_cluster = found_entry.cluster;
-	}
-
-	if (parts.empty())
-	{
-		PS2McDirEntry root;
-		root.mode = DF_DIR | DF_EXISTS;
-		root.name = "/";
-		root.cluster = rootdir_fat_cluster;
-		return root;
-	}
-
-	auto entries = read_dirents(parent_cluster);
-	for (const auto& e : entries)
-	{
-		if (e.name == parts.back())
-		{
-			return e;
+			parent_cluster = current_cluster;
+			current_cluster = found_entry.cluster;
 		}
 	}
 
-	throw PS2McPathNotFound(path);
+	out_entry = found_entry;
+	return true;
 }
 
 std::vector<PS2McDirEntry> PS2MemoryCard::Impl::read_dirents(uint32_t dir_cluster)
 {
 	std::vector<PS2McDirEntry> entries;
+	if (dir_cluster >= fat.size())
+	{
+		m_error.Fail("Directory cluster out of range");
+		return {};
+	}
 
 	uint32_t current_cluster = dir_cluster;
 	int iteration = 0;
@@ -603,11 +659,16 @@ std::vector<PS2McDirEntry> PS2MemoryCard::Impl::read_dirents(uint32_t dir_cluste
 	{
 		iteration++;
 		if (iteration > 1000)
-		{ // Safety limit
-			break;
+		{
+			m_error.Fail("Directory chain exceeds safety limit");
+			return {};
 		}
 		uint32_t disk_cluster = current_cluster + allocatable_cluster_offset;
 		auto cluster_data = read_cluster(disk_cluster);
+		if (cluster_data.empty())
+		{
+			return {};
+		}
 
 		uint32_t entries_per_cluster_block = cluster_size / PS2MC_DIRENT_LENGTH;
 
@@ -656,8 +717,17 @@ std::vector<PS2McDirEntry> PS2MemoryCard::Impl::read_dirents(uint32_t dir_cluste
 	return entries;
 }
 
-void PS2MemoryCard::Impl::write_dirents(uint32_t dir_cluster, const std::vector<PS2McDirEntry>& entries)
+bool PS2MemoryCard::Impl::write_dirents(uint32_t dir_cluster, const std::vector<PS2McDirEntry>& entries)
 {
+	if (dir_cluster >= fat.size())
+	{
+		return m_error.Fail("Directory cluster out of range");
+	}
+	if (entries.empty())
+	{
+		return true;
+	}
+
 	uint32_t current_cluster = dir_cluster;
 	uint32_t entry_idx = 0;
 	int iteration = 0;
@@ -667,7 +737,7 @@ void PS2MemoryCard::Impl::write_dirents(uint32_t dir_cluster, const std::vector<
 		iteration++;
 		if (iteration > 1000)
 		{
-			break;
+			return m_error.Fail("Directory chain exceeds safety limit");
 		}
 
 		std::vector<uint8_t> cluster_data(cluster_size, 0);
@@ -681,7 +751,10 @@ void PS2MemoryCard::Impl::write_dirents(uint32_t dir_cluster, const std::vector<
 		}
 
 		uint32_t disk_cluster = current_cluster + allocatable_cluster_offset;
-		write_cluster(disk_cluster, cluster_data);
+		if (!write_cluster(disk_cluster, cluster_data))
+		{
+			return false;
+		}
 
 		if (entry_idx < entries.size())
 		{
@@ -690,6 +763,10 @@ void PS2MemoryCard::Impl::write_dirents(uint32_t dir_cluster, const std::vector<
 			if (next >= fat.size() || next == PS2MC_FAT_CHAIN_END_UNALLOC || next == PS2MC_FAT_CHAIN_END)
 			{
 				uint32_t new_cluster = allocate_cluster();
+				if (new_cluster == PS2MC_FAT_CHAIN_END)
+				{
+					return false;
+				}
 				fat[current_cluster] = (fat[current_cluster] & ~PS2MC_FAT_CLUSTER_MASK) | (new_cluster | PS2MC_FAT_ALLOCATED_BIT);
 				fat[new_cluster] = PS2MC_FAT_CHAIN_END;
 				current_cluster = new_cluster;
@@ -719,20 +796,29 @@ void PS2MemoryCard::Impl::write_dirents(uint32_t dir_cluster, const std::vector<
 			next = temp;
 		}
 	}
+	return true;
 }
 
-void PS2MemoryCard::Impl::syncParentDirectoryEntryLength(uint32_t child_dir_cluster)
+bool PS2MemoryCard::Impl::syncParentDirectoryEntryLength(uint32_t child_dir_cluster)
 {
 	auto child = read_dirents(child_dir_cluster);
+	if (m_error.IsValid())
+	{
+		return false;
+	}
 	if (child.empty() || child[0].name != ".")
 	{
-		return;
+		return true;
 	}
 	const uint32_t newLen = child[0].length;
 	const uint32_t ancestor = child[0].cluster;
 	const uint32_t slot = child[0].dirEntry;
 
 	auto ancestor_entries = read_dirents(ancestor);
+	if (m_error.IsValid())
+	{
+		return false;
+	}
 	bool updated = false;
 	if (slot < ancestor_entries.size() && (ancestor_entries[slot].mode & DF_DIR) && ancestor_entries[slot].cluster == child_dir_cluster)
 	{
@@ -753,8 +839,9 @@ void PS2MemoryCard::Impl::syncParentDirectoryEntryLength(uint32_t child_dir_clus
 	}
 	if (updated)
 	{
-		write_dirents(ancestor, ancestor_entries);
+		return write_dirents(ancestor, ancestor_entries);
 	}
+	return true;
 }
 
 uint32_t PS2MemoryCard::Impl::allocate_cluster()
@@ -769,7 +856,8 @@ uint32_t PS2MemoryCard::Impl::allocate_cluster()
 		}
 	}
 
-	throw PS2McIOError("No free clusters available on memory card");
+	m_error.Fail("No free clusters available on memory card");
+	return PS2MC_FAT_CHAIN_END;
 }
 
 std::vector<uint32_t> PS2MemoryCard::Impl::allocate_clusters(uint32_t count)
@@ -780,6 +868,14 @@ std::vector<uint32_t> PS2MemoryCard::Impl::allocate_clusters(uint32_t count)
 	for (uint32_t i = 0; i < count; ++i)
 	{
 		uint32_t cluster = allocate_cluster();
+		if (cluster == PS2MC_FAT_CHAIN_END)
+		{
+			for (uint32_t c : clusters)
+			{
+				fat[c] = PS2MC_FAT_CHAIN_END_UNALLOC;
+			}
+			return {};
+		}
 		clusters.push_back(cluster);
 
 		if (i > 0)
@@ -818,7 +914,7 @@ void PS2MemoryCard::Impl::free_cluster_chain(uint32_t start_cluster)
 	modified = true;
 }
 
-void PS2MemoryCard::Impl::write_fat_to_card()
+bool PS2MemoryCard::Impl::write_fat_to_card()
 {
 	uint32_t fat_entry_idx = 0;
 
@@ -829,6 +925,10 @@ void PS2MemoryCard::Impl::write_fat_to_card()
 			continue;
 
 		auto indirect_data = read_cluster(indirect_cluster);
+		if (indirect_data.empty())
+		{
+			return false;
+		}
 		for (uint32_t j = 0; j < entries_per_cluster; ++j)
 		{
 			uint32_t fat_cluster_phys = readLE<uint32_t>(indirect_data, j * 4);
@@ -847,7 +947,10 @@ void PS2MemoryCard::Impl::write_fat_to_card()
 				writeLE(fat_data, k * 4, entry);
 			}
 
-			write_cluster(fat_cluster_phys, fat_data);
+			if (!write_cluster(fat_cluster_phys, fat_data))
+			{
+				return false;
+			}
 
 			if (fat_entry_idx >= fat.size())
 				break;
@@ -856,26 +959,21 @@ void PS2MemoryCard::Impl::write_fat_to_card()
 		if (fat_entry_idx >= fat.size())
 			break;
 	}
+	return true;
 }
 
 PS2MemoryCard::PS2MemoryCard()
-	: pImpl(std::make_unique<Impl>())
+	: pImpl(std::make_unique<Impl>(m_error))
 {
 }
 PS2MemoryCard::~PS2MemoryCard()
 {
-	try
-	{
-		close();
-	}
-	catch (...)
-	{
-		// ignore
-	}
+	close();
 }
 
-void PS2MemoryCard::open(const std::string& path, bool ignoreEcc)
+bool PS2MemoryCard::open(const std::string& path, bool ignoreEcc)
 {
+	m_error.Clear();
 	pImpl->filename = path;
 	pImpl->ignore_ecc = ignoreEcc;
 	pImpl->file.open(path, std::ios::in | std::ios::out | std::ios::binary);
@@ -885,11 +983,16 @@ void PS2MemoryCard::open(const std::string& path, bool ignoreEcc)
 		pImpl->file.open(path, std::ios::in | std::ios::binary);
 		if (!pImpl->file)
 		{
-			throw PS2McIOError("Failed to open memory card: " + path);
+			return m_error.Fail("Failed to open memory card: " + path);
 		}
 	}
 
 	auto sb_page = pImpl->load_superblock();
+	if (sb_page.empty())
+	{
+		close();
+		return false;
+	}
 
 	const uint32_t total_pages = pImpl->clusters_per_card * pImpl->pages_per_cluster;
 	const uint32_t ecc_spare = divRoundUp(pImpl->page_size, 128) * 4;
@@ -901,23 +1004,23 @@ void PS2MemoryCard::open(const std::string& path, bool ignoreEcc)
 	const bool can_ecc = file_size >= expected_with_ecc;
 
 	auto try_layout = [this, &sb_page](bool ecc) {
-		pImpl->apply_layout(ecc, sb_page);
-		try
-		{
-			return pImpl->root_directory_ok();
-		}
-		catch (...)
-		{
-			return false;
-		}
+		return pImpl->apply_layout(ecc, sb_page) && pImpl->root_directory_ok();
 	};
 
+	m_error.Clear();
 	if (can_ecc && try_layout(true))
-		return;
+		return true;
+	m_error.Clear();
 	if (try_layout(false))
-		return;
+		return true;
 
-	throw PS2McCorrupt("Root directory damaged");
+	if (m_error.IsValid())
+	{
+		close();
+		return false;
+	}
+	close();
+	return m_error.Fail("Root directory damaged");
 }
 
 void PS2MemoryCard::close()
@@ -978,12 +1081,12 @@ void PS2MemoryCard::Impl::calculate_fat_layout(uint32_t& first_ifc, uint32_t& in
 	fat_clusters_out = fat_clusters;
 }
 
-void PS2MemoryCard::Impl::create_empty_card_file(const std::string& fname, uint64_t totalBytes)
+bool PS2MemoryCard::Impl::create_empty_card_file(const std::string& fname, uint64_t totalBytes)
 {
 	std::ofstream ofs(fname, std::ios::binary | std::ios::out);
 	if (!ofs)
 	{
-		throw PS2McIOError("Could not create file: " + fname);
+		return m_error.Fail("Could not create file: " + fname);
 	}
 
 	std::vector<char> chunk(65536, 0);
@@ -992,11 +1095,16 @@ void PS2MemoryCard::Impl::create_empty_card_file(const std::string& fname, uint6
 	{
 		uint64_t toWrite = (std::min)((uint64_t)chunk.size(), totalBytes - written);
 		ofs.write(chunk.data(), toWrite);
+		if (!ofs)
+		{
+			return m_error.Fail("Could not create file: " + fname);
+		}
 		written += toWrite;
 	}
+	return true;
 }
 
-void PS2MemoryCard::Impl::write_superblock(uint32_t first_ifc, uint32_t indirect_fat_clusters, uint32_t good_block1, uint32_t good_block2)
+bool PS2MemoryCard::Impl::write_superblock(uint32_t first_ifc, uint32_t indirect_fat_clusters, uint32_t good_block1, uint32_t good_block2)
 {
 	std::vector<uint8_t> sb(page_size, 0);
 	std::memcpy(sb.data(), "Sony PS2 Memory Card Format ", 28);
@@ -1030,7 +1138,10 @@ void PS2MemoryCard::Impl::write_superblock(uint32_t first_ifc, uint32_t indirect
 	card_type = 2;
 	card_flags = sb[337];
 
-	write_page(0, sb);
+	if (!write_page(0, sb))
+	{
+		return false;
+	}
 
 	const uint64_t backup2_offset = static_cast<uint64_t>(good_block2) * pages_per_erase_block * raw_page_size;
 	std::vector<uint8_t> erased_page(raw_page_size, 0xFF);
@@ -1041,12 +1152,13 @@ void PS2MemoryCard::Impl::write_superblock(uint32_t first_ifc, uint32_t indirect
 			static_cast<std::streamsize>(erased_page.size()));
 		if (!file)
 		{
-			throw PS2McIOError("Failed to initialize backup erase block");
+			return m_error.Fail("Failed to initialize backup erase block");
 		}
 	}
+	return true;
 }
 
-void PS2MemoryCard::Impl::init_indirect_fat_clusters(uint32_t first_ifc, uint32_t indirect_fat_clusters, uint32_t epc)
+bool PS2MemoryCard::Impl::init_indirect_fat_clusters(uint32_t first_ifc, uint32_t indirect_fat_clusters, uint32_t epc)
 {
 	uint32_t current_fat_cluster_phys = first_ifc + indirect_fat_clusters;
 
@@ -1066,17 +1178,24 @@ void PS2MemoryCard::Impl::init_indirect_fat_clusters(uint32_t first_ifc, uint32_
 				writeLE<uint32_t>(ifc_data, j * 4, 0xFFFFFFFF);
 			}
 		}
-		write_cluster(ifc_phys, ifc_data);
+		if (!write_cluster(ifc_phys, ifc_data))
+		{
+			return false;
+		}
 	}
+	return true;
 }
 
-void PS2MemoryCard::Impl::init_root_directory()
+bool PS2MemoryCard::Impl::init_root_directory()
 {
 	fat.clear();
 	fat.resize(allocatable_cluster_end, PS2MC_FAT_CHAIN_END_UNALLOC);
 	fat[0] = PS2MC_FAT_CHAIN_END;
 
-	write_fat_to_card();
+	if (!write_fat_to_card())
+	{
+		return false;
+	}
 
 	std::vector<PS2McDirEntry> rootEntries;
 
@@ -1098,11 +1217,12 @@ void PS2MemoryCard::Impl::init_root_directory()
 	dotdot.modified = dot.modified;
 	rootEntries.push_back(dotdot);
 
-	write_dirents(0, rootEntries);
+	return write_dirents(0, rootEntries);
 }
 
-void PS2MemoryCard::create(const std::string& filename, int sizeInMB, bool disableEcc)
+bool PS2MemoryCard::create(const std::string& filename, int sizeInMB, bool disableEcc)
 {
+	m_error.Clear();
 	close();
 
 	pImpl->filename = filename;
@@ -1119,24 +1239,40 @@ void PS2MemoryCard::create(const std::string& filename, int sizeInMB, bool disab
 	uint64_t totalBytes = static_cast<uint64_t>(pImpl->clusters_per_card) *
 	                      pImpl->pages_per_cluster * pImpl->raw_page_size;
 
-	pImpl->create_empty_card_file(filename, totalBytes);
+	if (!pImpl->create_empty_card_file(filename, totalBytes))
+	{
+		return false;
+	}
 
 	pImpl->file.open(filename, std::ios::in | std::ios::out | std::ios::binary);
 	if (!pImpl->file)
 	{
-		throw PS2McIOError("Failed to open created card");
+		return m_error.Fail("Failed to open created card");
 	}
 
-	pImpl->write_superblock(first_ifc, indirect_fat_clusters, good_block1, good_block2);
+	if (!pImpl->write_superblock(first_ifc, indirect_fat_clusters, good_block1, good_block2))
+	{
+		return false;
+	}
 
 	uint32_t epc = pImpl->cluster_size / 4;
-	pImpl->init_indirect_fat_clusters(first_ifc, indirect_fat_clusters, epc);
+	if (!pImpl->init_indirect_fat_clusters(first_ifc, indirect_fat_clusters, epc))
+	{
+		return false;
+	}
 
-	pImpl->init_root_directory();
+	return pImpl->init_root_directory();
 }
 
 std::vector<PS2McDirEntry> PS2MemoryCard::listDir(const std::string& path)
 {
+	m_error.Clear();
+	if (!pImpl->file.is_open())
+	{
+		m_error.Fail("Memory card not open");
+		return {};
+	}
+
 	std::string check_path = path.empty() ? "/" : path;
 
 	if (check_path == "/")
@@ -1145,21 +1281,56 @@ std::vector<PS2McDirEntry> PS2MemoryCard::listDir(const std::string& path)
 	}
 
 	uint32_t parent_cluster = 0;
-	auto entry = pImpl->find_entry(check_path, parent_cluster);
+	PS2McDirEntry entry{};
+	if (!pImpl->find_entry(check_path, parent_cluster, entry))
+	{
+		return {};
+	}
 
 	if (!(entry.mode & DF_DIR))
 	{
-		throw PS2McIOError("Not a directory: " + path);
+		m_error.Fail("Not a directory: " + path);
+		return {};
 	}
 
 	return pImpl->read_dirents(entry.cluster);
 }
 
+bool PS2MemoryCard::hasEntry(const std::string& path)
+{
+	if (!pImpl || !pImpl->file.is_open())
+	{
+		return false;
+	}
+
+	std::string check_path = path.empty() ? "/" : path;
+	if (check_path == "/")
+	{
+		return true;
+	}
+
+	uint32_t parent_cluster = 0;
+	PS2McDirEntry entry{};
+	bool path_not_found = false;
+	if (pImpl->find_entry(check_path, parent_cluster, entry, &path_not_found, /*quiet=*/true))
+	{
+		return (entry.mode & DF_EXISTS) != 0;
+	}
+	return false;
+}
+
 PS2McDirEntry PS2MemoryCard::getEntry(const std::string& path)
 {
+	m_error.Clear();
+	if (!pImpl->file.is_open())
+	{
+		m_error.Fail("Memory card not open");
+		return {};
+	}
+
 	if (path == "/")
 	{
-		PS2McDirEntry root;
+		PS2McDirEntry root{};
 		root.mode = DF_DIR | DF_EXISTS;
 		root.name = "/";
 		root.cluster = pImpl->rootdir_fat_cluster;
@@ -1167,17 +1338,37 @@ PS2McDirEntry PS2MemoryCard::getEntry(const std::string& path)
 	}
 
 	uint32_t parent_cluster = 0;
-	return pImpl->find_entry(path, parent_cluster);
+	PS2McDirEntry entry{};
+	pImpl->find_entry(path, parent_cluster, entry);
+	return entry;
 }
 
-std::vector<uint8_t> PS2MemoryCard::readFile(const std::string& path)
+std::vector<uint8_t> PS2MemoryCard::readFile(const std::string& path, bool quiet)
 {
+	m_error.Clear();
+	if (!pImpl->file.is_open())
+	{
+		if (!quiet)
+		{
+			m_error.Fail("Memory card not open");
+		}
+		return {};
+	}
+
 	uint32_t parent_cluster = 0;
-	auto entry = pImpl->find_entry(path, parent_cluster);
+	PS2McDirEntry entry{};
+	if (!pImpl->find_entry(path, parent_cluster, entry, nullptr, quiet))
+	{
+		return {};
+	}
 
 	if (entry.mode & DF_DIR)
 	{
-		throw PS2McIOError("Cannot read directory as file");
+		if (!quiet)
+		{
+			m_error.Fail("Cannot read directory as file");
+		}
+		return {};
 	}
 
 	std::vector<uint8_t> result;
@@ -1191,6 +1382,10 @@ std::vector<uint8_t> PS2MemoryCard::readFile(const std::string& path)
 	{
 		uint32_t disk_cluster = current_cluster + pImpl->allocatable_cluster_offset;
 		auto cluster_data = pImpl->read_cluster(disk_cluster);
+		if (cluster_data.empty())
+		{
+			return {};
+		}
 		uint32_t remaining = entry.length - bytes_read;
 		uint32_t to_read = remaining < pImpl->cluster_size ? remaining : pImpl->cluster_size;
 
@@ -1207,60 +1402,61 @@ std::vector<uint8_t> PS2MemoryCard::readFile(const std::string& path)
 		current_cluster = next;
 	}
 
+	if (bytes_read != entry.length)
+	{
+		m_error.Fail("File data is truncated: " + path);
+		return {};
+	}
 	return result;
 }
 
-void PS2MemoryCard::exportFile(const std::string& path, const std::string& dest_path)
+bool PS2MemoryCard::exportFile(const std::string& path, const std::string& dest_path)
 {
 	auto data = readFile(path);
+	if (m_error.IsValid())
+	{
+		return false;
+	}
 	std::ofstream outfile(dest_path, std::ios::binary);
 	if (!outfile)
 	{
-		throw PS2McIOError("Failed to create export file: " + dest_path);
+		return m_error.Fail("Failed to create export file: " + dest_path);
 	}
 	outfile.write(reinterpret_cast<const char*>(data.data()), data.size());
+	if (!outfile)
+	{
+		return m_error.Fail("Failed to write export file: " + dest_path);
+	}
+	return true;
 }
 
 std::vector<uint8_t> PS2MemoryCard::getIconData(const std::string& savePath)
 {
 	Logger::debug("getIconData: Trying to load icon for path: {}", savePath);
 
-	try
+	std::string iconSysPath = savePath + "/icon.sys";
+	Logger::debug("getIconData: Trying to read icon.sys at: {}", iconSysPath);
+	auto iconSysData = readFile(iconSysPath, /*quiet=*/true);
+	if (!iconSysData.empty())
 	{
-		std::string iconSysPath = savePath + "/icon.sys";
-		Logger::debug("getIconData: Trying to read icon.sys at: {}", iconSysPath);
-		auto iconSysData = readFile(iconSysPath);
-		if (!iconSysData.empty())
-		{
-			Logger::debug("getIconData: icon.sys loaded, size: {}", iconSysData.size());
-			PS2IconSys iconSys;
-			iconSys.load(iconSysData);
+		Logger::debug("getIconData: icon.sys loaded, size: {}", iconSysData.size());
+		PS2IconSys iconSys;
+		iconSys.load(iconSysData);
 
-			std::string iconFile = iconSys.getIconFileNormal();
-			Logger::debug("getIconData: icon.sys specifies icon file: {}", iconFile);
-			if (!iconFile.empty())
+		std::string iconFile = iconSys.getIconFileNormal();
+		Logger::debug("getIconData: icon.sys specifies icon file: {}", iconFile);
+		if (!iconFile.empty())
+		{
+			std::string iconPath = savePath + "/" + iconFile;
+			Logger::debug("getIconData: Trying to read icon at: {}", iconPath);
+			auto data = readFile(iconPath, /*quiet=*/true);
+			if (!data.empty())
 			{
-				try
-				{
-					std::string iconPath = savePath + "/" + iconFile;
-					Logger::debug("getIconData: Trying to read icon at: {}", iconPath);
-					auto data = readFile(iconPath);
-					if (!data.empty())
-					{
-						Logger::debug("getIconData: Successfully loaded icon, size: {}", data.size());
-						return data;
-					}
-				}
-				catch (const std::exception& e)
-				{
-					Logger::debug("getIconData: Exception reading icon file: {}", e.what());
-				}
+				Logger::debug("getIconData: Successfully loaded icon, size: {}", data.size());
+				m_error.Clear();
+				return data;
 			}
 		}
-	}
-	catch (const std::exception& e)
-	{
-		Logger::debug("getIconData: Exception reading icon.sys: {}", e.what());
 	}
 
 	std::vector<std::string> iconPaths = {
@@ -1270,125 +1466,103 @@ std::vector<uint8_t> PS2MemoryCard::getIconData(const std::string& savePath)
 
 	for (const auto& iconPath : iconPaths)
 	{
-		try
+		auto data = readFile(iconPath, /*quiet=*/true);
+		if (!data.empty())
 		{
-			auto data = readFile(iconPath);
-			if (!data.empty())
-			{
-				return data;
-			}
-		}
-		catch (...)
-		{
-			// Try next icon file
-			continue;
+			m_error.Clear();
+			return data;
 		}
 	}
 
-	// Return empty vector if no icon found
+	m_error.Clear();
 	return std::vector<uint8_t>();
 }
 
 PS2IconSys* PS2MemoryCard::getIconSys(const std::string& savePath)
 {
-	try
+	std::string iconSysPath = savePath + "/icon.sys";
+	auto iconSysData = readFile(iconSysPath, /*quiet=*/true);
+	m_error.Clear();
+
+	if (iconSysData.empty())
 	{
-		std::string iconSysPath = savePath + "/icon.sys";
-		auto iconSysData = readFile(iconSysPath);
-
-		if (iconSysData.empty())
-		{
-			return nullptr;
-		}
-
-		PS2IconSys* iconSys = new PS2IconSys();
-		iconSys->load(iconSysData);
-
-		return iconSys;
-	}
-	catch (const std::exception& e)
-	{
-		Logger::debug("getIconSys: Exception: {}", e.what());
 		return nullptr;
 	}
+
+	auto* iconSys = new PS2IconSys();
+	iconSys->load(iconSysData);
+
+	return iconSys;
 }
 
 std::string PS2MemoryCard::getSaveTitle(const std::string& savePath)
 {
-	try
-	{
-		auto iconData = readFile(savePath + "/icon.sys");
-		if (iconData.empty())
-		{
-			return "";
-		}
-
-		PS2IconSys iconSys;
-		iconSys.load(iconData);
-		return iconSys.getTitle();
-	}
-	catch (...)
+	auto iconData = readFile(savePath + "/icon.sys", /*quiet=*/true);
+	m_error.Clear();
+	if (iconData.empty())
 	{
 		return "";
 	}
+
+	PS2IconSys iconSys;
+	iconSys.load(iconData);
+	return iconSys.getTitle();
 }
 
 std::string PS2MemoryCard::getSaveSubtitle(const std::string& savePath)
 {
-	try
-	{
-		auto iconData = readFile(savePath + "/icon.sys");
-		if (iconData.empty())
-		{
-			return "";
-		}
-
-		PS2IconSys iconSys;
-		iconSys.load(iconData);
-		return iconSys.getSubtitle();
-	}
-	catch (...)
+	auto iconData = readFile(savePath + "/icon.sys", /*quiet=*/true);
+	m_error.Clear();
+	if (iconData.empty())
 	{
 		return "";
 	}
+
+	PS2IconSys iconSys;
+	iconSys.load(iconData);
+	return iconSys.getSubtitle();
 }
 
 uint32_t PS2MemoryCard::getSaveSize(const std::string& savePath)
 {
-	try
-	{
-		auto entries = listDir(savePath);
-
-		uint32_t totalSize = roundUp(static_cast<uint32_t>(entries.size()) * PS2MC_DIRENT_LENGTH, pImpl->cluster_size);
-
-		for (const auto& entry : entries)
-		{
-			if (entry.mode & DF_HIDDEN || entry.name == "." || entry.name == "..")
-			{
-				continue;
-			}
-
-			if (entry.mode & DF_DIR)
-			{
-				std::string subPath = savePath + "/" + entry.name;
-				totalSize += getSaveSize(subPath);
-			}
-			else
-			{
-				totalSize += roundUp(entry.length, pImpl->cluster_size);
-			}
-		}
-
-		return totalSize;
-	}
-	catch (...)
+	auto entries = listDir(savePath);
+	m_error.Clear();
+	if (entries.empty())
 	{
 		return 0;
 	}
+
+	uint32_t totalSize = roundUp(static_cast<uint32_t>(entries.size()) * PS2MC_DIRENT_LENGTH, pImpl->cluster_size);
+
+	for (const auto& entry : entries)
+	{
+		if (entry.mode & DF_HIDDEN || entry.name == "." || entry.name == "..")
+		{
+			continue;
+		}
+
+		if (entry.mode & DF_DIR)
+		{
+			std::string subPath = savePath + "/" + entry.name;
+			totalSize += getSaveSize(subPath);
+		}
+		else
+		{
+			totalSize += roundUp(entry.length, pImpl->cluster_size);
+		}
+	}
+
+	return totalSize;
 }
 
 uint32_t PS2MemoryCard::getFreeSpace()
 {
+	m_error.Clear();
+	if (!pImpl->file.is_open())
+	{
+		m_error.Fail("Memory card not open");
+		return 0;
+	}
 	uint32_t free_clusters = 0;
 	for (uint32_t entry : pImpl->fat)
 	{
@@ -1402,9 +1576,11 @@ uint32_t PS2MemoryCard::getFreeSpace()
 
 PS2MemoryCard::CardInfo PS2MemoryCard::getCardInfo()
 {
+	m_error.Clear();
 	if (!pImpl->file.is_open())
 	{
-		throw PS2McError("Memory card not open");
+		m_error.Fail("Memory card not open");
+		return {};
 	}
 
 	CardInfo info{};
@@ -1466,354 +1642,426 @@ PS2MemoryCard::CardInfo PS2MemoryCard::getCardInfo()
 	return info;
 }
 
-void PS2MemoryCard::makeDir(const std::string& path)
+bool PS2MemoryCard::makeDir(const std::string& path)
 {
+	m_error.Clear();
+	if (!pImpl->file.is_open())
+	{
+		return m_error.Fail("Memory card not open");
+	}
+
 	if (path == "/" || path.empty())
 	{
-		throw PS2McIOError("Invalid directory path");
+		return m_error.Fail("Invalid directory path");
 	}
 
-	try
+	uint32_t unusedParent = 0;
+	PS2McDirEntry existingEntry{};
+	bool path_not_found = false;
+	if (pImpl->find_entry(path, unusedParent, existingEntry, &path_not_found, /*quiet=*/true))
 	{
-		try
+		if (existingEntry.mode & DF_EXISTS)
 		{
-			uint32_t unusedParent = 0;
-			auto entry = pImpl->find_entry(path, unusedParent);
-			if (entry.mode & DF_EXISTS)
-			{
-				return;
-			}
+			return true;
 		}
-		catch (const PS2McIOError&)
-		{
-		}
-
-		size_t last_slash = path.rfind('/');
-		std::string parent_path = (last_slash == 0) ? "/" : path.substr(0, last_slash);
-		std::string dir_name = path.substr(last_slash + 1);
-
-		uint32_t parent_cluster = 0;
-		if (parent_path != "/")
-		{
-			auto parent_entry = pImpl->find_entry(parent_path, parent_cluster);
-			parent_cluster = parent_entry.cluster;
-		}
-		else
-		{
-			parent_cluster = pImpl->rootdir_fat_cluster;
-		}
-
-		uint32_t dir_cluster = pImpl->allocate_cluster();
-
-		auto parent_entries = pImpl->read_dirents(parent_cluster);
-		const uint32_t slot_for_new_dir = static_cast<uint32_t>(parent_entries.size());
-
-		const auto now = timeToTod(time(nullptr));
-
-		PS2McDirEntry new_dir_entry = {};
-		new_dir_entry.mode = DF_DIR | DF_EXISTS | DF_RWX | DF_0400;
-		new_dir_entry.name = dir_name;
-		new_dir_entry.cluster = dir_cluster;
-		new_dir_entry.length = 2;
-		new_dir_entry.created = now;
-		new_dir_entry.modified = now;
-
-		std::vector<PS2McDirEntry> new_dir_entries;
-
-		PS2McDirEntry dot_entry = {};
-		dot_entry.mode = DF_DIR | DF_EXISTS | DF_RWX | DF_0400;
-		dot_entry.name = ".";
-		dot_entry.cluster = parent_cluster;
-		dot_entry.length = 2;
-		dot_entry.created = now;
-		dot_entry.modified = now;
-		dot_entry.dirEntry = slot_for_new_dir;
-		new_dir_entries.push_back(dot_entry);
-
-		PS2McDirEntry dotdot_entry = {};
-		dotdot_entry.mode = DF_DIR | DF_EXISTS | DF_RWX | DF_0400;
-		dotdot_entry.name = "..";
-		dotdot_entry.cluster = 0;
-		dotdot_entry.length = 0;
-		dotdot_entry.created = now;
-		dotdot_entry.modified = now;
-		dotdot_entry.dirEntry = 0;
-		new_dir_entries.push_back(dotdot_entry);
-
-		pImpl->write_dirents(dir_cluster, new_dir_entries);
-
-		parent_entries.push_back(new_dir_entry);
-		if (!parent_entries.empty() && (parent_entries[0].mode & DF_DIR))
-		{
-			parent_entries[0].length = static_cast<uint32_t>(parent_entries.size());
-		}
-
-		pImpl->write_dirents(parent_cluster, parent_entries);
-
-		pImpl->write_fat_to_card();
-
-		pImpl->modified = true;
 	}
-	catch (const PS2McIOError&)
+	else if (!path_not_found)
 	{
-		throw;
+		return false;
 	}
-	catch (const std::exception& e)
+	m_error.Clear();
+
+	size_t last_slash = path.rfind('/');
+	std::string parent_path = (last_slash == 0) ? "/" : path.substr(0, last_slash);
+	std::string dir_name = path.substr(last_slash + 1);
+
+	uint32_t parent_cluster = 0;
+	if (parent_path != "/")
 	{
-		throw PS2McIOError(std::string("Failed to create directory: ") + e.what());
+		PS2McDirEntry parent_entry{};
+		if (!pImpl->find_entry(parent_path, parent_cluster, parent_entry))
+		{
+			return false;
+		}
+		parent_cluster = parent_entry.cluster;
 	}
+	else
+	{
+		parent_cluster = pImpl->rootdir_fat_cluster;
+	}
+
+	uint32_t dir_cluster = pImpl->allocate_cluster();
+	if (dir_cluster == PS2MC_FAT_CHAIN_END)
+	{
+		return false;
+	}
+
+	auto parent_entries = pImpl->read_dirents(parent_cluster);
+	if (m_error.IsValid())
+	{
+		return false;
+	}
+	const uint32_t slot_for_new_dir = static_cast<uint32_t>(parent_entries.size());
+
+	const auto now = timeToTod(time(nullptr));
+
+	PS2McDirEntry new_dir_entry = {};
+	new_dir_entry.mode = DF_DIR | DF_EXISTS | DF_RWX | DF_0400;
+	new_dir_entry.name = dir_name;
+	new_dir_entry.cluster = dir_cluster;
+	new_dir_entry.length = 2;
+	new_dir_entry.created = now;
+	new_dir_entry.modified = now;
+
+	std::vector<PS2McDirEntry> new_dir_entries;
+
+	PS2McDirEntry dot_entry = {};
+	dot_entry.mode = DF_DIR | DF_EXISTS | DF_RWX | DF_0400;
+	dot_entry.name = ".";
+	dot_entry.cluster = parent_cluster;
+	dot_entry.length = 2;
+	dot_entry.created = now;
+	dot_entry.modified = now;
+	dot_entry.dirEntry = slot_for_new_dir;
+	new_dir_entries.push_back(dot_entry);
+
+	PS2McDirEntry dotdot_entry = {};
+	dotdot_entry.mode = DF_DIR | DF_EXISTS | DF_RWX | DF_0400;
+	dotdot_entry.name = "..";
+	dotdot_entry.cluster = 0;
+	dotdot_entry.length = 0;
+	dotdot_entry.created = now;
+	dotdot_entry.modified = now;
+	dotdot_entry.dirEntry = 0;
+	new_dir_entries.push_back(dotdot_entry);
+
+	if (!pImpl->write_dirents(dir_cluster, new_dir_entries))
+	{
+		return false;
+	}
+
+	parent_entries.push_back(new_dir_entry);
+	if (!parent_entries.empty() && (parent_entries[0].mode & DF_DIR))
+	{
+		parent_entries[0].length = static_cast<uint32_t>(parent_entries.size());
+	}
+
+	if (!pImpl->write_dirents(parent_cluster, parent_entries))
+	{
+		return false;
+	}
+
+	if (!pImpl->write_fat_to_card())
+	{
+		return false;
+	}
+
+	pImpl->modified = true;
+	return true;
 }
 
-void PS2MemoryCard::writeFile(const std::string& path, const std::vector<uint8_t>& data)
+bool PS2MemoryCard::writeFile(const std::string& path, const std::vector<uint8_t>& data)
 {
+	m_error.Clear();
+	if (!pImpl->file.is_open())
+	{
+		return m_error.Fail("Memory card not open");
+	}
+
 	if (path == "/" || path.empty())
 	{
-		throw PS2McIOError("Invalid file path");
+		return m_error.Fail("Invalid file path");
 	}
 
-	try
+	uint32_t unusedParent = 0;
+	PS2McDirEntry existingEntry{};
+	bool path_not_found = false;
+	if (pImpl->find_entry(path, unusedParent, existingEntry, &path_not_found, /*quiet=*/true) && (existingEntry.mode & DF_EXISTS))
 	{
-		try
-		{
-			uint32_t unusedParent = 0;
-			auto entry = pImpl->find_entry(path, unusedParent);
-			if (entry.mode & DF_EXISTS)
-			{
-				throw PS2McIOError("File already exists: " + path);
-			}
-		}
-		catch (const PS2McPathNotFound&)
-		{
-		}
-
-		size_t last_slash = path.rfind('/');
-		std::string parent_path = (last_slash == 0) ? "/" : path.substr(0, last_slash);
-		std::string file_name = path.substr(last_slash + 1);
-
-		uint32_t parent_cluster = 0;
-		if (parent_path != "/")
-		{
-			auto parent_entry = pImpl->find_entry(parent_path, parent_cluster);
-			parent_cluster = parent_entry.cluster;
-		}
-		else
-		{
-			parent_cluster = pImpl->rootdir_fat_cluster;
-		}
-
-		// Calculate clusters needed
-		uint32_t clusters_needed = (static_cast<uint32_t>(data.size()) + pImpl->cluster_size - 1) / pImpl->cluster_size;
-		std::vector<uint32_t> file_clusters;
-		if (clusters_needed > 0)
-		{
-			file_clusters = pImpl->allocate_clusters(clusters_needed);
-		}
-
-		uint32_t offset = 0;
-		for (uint32_t cluster : file_clusters)
-		{
-			uint32_t remaining = static_cast<uint32_t>(data.size()) - offset;
-			uint32_t to_write = (pImpl->cluster_size < remaining) ? pImpl->cluster_size : remaining;
-			std::vector<uint8_t> cluster_data(pImpl->cluster_size, 0);
-
-			if (to_write > 0)
-			{
-				std::copy(data.begin() + offset, data.begin() + offset + to_write, cluster_data.begin());
-			}
-
-			uint32_t disk_cluster = cluster + pImpl->allocatable_cluster_offset;
-			pImpl->write_cluster(disk_cluster, cluster_data);
-
-			offset += to_write;
-		}
-
-		PS2McDirEntry file_entry = {};
-		file_entry.mode = DF_FILE | DF_EXISTS | DF_RWX | DF_0400;
-		file_entry.name = file_name;
-		file_entry.cluster = file_clusters.empty() ? PS2MC_FAT_CHAIN_END : file_clusters[0];
-		file_entry.length = static_cast<uint32_t>(data.size());
-		file_entry.created = timeToTod(time(nullptr));
-		file_entry.modified = file_entry.created;
-
-		auto parent_entries = pImpl->read_dirents(parent_cluster);
-		parent_entries.push_back(file_entry);
-		if (!parent_entries.empty() && (parent_entries[0].mode & DF_DIR) && parent_entries[0].name == ".")
-		{
-			parent_entries[0].length = static_cast<uint32_t>(parent_entries.size());
-		}
-		pImpl->write_dirents(parent_cluster, parent_entries);
-		pImpl->syncParentDirectoryEntryLength(parent_cluster);
-
-		pImpl->write_fat_to_card();
-
-		pImpl->modified = true;
+		return m_error.Fail("File already exists: " + path);
 	}
-	catch (const PS2McIOError&)
+	if (!path_not_found)
 	{
-		throw;
+		return false;
 	}
-	catch (const std::exception& e)
+	m_error.Clear();
+
+	size_t last_slash = path.rfind('/');
+	std::string parent_path = (last_slash == 0) ? "/" : path.substr(0, last_slash);
+	std::string file_name = path.substr(last_slash + 1);
+
+	uint32_t parent_cluster = 0;
+	if (parent_path != "/")
 	{
-		throw PS2McIOError(std::string("Failed to write file: ") + e.what());
+		PS2McDirEntry parent_entry{};
+		if (!pImpl->find_entry(parent_path, parent_cluster, parent_entry))
+		{
+			return false;
+		}
+		parent_cluster = parent_entry.cluster;
 	}
+	else
+	{
+		parent_cluster = pImpl->rootdir_fat_cluster;
+	}
+
+	// Calculate clusters needed
+	uint32_t clusters_needed = (static_cast<uint32_t>(data.size()) + pImpl->cluster_size - 1) / pImpl->cluster_size;
+	std::vector<uint32_t> file_clusters;
+	if (clusters_needed > 0)
+	{
+		file_clusters = pImpl->allocate_clusters(clusters_needed);
+		if (file_clusters.empty())
+		{
+			return false;
+		}
+	}
+
+	uint32_t offset = 0;
+	for (uint32_t cluster : file_clusters)
+	{
+		uint32_t remaining = static_cast<uint32_t>(data.size()) - offset;
+		uint32_t to_write = (pImpl->cluster_size < remaining) ? pImpl->cluster_size : remaining;
+		std::vector<uint8_t> cluster_data(pImpl->cluster_size, 0);
+
+		if (to_write > 0)
+		{
+			std::copy(data.begin() + offset, data.begin() + offset + to_write, cluster_data.begin());
+		}
+
+		uint32_t disk_cluster = cluster + pImpl->allocatable_cluster_offset;
+		if (!pImpl->write_cluster(disk_cluster, cluster_data))
+		{
+			return false;
+		}
+
+		offset += to_write;
+	}
+
+	PS2McDirEntry file_entry = {};
+	file_entry.mode = DF_FILE | DF_EXISTS | DF_RWX | DF_0400;
+	file_entry.name = file_name;
+	file_entry.cluster = file_clusters.empty() ? PS2MC_FAT_CHAIN_END : file_clusters[0];
+	file_entry.length = static_cast<uint32_t>(data.size());
+	file_entry.created = timeToTod(time(nullptr));
+	file_entry.modified = file_entry.created;
+
+	auto parent_entries = pImpl->read_dirents(parent_cluster);
+	if (m_error.IsValid())
+	{
+		return false;
+	}
+	parent_entries.push_back(file_entry);
+	if (!parent_entries.empty() && (parent_entries[0].mode & DF_DIR) && parent_entries[0].name == ".")
+	{
+		parent_entries[0].length = static_cast<uint32_t>(parent_entries.size());
+	}
+	if (!pImpl->write_dirents(parent_cluster, parent_entries) ||
+		!pImpl->syncParentDirectoryEntryLength(parent_cluster))
+	{
+		return false;
+	}
+
+	if (!pImpl->write_fat_to_card())
+	{
+		return false;
+	}
+
+	pImpl->modified = true;
+	return true;
 }
 
-void PS2MemoryCard::remove(const std::string& path)
+bool PS2MemoryCard::remove(const std::string& path)
 {
-	if (path == "/")
+	m_error.Clear();
+	if (!pImpl->file.is_open())
 	{
-		throw PS2McIOError("Cannot delete root directory");
+		return m_error.Fail("Memory card not open");
 	}
 
-	try
+	if (path == "/" || path.empty())
 	{
-		uint32_t parent_cluster = 0;
-		auto entry = pImpl->find_entry(path, parent_cluster);
+		return m_error.Fail("Cannot delete root directory");
+	}
 
-		if (!(entry.mode & DF_EXISTS))
+	uint32_t parent_cluster = 0;
+	PS2McDirEntry entry{};
+	if (!pImpl->find_entry(path, parent_cluster, entry))
+	{
+		return false;
+	}
+	if (!(entry.mode & DF_EXISTS))
+	{
+		return m_error.Fail("File not found: " + path);
+	}
+
+	entry.mode &= ~DF_EXISTS;
+
+	if (entry.mode & DF_DIR)
+	{
+		auto contents = listDir(path);
+		if (m_error.IsValid())
 		{
-			throw PS2McIOError("File not found: " + path);
+			return false;
 		}
-
-		entry.mode &= ~DF_EXISTS;
-
-		if (entry.mode & DF_DIR)
+		for (const auto& sub : contents)
 		{
-			try
+			if (sub.name == "." || sub.name == "..")
+				continue;
+			if (sub.mode & DF_EXISTS)
 			{
-				auto contents = listDir(path);
-				for (const auto& sub : contents)
+				if (!remove(path + "/" + sub.name))
 				{
-					if (sub.name == "." || sub.name == "..")
-						continue;
-					if (sub.mode & DF_EXISTS)
-					{
-						remove(path + "/" + sub.name);
-					}
+					return false;
 				}
 			}
-			catch (...)
-			{
-			}
-
-			uint32_t cluster = entry.cluster;
-			while (cluster != PS2MC_FAT_CHAIN_END && cluster < pImpl->fat.size())
-			{
-				uint32_t next = pImpl->fat[cluster] & PS2MC_FAT_CLUSTER_MASK;
-				pImpl->fat[cluster] = PS2MC_FAT_CHAIN_END_UNALLOC;
-				cluster = next;
-			}
 		}
-		else
+
+		uint32_t cluster = entry.cluster;
+		while (cluster != PS2MC_FAT_CHAIN_END && cluster < pImpl->fat.size())
 		{
-			uint32_t cluster = entry.cluster;
-			while (cluster != PS2MC_FAT_CHAIN_END && cluster < pImpl->fat.size())
-			{
-				uint32_t next = pImpl->fat[cluster] & PS2MC_FAT_CLUSTER_MASK;
-				pImpl->fat[cluster] = PS2MC_FAT_CHAIN_END_UNALLOC;
-				cluster = next;
-			}
+			uint32_t next = pImpl->fat[cluster] & PS2MC_FAT_CLUSTER_MASK;
+			pImpl->fat[cluster] = PS2MC_FAT_CHAIN_END_UNALLOC;
+			cluster = next;
 		}
-
-		auto parent_entries = pImpl->read_dirents(parent_cluster);
-		for (auto& e : parent_entries)
+	}
+	else
+	{
+		uint32_t cluster = entry.cluster;
+		while (cluster != PS2MC_FAT_CHAIN_END && cluster < pImpl->fat.size())
 		{
-			if (e.name == entry.name)
-			{
-				e.mode = entry.mode; // Update with deleted flag
-				break;
-			}
+			uint32_t next = pImpl->fat[cluster] & PS2MC_FAT_CLUSTER_MASK;
+			pImpl->fat[cluster] = PS2MC_FAT_CHAIN_END_UNALLOC;
+			cluster = next;
 		}
-
-		pImpl->write_dirents(parent_cluster, parent_entries);
-
-		pImpl->write_fat_to_card();
-		pImpl->file.flush();
-
-		pImpl->modified = true;
 	}
-	catch (const PS2McIOError&)
+
+	auto parent_entries = pImpl->read_dirents(parent_cluster);
+	if (m_error.IsValid())
 	{
-		throw;
+		return false;
 	}
-	catch (const std::exception& e)
+	for (auto& e : parent_entries)
 	{
-		throw PS2McIOError(std::string("Failed to delete: ") + e.what());
+		if (e.name == entry.name)
+		{
+			e.mode = entry.mode; // Update with deleted flag
+			break;
+		}
 	}
+
+	if (!pImpl->write_dirents(parent_cluster, parent_entries))
+	{
+		return false;
+	}
+
+	if (!pImpl->write_fat_to_card())
+	{
+		return false;
+	}
+	pImpl->file.flush();
+	if (!pImpl->file)
+	{
+		return m_error.Fail("Failed to flush memory card file");
+	}
+
+	pImpl->modified = true;
+	return true;
 }
+
 bool PS2MemoryCard::importSaveFile(PS2SaveFile& save, bool ignoreExisting, const std::string& targetDir)
 {
+	m_error.Clear();
 	if (!pImpl || !pImpl->file.is_open())
 	{
-		throw PS2McError("No memory card open");
+		return m_error.Fail("No memory card open");
 	}
 
-	try
+	const auto& entries = save.getEntries();
+	if (entries.empty())
 	{
-		const auto& entries = save.getEntries();
-		if (entries.empty())
+		return m_error.Fail("Save file contains no entries");
+	}
+
+	const bool hasDirHeader = (entries[0].dirEntry.mode & DF_DIR) != 0;
+	PS2McDirEntry dirEntry{};
+	if (hasDirHeader)
+	{
+		dirEntry = entries[0].dirEntry;
+	}
+	else
+	{
+		dirEntry.name = save.getTitle();
+		if (dirEntry.name.empty())
 		{
-			throw PS2McError("Save file contains no entries");
+			dirEntry.name = entries[0].dirEntry.name;
+		}
+		dirEntry.mode = DF_DIR | DF_EXISTS | DF_RWX | DF_0400;
+		dirEntry.created = entries[0].dirEntry.created;
+		dirEntry.modified = dirEntry.created;
+		dirEntry.unused = 0;
+		dirEntry.attr = 0;
+	}
+
+	std::string saveDirName = targetDir.empty() ? dirEntry.name : targetDir;
+
+	if (!saveDirName.empty() && saveDirName[0] == '/')
+	{
+		saveDirName = saveDirName.substr(1);
+	}
+
+	std::string savePath = "/" + saveDirName;
+
+	uint32_t dummy = 0;
+	PS2McDirEntry checkExisting{};
+	bool path_not_found = false;
+	if (pImpl->find_entry(savePath, dummy, checkExisting, &path_not_found, /*quiet=*/true))
+	{
+		if (!ignoreExisting)
+		{
+			return false; // Save already exists, not imported
 		}
 
-		const bool hasDirHeader = (entries[0].dirEntry.mode & DF_DIR) != 0;
-		PS2McDirEntry dirEntry{};
-		if (hasDirHeader)
+		if (!remove(savePath))
 		{
-			dirEntry = entries[0].dirEntry;
+			return false;
+		}
+	}
+	else if (!path_not_found)
+	{
+		return false;
+	}
+	m_error.Clear();
+
+	if (!makeDir(savePath))
+	{
+		return false;
+	}
+
+	const size_t firstFileIdx = hasDirHeader ? 1 : 0;
+	for (size_t i = firstFileIdx; i < entries.size(); ++i)
+	{
+		const auto& entry = entries[i];
+		std::string filePath = savePath + "/" + entry.dirEntry.name;
+
+		if (!writeFile(filePath, entry.data))
+		{
+			return false;
+		}
+
+		uint32_t parent_cluster_inner = 0;
+		PS2McDirEntry currentEntry{};
+		if (!pImpl->find_entry(filePath, parent_cluster_inner, currentEntry))
+		{
+			return false;
 		}
 		else
 		{
-			dirEntry.name = save.getTitle();
-			if (dirEntry.name.empty())
-			{
-				dirEntry.name = entries[0].dirEntry.name;
-			}
-			dirEntry.mode = DF_DIR | DF_EXISTS | DF_RWX | DF_0400;
-			dirEntry.created = entries[0].dirEntry.created;
-			dirEntry.modified = dirEntry.created;
-			dirEntry.unused = 0;
-			dirEntry.attr = 0;
-		}
-
-		std::string saveDirName = targetDir.empty() ? dirEntry.name : targetDir;
-
-		if (!saveDirName.empty() && saveDirName[0] == '/')
-		{
-			saveDirName = saveDirName.substr(1);
-		}
-
-		std::string savePath = "/" + saveDirName;
-
-		try
-		{
-			uint32_t dummy = 0;
-			pImpl->find_entry(savePath, dummy);
-
-			if (!ignoreExisting)
-			{
-				return false; // Save already exists, not imported
-			}
-
-			remove(savePath);
-		}
-		catch (const PS2McPathNotFound&)
-		{
-		}
-
-		makeDir(savePath);
-
-		const size_t firstFileIdx = hasDirHeader ? 1 : 0;
-		for (size_t i = firstFileIdx; i < entries.size(); ++i)
-		{
-			const auto& entry = entries[i];
-			std::string filePath = savePath + "/" + entry.dirEntry.name;
-
-			writeFile(filePath, entry.data);
-
-			uint32_t parent_cluster_inner = 0;
-			auto currentEntry = pImpl->find_entry(filePath, parent_cluster_inner);
 			auto parentEntries = pImpl->read_dirents(parent_cluster_inner);
+			if (m_error.IsValid())
+			{
+				return false;
+			}
 			bool updated = false;
 			for (auto& pe : parentEntries)
 			{
@@ -1836,154 +2084,194 @@ bool PS2MemoryCard::importSaveFile(PS2SaveFile& save, bool ignoreExisting, const
 			}
 			if (updated)
 			{
-				pImpl->write_dirents(parent_cluster_inner, parentEntries);
-				pImpl->syncParentDirectoryEntryLength(parent_cluster_inner);
-			}
-		}
-
-		{
-			uint32_t saveParentCluster = 0;
-			(void)pImpl->find_entry(savePath, saveParentCluster);
-
-			auto parentRows = pImpl->read_dirents(saveParentCluster);
-			constexpr uint16_t typeMask = DF_FILE | DF_DIR | DF_EXISTS;
-			for (auto& row : parentRows)
-			{
-				if (row.name == saveDirName && (row.mode & DF_DIR))
+				if (!pImpl->write_dirents(parent_cluster_inner, parentEntries) ||
+					!pImpl->syncParentDirectoryEntryLength(parent_cluster_inner))
 				{
-					row.mode = static_cast<uint16_t>((dirEntry.mode & ~typeMask) | (row.mode & typeMask));
-					if ((row.mode & DF_EXISTS) && (row.mode & DF_DIR) && !(row.mode & DF_PSX))
-					{
-						row.mode |= DF_0400;
-					}
-					row.unused = dirEntry.unused;
-					row.created = dirEntry.created;
-					row.modified = dirEntry.modified;
-					row.attr = dirEntry.attr;
-					break;
+					return false;
 				}
 			}
-			pImpl->write_dirents(saveParentCluster, parentRows);
 		}
-
-		uint32_t rootParent = pImpl->rootdir_fat_cluster;
-		auto finalRoot = pImpl->read_dirents(rootParent);
-		if (!finalRoot.empty() && (finalRoot[0].mode & DF_DIR))
-		{
-			finalRoot[0].length = static_cast<uint32_t>(finalRoot.size());
-			pImpl->write_dirents(rootParent, finalRoot);
-		}
-
-		pImpl->write_fat_to_card();
-		pImpl->file.flush();
-
-		return true;
 	}
-	catch (const std::exception& e)
+
 	{
-		throw PS2McError(std::string("Import failed: ") + e.what());
+		uint32_t saveParentCluster = 0;
+		PS2McDirEntry unusedEntry{};
+		if (!pImpl->find_entry(savePath, saveParentCluster, unusedEntry))
+		{
+			return false;
+		}
+
+		auto parentRows = pImpl->read_dirents(saveParentCluster);
+		if (m_error.IsValid())
+		{
+			return false;
+		}
+		constexpr uint16_t typeMask = DF_FILE | DF_DIR | DF_EXISTS;
+		for (auto& row : parentRows)
+		{
+			if (row.name == saveDirName && (row.mode & DF_DIR))
+			{
+				row.mode = static_cast<uint16_t>((dirEntry.mode & ~typeMask) | (row.mode & typeMask));
+				if ((row.mode & DF_EXISTS) && (row.mode & DF_DIR) && !(row.mode & DF_PSX))
+				{
+					row.mode |= DF_0400;
+				}
+				row.unused = dirEntry.unused;
+				row.created = dirEntry.created;
+				row.modified = dirEntry.modified;
+				row.attr = dirEntry.attr;
+				break;
+			}
+		}
+		if (!pImpl->write_dirents(saveParentCluster, parentRows))
+		{
+			return false;
+		}
 	}
+
+	uint32_t rootParent = pImpl->rootdir_fat_cluster;
+	auto finalRoot = pImpl->read_dirents(rootParent);
+	if (m_error.IsValid())
+	{
+		return false;
+	}
+	if (!finalRoot.empty() && (finalRoot[0].mode & DF_DIR))
+	{
+		finalRoot[0].length = static_cast<uint32_t>(finalRoot.size());
+		if (!pImpl->write_dirents(rootParent, finalRoot))
+		{
+			return false;
+		}
+	}
+
+	if (!pImpl->write_fat_to_card())
+	{
+		return false;
+	}
+	pImpl->file.flush();
+	if (!pImpl->file)
+	{
+		return m_error.Fail("Failed to flush memory card file");
+	}
+
+	return true;
 }
 
-void PS2MemoryCard::exportSaveFile(const std::string& savePath, PS2SaveFile& save)
+bool PS2MemoryCard::exportSaveFile(const std::string& savePath, PS2SaveFile& save)
 {
+	m_error.Clear();
 	if (!pImpl || !pImpl->file.is_open())
 	{
-		throw PS2McError("No memory card open");
+		return m_error.Fail("No memory card open");
 	}
 
-	try
+	// Read the save directory entry
+	uint32_t parent_cluster = 0;
+	PS2McDirEntry dirEntry{};
+	if (!pImpl->find_entry(savePath, parent_cluster, dirEntry))
 	{
-		// Read the save directory entry
-		uint32_t parent_cluster;
-		PS2McDirEntry dirEntry = pImpl->find_entry(savePath, parent_cluster);
-
-		if (!(dirEntry.mode & DF_DIR))
-		{
-			throw PS2McError("Path is not a directory");
-		}
-
-		// Create PS2SaveEntry for the directory itself
-		PS2SaveEntry dirSaveEntry;
-		dirSaveEntry.dirEntry = dirEntry;
-
-		auto& entries = save.getEntries();
-		entries.clear();
-		entries.push_back(dirSaveEntry);
-
-		// Read all files in the directory
-		auto dirContents = pImpl->read_dirents(dirEntry.cluster);
-
-		for (const auto& entry : dirContents)
-		{
-			if (entry.name == "." || entry.name == "..")
-			{
-				continue;
-			}
-
-			if (!(entry.mode & DF_EXISTS))
-			{
-				continue;
-			}
-
-			if (entry.mode & DF_DIR)
-			{
-				continue;
-			}
-
-			PS2SaveEntry fileEntry;
-			fileEntry.dirEntry = entry;
-
-			std::string filePath = savePath + "/" + entry.name;
-			fileEntry.data = readFile(filePath);
-
-			entries.push_back(fileEntry);
-		}
-
-		// Set the save title from icon.sys if available
-		try
-		{
-			std::string title = getSaveTitle(savePath);
-			if (!title.empty())
-			{
-				save.setTitle(title);
-			}
-		}
-		catch (...)
-		{
-			// Ignore if we can't get the title
-		}
+		return false;
 	}
-	catch (const std::exception& e)
+
+	if (!(dirEntry.mode & DF_DIR))
 	{
-		throw PS2McError(std::string("Export failed: ") + e.what());
+		return m_error.Fail("Path is not a directory");
 	}
+
+	// Create PS2SaveEntry for the directory itself
+	PS2SaveEntry dirSaveEntry;
+	dirSaveEntry.dirEntry = dirEntry;
+
+	auto& entries = save.getEntries();
+	entries.clear();
+	entries.push_back(dirSaveEntry);
+
+	// Read all files in the directory
+	auto dirContents = pImpl->read_dirents(dirEntry.cluster);
+	if (m_error.IsValid())
+	{
+		return false;
+	}
+
+	for (const auto& entry : dirContents)
+	{
+		if (entry.name == "." || entry.name == "..")
+		{
+			continue;
+		}
+
+		if (!(entry.mode & DF_EXISTS))
+		{
+			continue;
+		}
+
+		if (entry.mode & DF_DIR)
+		{
+			continue;
+		}
+
+		PS2SaveEntry fileEntry;
+		fileEntry.dirEntry = entry;
+
+		std::string filePath = savePath + "/" + entry.name;
+		fileEntry.data = readFile(filePath);
+		if (m_error.IsValid())
+		{
+			return false;
+		}
+
+		entries.push_back(fileEntry);
+	}
+
+	// Set the save title from icon.sys if available
+	std::string title = getSaveTitle(savePath);
+	if (!title.empty())
+	{
+		save.setTitle(title);
+	}
+
+	return true;
 }
 
 uint16_t PS2MemoryCard::getMode(const std::string& path)
 {
+	m_error.Clear();
 	if (!pImpl->file.is_open())
 	{
-		throw PS2McError("Memory card not open");
+		m_error.Fail("Memory card not open");
+		return 0;
 	}
 
 	uint32_t parent_cluster = 0;
-	auto entry = pImpl->find_entry(path, parent_cluster);
+	PS2McDirEntry entry{};
+	if (!pImpl->find_entry(path, parent_cluster, entry))
+	{
+		return 0;
+	}
 	return entry.mode;
 }
 
-void PS2MemoryCard::setMode(const std::string& path, uint16_t mode)
+bool PS2MemoryCard::setMode(const std::string& path, uint16_t mode)
 {
+	m_error.Clear();
 	if (!pImpl->file.is_open())
 	{
-		throw PS2McError("Memory card not open");
+		return m_error.Fail("Memory card not open");
 	}
 
 	uint32_t parent_cluster = 0;
-	auto entry = pImpl->find_entry(path, parent_cluster);
+	PS2McDirEntry entry{};
+	if (!pImpl->find_entry(path, parent_cluster, entry))
+	{
+		return false;
+	}
 
 	// Read all entries in the parent directory
 	auto entries = pImpl->read_dirents(parent_cluster);
+	if (m_error.IsValid())
+	{
+		return false;
+	}
 
 	// Find and update the target entry
 	bool found = false;
@@ -1999,24 +2287,33 @@ void PS2MemoryCard::setMode(const std::string& path, uint16_t mode)
 
 	if (!found)
 	{
-		throw PS2McError("Entry not found in parent directory");
+		return m_error.Fail("Entry not found in parent directory");
 	}
 
 	// Write all entries back
-	pImpl->write_dirents(parent_cluster, entries);
+	return pImpl->write_dirents(parent_cluster, entries);
 }
 
-void PS2MemoryCard::setModifiedTime(const std::string& path, std::time_t newTime)
+bool PS2MemoryCard::setModifiedTime(const std::string& path, std::time_t newTime)
 {
+	m_error.Clear();
 	if (!pImpl->file.is_open())
 	{
-		throw PS2McError("Memory card not open");
+		return m_error.Fail("Memory card not open");
 	}
 
 	uint32_t parent_cluster = 0;
-	auto entry = pImpl->find_entry(path, parent_cluster);
+	PS2McDirEntry entry{};
+	if (!pImpl->find_entry(path, parent_cluster, entry))
+	{
+		return false;
+	}
 
 	auto entries = pImpl->read_dirents(parent_cluster);
+	if (m_error.IsValid())
+	{
+		return false;
+	}
 	PS2McTod newTod = timeToTod(newTime);
 
 	bool found = false;
@@ -2032,45 +2329,58 @@ void PS2MemoryCard::setModifiedTime(const std::string& path, std::time_t newTime
 
 	if (!found)
 	{
-		throw PS2McError("Entry not found in parent directory");
+		return m_error.Fail("Entry not found in parent directory");
 	}
 
-	pImpl->write_dirents(parent_cluster, entries);
+	if (!pImpl->write_dirents(parent_cluster, entries))
+	{
+		return false;
+	}
 	pImpl->modified = true;
+	return true;
 }
 
-void PS2MemoryCard::renameEntry(const std::string& path, const std::string& newName)
+bool PS2MemoryCard::renameEntry(const std::string& path, const std::string& newName)
 {
+	m_error.Clear();
 	if (!pImpl->file.is_open())
 	{
-		throw PS2McError("Memory card not open");
+		return m_error.Fail("Memory card not open");
 	}
 
 	if (path.empty() || path == "/")
 	{
-		throw PS2McIOError("Invalid path for rename");
+		return m_error.Fail("Invalid path for rename");
 	}
 
 	if (newName.empty() || newName == "." || newName == "..")
 	{
-		throw PS2McIOError("Invalid new name");
+		return m_error.Fail("Invalid new name");
 	}
 
 	if (newName.find('/') != std::string::npos)
 	{
-		throw PS2McIOError("Name cannot contain '/'");
+		return m_error.Fail("Name cannot contain '/'");
 	}
 
 	uint32_t parent_cluster = 0;
-	auto entry = pImpl->find_entry(path, parent_cluster);
+	PS2McDirEntry entry{};
+	if (!pImpl->find_entry(path, parent_cluster, entry))
+	{
+		return false;
+	}
 
 	auto entries = pImpl->read_dirents(parent_cluster);
+	if (m_error.IsValid())
+	{
+		return false;
+	}
 
 	for (const auto& e : entries)
 	{
 		if ((e.mode & DF_EXISTS) && e.name == newName)
 		{
-			throw PS2McIOError("An entry with the new name already exists");
+			return m_error.Fail("An entry with the new name already exists");
 		}
 	}
 
@@ -2087,18 +2397,24 @@ void PS2MemoryCard::renameEntry(const std::string& path, const std::string& newN
 
 	if (!found)
 	{
-		throw PS2McError("Entry not found in parent directory");
+		return m_error.Fail("Entry not found in parent directory");
 	}
 
-	pImpl->write_dirents(parent_cluster, entries);
+	if (!pImpl->write_dirents(parent_cluster, entries))
+	{
+		return false;
+	}
 	pImpl->modified = true;
+	return true;
 }
 
 uint32_t PS2MemoryCard::getAllocatableSpace()
 {
+	m_error.Clear();
 	if (!pImpl->file.is_open())
 	{
-		throw PS2McError("Memory card not open");
+		m_error.Fail("Memory card not open");
+		return 0;
 	}
 
 	// Return total usable space on card (excluding system clusters)
@@ -2110,53 +2426,42 @@ uint32_t PS2MemoryCard::getAllocatableSpace()
 
 bool PS2MemoryCard::check()
 {
+	m_error.Clear();
 	if (!pImpl->file.is_open())
 	{
-		throw PS2McError("Memory card not open");
+		return m_error.Fail("Memory card not open");
 	}
 
-	bool valid = true;
-
-	try
+	auto entries = listDir("/");
+	if (m_error.IsValid())
 	{
-		auto entries = listDir("/");
-		for (const auto& entry : entries)
+		return false;
+	}
+	for (const auto& entry : entries)
+	{
+		if (entry.mode & DF_DIR)
 		{
-			if (entry.mode & DF_DIR)
+			auto subentries = listDir("/" + entry.name);
+			if (m_error.IsValid())
 			{
-				try
+				return false;
+			}
+			for (const auto& subentry : subentries)
+			{
+				if (subentry.mode & DF_FILE)
 				{
-					auto subentries = listDir("/" + entry.name);
-					for (const auto& subentry : subentries)
+					std::string path = "/" + entry.name + "/" + subentry.name;
+					auto data = readFile(path);
+					if (m_error.IsValid())
 					{
-						if (subentry.mode & DF_FILE)
-						{
-							try
-							{
-								std::string path = "/" + entry.name + "/" + subentry.name;
-								auto data = readFile(path);
-								(void)data; // Just verify we can read it
-							}
-							catch (...)
-							{
-								valid = false;
-							}
-						}
+						return false;
 					}
-				}
-				catch (...)
-				{
-					valid = false;
 				}
 			}
 		}
 	}
-	catch (...)
-	{
-		valid = false;
-	}
 
-	return valid;
+	return true;
 }
 
 bool PS2MemoryCard::hasEcc() const
@@ -2166,15 +2471,18 @@ bool PS2MemoryCard::hasEcc() const
 
 std::string PS2MemoryCard::getPsxTitle(const std::string& savePath)
 {
+	m_error.Clear();
 	if (!pImpl->file.is_open())
 	{
-		throw PS2McError("Memory card not open");
+		m_error.Fail("Memory card not open");
+		return "";
 	}
 
 	// Get the save directory mode to check if it's PSX
 	auto entry = getEntry(savePath);
 	if (!(entry.mode & DF_PSX))
 	{
+		m_error.Clear();
 		return ""; // Not a PSX save
 	}
 
@@ -2187,6 +2495,7 @@ std::string PS2MemoryCard::getPsxTitle(const std::string& savePath)
 			// Read the PSX save header (first 128 bytes)
 			std::string filePath = savePath + "/" + e.name;
 			auto data = readFile(filePath);
+			m_error.Clear();
 
 			if (data.size() >= 128)
 			{
@@ -2203,14 +2512,16 @@ std::string PS2MemoryCard::getPsxTitle(const std::string& savePath)
 		}
 	}
 
+	m_error.Clear();
 	return "";
 }
 
-void PS2MemoryCard::saveAs(const std::string& filename, bool withEcc)
+bool PS2MemoryCard::saveAs(const std::string& filename, bool withEcc)
 {
+	m_error.Clear();
 	if (!pImpl->file.is_open())
 	{
-		throw PS2McError("Memory card not open");
+		return m_error.Fail("Memory card not open");
 	}
 
 	std::error_code ec;
@@ -2223,13 +2534,20 @@ void PS2MemoryCard::saveAs(const std::string& filename, bool withEcc)
 
 	if (pImpl->modified)
 	{
-		pImpl->write_fat_to_card();
+		if (!pImpl->write_fat_to_card())
+		{
+			return false;
+		}
 	}
 	pImpl->file.flush();
+	if (!pImpl->file)
+	{
+		return m_error.Fail("Failed to flush memory card file");
+	}
 
 	if (sameFile && withEcc == pImpl->with_ecc)
 	{
-		return;
+		return true;
 	}
 
 	const std::filesystem::path dest(sameFile ? pImpl->filename : filename);
@@ -2249,7 +2567,7 @@ void PS2MemoryCard::saveAs(const std::string& filename, bool withEcc)
 			{
 				pImpl->file.open(pImpl->filename, std::ios::in | std::ios::binary);
 			}
-			throw PS2McIOError("Failed to copy memory card file: " + ec.message());
+			return m_error.Fail("Failed to copy memory card file: " + ec.message());
 		}
 
 		pImpl->file.open(pImpl->filename, std::ios::in | std::ios::out | std::ios::binary);
@@ -2259,10 +2577,9 @@ void PS2MemoryCard::saveAs(const std::string& filename, bool withEcc)
 		}
 		if (!pImpl->file)
 		{
-			throw PS2McIOError("Failed to reopen memory card after save");
+			return m_error.Fail("Failed to reopen memory card after save");
 		}
-		pImpl->read_superblock();
-		return;
+		return pImpl->read_superblock();
 	}
 
 	const uint32_t pageCount = pImpl->clusters_per_card * pImpl->pages_per_cluster;
@@ -2272,19 +2589,21 @@ void PS2MemoryCard::saveAs(const std::string& filename, bool withEcc)
 	std::ofstream out(tmpPath, std::ios::binary);
 	if (!out)
 	{
-		throw PS2McError("Failed to create file: " + tmpPath.string());
+		return m_error.Fail("Failed to create file: " + tmpPath.string());
 	}
 
 	for (uint32_t i = 0; i < pageCount; ++i)
 	{
 		auto pageData = pImpl->read_page(i);
+		if (pageData.empty())
+		{
+			out.close();
+			std::filesystem::remove(tmpPath, ec);
+			return false;
+		}
 		if (pageData.size() > pImpl->page_size)
 		{
 			pageData.resize(pImpl->page_size);
-		}
-		else if (pageData.size() < pImpl->page_size)
-		{
-			pageData.resize(pImpl->page_size, 0);
 		}
 
 		const char* MAGIC = "Sony PS2 Memory Card Format ";
@@ -2308,7 +2627,7 @@ void PS2MemoryCard::saveAs(const std::string& filename, bool withEcc)
 		if (!out)
 		{
 			std::filesystem::remove(tmpPath, ec);
-			throw PS2McIOError("Failed to write memory card file");
+			return m_error.Fail("Failed to write memory card file");
 		}
 
 		if (withEcc && !pImpl->with_ecc)
@@ -2325,7 +2644,7 @@ void PS2MemoryCard::saveAs(const std::string& filename, bool withEcc)
 			if (!out)
 			{
 				std::filesystem::remove(tmpPath, ec);
-				throw PS2McIOError("Failed to write memory card file");
+				return m_error.Fail("Failed to write memory card file");
 			}
 		}
 	}
@@ -2334,14 +2653,16 @@ void PS2MemoryCard::saveAs(const std::string& filename, bool withEcc)
 
 	if (!sameFile)
 	{
-		renameReplace(dest, tmpPath);
-		return;
+		return renameReplace(dest, tmpPath, m_error);
 	}
 
 	pImpl->file.close();
 	pImpl->page_cache.clear();
 	pImpl->fat_cluster_cache.clear();
-	renameReplace(dest, tmpPath);
+	if (!renameReplace(dest, tmpPath, m_error))
+	{
+		return false;
+	}
 
 	pImpl->with_ecc = withEcc;
 	if (withEcc)
@@ -2361,7 +2682,7 @@ void PS2MemoryCard::saveAs(const std::string& filename, bool withEcc)
 	}
 	if (!pImpl->file)
 	{
-		throw PS2McIOError("Failed to reopen memory card after save");
+		return m_error.Fail("Failed to reopen memory card after save");
 	}
-	pImpl->read_superblock();
+	return pImpl->read_superblock();
 }

--- a/src/core/formats/ps2mc.h
+++ b/src/core/formats/ps2mc.h
@@ -4,10 +4,10 @@
 #pragma once
 
 #include "ps2mc_dir.h"
+#include "Error.h"
 #include <string>
 #include <vector>
 #include <memory>
-#include <stdexcept>
 
 class PS2SaveFile;
 
@@ -22,60 +22,6 @@ const int PS2MC_INDIRECT_FAT_OFFSET = 0x2000;
 const int PS2MC_STANDARD_PAGE_SIZE = 512;
 const int PS2MC_STANDARD_PAGES_PER_CARD = 16384;
 const int PS2MC_STANDARD_PAGES_PER_ERASE_BLOCK = 16;
-
-class PS2McError : public std::runtime_error
-{
-public:
-	explicit PS2McError(const std::string& msg)
-		: std::runtime_error(msg)
-	{
-	}
-};
-
-class PS2McIOError : public PS2McError
-{
-public:
-	explicit PS2McIOError(const std::string& msg)
-		: PS2McError(msg)
-	{
-	}
-};
-
-class PS2McPathNotFound : public PS2McIOError
-{
-public:
-	explicit PS2McPathNotFound(const std::string& path)
-		: PS2McIOError("Path not found: " + path)
-	{
-	}
-};
-
-class PS2McFileNotFound : public PS2McIOError
-{
-public:
-	explicit PS2McFileNotFound(const std::string& path)
-		: PS2McIOError("File not found: " + path)
-	{
-	}
-};
-
-class PS2McDirNotFound : public PS2McIOError
-{
-public:
-	explicit PS2McDirNotFound(const std::string& path)
-		: PS2McIOError("Directory not found: " + path)
-	{
-	}
-};
-
-class PS2McCorrupt : public PS2McIOError
-{
-public:
-	explicit PS2McCorrupt(const std::string& msg)
-		: PS2McIOError("Corrupt memory card: " + msg)
-	{
-	}
-};
 
 class PS2MemoryCard
 {
@@ -115,30 +61,33 @@ public:
 	PS2MemoryCard();
 	~PS2MemoryCard();
 
+	const Error& GetError() const { return m_error; }
+
 	static const std::vector<CardFormat>& getFormats();
 	static bool usesEccForPath(const std::string& path, bool unknownFallback = true);
 
-	void open(const std::string& filename, bool ignoreEcc = false);
+	bool open(const std::string& filename, bool ignoreEcc = false);
 	void close();
-	void create(const std::string& filename, int sizeInMB = 8, bool disableEcc = false);
+	bool create(const std::string& filename, int sizeInMB = 8, bool disableEcc = false);
 
 	std::vector<PS2McDirEntry> listDir(const std::string& path = "/");
+	bool hasEntry(const std::string& path);
 	PS2McDirEntry getEntry(const std::string& path);
-	void makeDir(const std::string& path);
-	void remove(const std::string& path);
+	bool makeDir(const std::string& path);
+	bool remove(const std::string& path);
 
 	uint16_t getMode(const std::string& path);
-	void setMode(const std::string& path, uint16_t mode);
+	bool setMode(const std::string& path, uint16_t mode);
 
-	void setModifiedTime(const std::string& path, std::time_t newTime);
-	void renameEntry(const std::string& path, const std::string& newName);
+	bool setModifiedTime(const std::string& path, std::time_t newTime);
+	bool renameEntry(const std::string& path, const std::string& newName);
 
-	std::vector<uint8_t> readFile(const std::string& path);
-	void exportFile(const std::string& mcPath, const std::string& hostPath);
-	void writeFile(const std::string& path, const std::vector<uint8_t>& data);
+	std::vector<uint8_t> readFile(const std::string& path, bool quiet = false);
+	bool exportFile(const std::string& mcPath, const std::string& hostPath);
+	bool writeFile(const std::string& path, const std::vector<uint8_t>& data);
 
 	bool importSaveFile(class PS2SaveFile& save, bool ignoreExisting = false, const std::string& targetDir = "");
-	void exportSaveFile(const std::string& savePath, class PS2SaveFile& save);
+	bool exportSaveFile(const std::string& savePath, class PS2SaveFile& save);
 
 	std::vector<uint8_t> getIconData(const std::string& savePath);
 
@@ -157,11 +106,12 @@ public:
 
 	std::string getPsxTitle(const std::string& savePath);
 
-	void saveAs(const std::string& filename, bool withEcc = true);
+	bool saveAs(const std::string& filename, bool withEcc = true);
 
 	CardInfo getCardInfo();
 
 private:
+	Error m_error;
 	class Impl;
 	std::unique_ptr<Impl> pImpl;
 };

--- a/src/core/formats/ps2save.cpp
+++ b/src/core/formats/ps2save.cpp
@@ -18,52 +18,60 @@ namespace
 {
 	inline bool modeIsDir(uint16_t mode) { return (mode & DF_DIR) != 0; }
 	inline bool modeIsFile(uint16_t mode) { return (mode & DF_FILE) != 0; }
-
-	std::vector<uint8_t> readFixed(std::ifstream& f, size_t n)
-	{
-		std::vector<uint8_t> buf(n);
-		f.read(reinterpret_cast<char*>(buf.data()), n);
-		if (static_cast<size_t>(f.gcount()) != n)
-		{
-			throw PS2SaveError("Unexpected EOF");
-		}
-		return buf;
-	}
 } // namespace
 
 class PS2SaveFile::Impl
 {
 public:
+	Error& m_error;
 	std::vector<PS2SaveEntry> entries;
 	std::string title;
 	SaveFormat format;
 
-	Impl()
-		: format(SaveFormat::UNKNOWN)
+	explicit Impl(Error& error)
+		: m_error(error)
+		, format(SaveFormat::UNKNOWN)
 	{
 	}
 
-	void loadEms(std::ifstream& file);
-	void loadMaxDrive(std::ifstream& file);
-	void loadSharkPort(std::ifstream& file);
-	void loadCodeBreaker(std::ifstream& file);
-	void loadPsv(std::ifstream& file);
-	void saveEms(std::ofstream& file);
-	void saveMaxDrive(std::ofstream& file);
+	bool readBytes(std::ifstream& f, void* dest, size_t n)
+	{
+		f.read(reinterpret_cast<char*>(dest), n);
+		if (static_cast<size_t>(f.gcount()) != n)
+		{
+			return m_error.Fail("Unexpected EOF");
+		}
+		return true;
+	}
+
+	bool readFixed(std::ifstream& f, size_t n, std::vector<uint8_t>& out)
+	{
+		out.resize(n);
+		return readBytes(f, out.data(), n);
+	}
+
+	bool loadEms(std::ifstream& file);
+	bool loadMaxDrive(std::ifstream& file);
+	bool loadSharkPort(std::ifstream& file);
+	bool loadCodeBreaker(std::ifstream& file);
+	bool loadPsv(std::ifstream& file);
+	bool saveEms(std::ofstream& file);
+	bool saveMaxDrive(std::ofstream& file);
 };
 
 PS2SaveFile::PS2SaveFile()
-	: pImpl(std::make_unique<Impl>())
+	: pImpl(std::make_unique<Impl>(m_error))
 {
 }
 PS2SaveFile::~PS2SaveFile() = default;
 
-void PS2SaveFile::load(const std::string& filename)
+bool PS2SaveFile::load(const std::string& filename)
 {
+	m_error.Clear();
 	std::ifstream file(filename, std::ios::binary);
 	if (!file)
 	{
-		throw PS2SaveError("Failed to open: " + filename);
+		return m_error.Fail("Failed to open: " + filename);
 	}
 
 	pImpl->format = detectFormat(filename);
@@ -71,32 +79,28 @@ void PS2SaveFile::load(const std::string& filename)
 	switch (pImpl->format)
 	{
 		case SaveFormat::MAX_DRIVE:
-			pImpl->loadMaxDrive(file);
-			break;
+			return pImpl->loadMaxDrive(file);
 		case SaveFormat::EMS:
-			pImpl->loadEms(file);
-			break;
+			return pImpl->loadEms(file);
 		case SaveFormat::SHARKPORT:
 		case SaveFormat::XPORT: // X-Port uses same format as SharkPort
-			pImpl->loadSharkPort(file);
-			break;
+			return pImpl->loadSharkPort(file);
 		case SaveFormat::CODEBREAKER:
-			pImpl->loadCodeBreaker(file);
-			break;
+			return pImpl->loadCodeBreaker(file);
 		case SaveFormat::PSV:
-			pImpl->loadPsv(file);
-			break;
+			return pImpl->loadPsv(file);
 		default:
-			throw PS2SaveError("Unknown save format");
+			return m_error.Fail("Unknown save format");
 	}
 }
 
-void PS2SaveFile::save(const std::string& filename, SaveFormat format)
+bool PS2SaveFile::save(const std::string& filename, SaveFormat format)
 {
+	m_error.Clear();
 	std::ofstream file(filename, std::ios::binary);
 	if (!file)
 	{
-		throw PS2SaveError("Failed to create: " + filename);
+		return m_error.Fail("Failed to create: " + filename);
 	}
 
 	if (format == SaveFormat::UNKNOWN)
@@ -107,13 +111,11 @@ void PS2SaveFile::save(const std::string& filename, SaveFormat format)
 	switch (format)
 	{
 		case SaveFormat::MAX_DRIVE:
-			pImpl->saveMaxDrive(file);
-			break;
+			return pImpl->saveMaxDrive(file);
 		case SaveFormat::EMS:
-			pImpl->saveEms(file);
-			break;
+			return pImpl->saveEms(file);
 		default:
-			throw PS2SaveError("Unsupported save format for writing");
+			return m_error.Fail("Unsupported save format for writing");
 	}
 }
 
@@ -241,12 +243,11 @@ std::string PS2SaveFile::formatToExtension(SaveFormat format)
 	}
 }
 
-void PS2SaveFile::Impl::loadMaxDrive(std::ifstream& file)
+bool PS2SaveFile::Impl::loadMaxDrive(std::ifstream& file)
 {
 	char hdr[0x5C];
-	file.read(hdr, 0x5C);
-	if (file.gcount() != 0x5C)
-		throw PS2SaveError("Corrupt MAX header");
+	if (!readBytes(file, hdr, 0x5C))
+		return m_error.Fail("Corrupt MAX header");
 	struct Hdr
 	{
 		char magic[12];
@@ -260,7 +261,7 @@ void PS2SaveFile::Impl::loadMaxDrive(std::ifstream& file)
 	const Hdr* h = reinterpret_cast<const Hdr*>(hdr);
 	if (std::memcmp(h->magic, PS2SAVE_MAX_MAGIC, 12) != 0)
 	{
-		throw PS2SaveError("Not a MAX Drive save");
+		return m_error.Fail("Not a MAX Drive save");
 	}
 	std::string dirname = zeroTerminate(std::string(h->dirname, 32));
 	uint32_t clen = h->clen;
@@ -273,17 +274,18 @@ void PS2SaveFile::Impl::loadMaxDrive(std::ifstream& file)
 		file.seekg(0, std::ios::end);
 		size_t remaining = static_cast<size_t>(file.tellg()) - 0x5C;
 		file.seekg(0x5C, std::ios::beg);
-		compressed.resize(remaining);
-		file.read(reinterpret_cast<char*>(compressed.data()), remaining);
+		if (!readFixed(file, remaining, compressed))
+			return false;
 	}
 	else
 	{
-		compressed = readFixed(file, clen - 4); // -4 because crc already read
+		if (!readFixed(file, clen - 4, compressed)) // -4 because crc already read
+			return false;
 	}
 
 	auto decompressed = lzariDecompress(compressed, length);
 	if (decompressed.size() != length)
-		throw PS2SaveError("MAX decompress size mismatch");
+		return m_error.Fail("MAX decompress size mismatch");
 
 	entries.clear();
 	entries.reserve(dirlen);
@@ -292,13 +294,13 @@ void PS2SaveFile::Impl::loadMaxDrive(std::ifstream& file)
 	for (uint32_t i = 0; i < dirlen; ++i)
 	{
 		if (off + 36 > decompressed.size())
-			throw PS2SaveError("MAX directory truncated");
+			return m_error.Fail("MAX directory truncated");
 		uint32_t l = *reinterpret_cast<const uint32_t*>(&decompressed[off]);
 		std::string name(reinterpret_cast<const char*>(&decompressed[off + 4]), 32);
 		name = zeroTerminate(name);
 		off += 36;
 		if (off + l > decompressed.size())
-			throw PS2SaveError("MAX file truncated");
+			return m_error.Fail("MAX file truncated");
 		std::vector<uint8_t> data(decompressed.begin() + off, decompressed.begin() + off + l);
 		off += l;
 		off = roundUp(static_cast<int>(off) + 8, 16) - 8;
@@ -317,65 +319,91 @@ void PS2SaveFile::Impl::loadMaxDrive(std::ifstream& file)
 	}
 	title = dirname;
 	format = SaveFormat::MAX_DRIVE;
+	return true;
 }
 
-void PS2SaveFile::Impl::loadSharkPort(std::ifstream& file)
+bool PS2SaveFile::Impl::loadSharkPort(std::ifstream& file)
 {
 	const std::string fmtName = (format == SaveFormat::XPORT) ? "X-Port" : "SharkPort";
 
-	auto magic = readFixed(file, 17);
+	std::vector<uint8_t> magic;
+	if (!readFixed(file, 17, magic))
+		return false;
 	if (std::memcmp(magic.data(), PS2SAVE_SPS_MAGIC, 13) != 0)
 	{
-		throw PS2SaveError("Not a " + fmtName + " save");
+		return m_error.Fail("Not a " + fmtName + " save");
 	}
 
 	uint32_t savetype = 0;
-	file.read(reinterpret_cast<char*>(&savetype), 4);
+	if (!readBytes(file, &savetype, 4))
+		return false;
 
 	uint32_t dirname_len = 0;
-	file.read(reinterpret_cast<char*>(&dirname_len), 4);
-	auto dirname_data = readFixed(file, dirname_len);
+	if (!readBytes(file, &dirname_len, 4))
+		return false;
+	std::vector<uint8_t> dirname_data;
+	if (!readFixed(file, dirname_len, dirname_data))
+		return false;
 	std::string dirname(dirname_data.begin(), dirname_data.end());
 
 	uint32_t datestamp_len = 0;
-	file.read(reinterpret_cast<char*>(&datestamp_len), 4);
-	readFixed(file, datestamp_len);
+	if (!readBytes(file, &datestamp_len, 4))
+		return false;
+	std::vector<uint8_t> unused;
+	if (!readFixed(file, datestamp_len, unused))
+		return false;
 
 	uint32_t comment_len = 0;
-	file.read(reinterpret_cast<char*>(&comment_len), 4);
-	readFixed(file, comment_len);
+	if (!readBytes(file, &comment_len, 4))
+		return false;
+	if (!readFixed(file, comment_len, unused))
+		return false;
 
 	uint32_t flen = 0;
-	file.read(reinterpret_cast<char*>(&flen), 4);
+	if (!readBytes(file, &flen, 4))
+		return false;
 
 	uint16_t hlen = 0;
-	file.read(reinterpret_cast<char*>(&hlen), 2);
+	if (!readBytes(file, &hlen, 2))
+		return false;
 
 	std::vector<uint8_t> name_buf(64);
-	file.read(reinterpret_cast<char*>(name_buf.data()), 64);
+	if (!readBytes(file, name_buf.data(), 64))
+		return false;
 
 	uint32_t dirlen = 0;
-	file.read(reinterpret_cast<char*>(&dirlen), 4);
+	if (!readBytes(file, &dirlen, 4))
+		return false;
 
-	readFixed(file, 8); // skip 8 bytes
+	if (!readFixed(file, 8, unused)) // skip 8 bytes
+		return false;
 
 	uint16_t dirmode = 0;
-	file.read(reinterpret_cast<char*>(&dirmode), 2);
+	if (!readBytes(file, &dirmode, 2))
+		return false;
 
-	readFixed(file, 2); // skip 2 bytes
+	if (!readFixed(file, 2, unused)) // skip 2 bytes
+		return false;
 
-	auto created_data = readFixed(file, 8);
+	std::vector<uint8_t> created_data;
+	if (!readFixed(file, 8, created_data))
+		return false;
 
-	auto modified_data = readFixed(file, 8);
+	std::vector<uint8_t> modified_data;
+	if (!readFixed(file, 8, modified_data))
+		return false;
 
 	if (hlen > 98)
-		readFixed(file, hlen - 98);
+	{
+		if (!readFixed(file, hlen - 98, unused))
+			return false;
+	}
 
 	dirmode = ((dirmode / 256) % 256) + ((dirmode % 256) * 256);
 
 	if (!(dirmode & DF_DIR) || dirlen < 2)
 	{
-		throw PS2SaveError("Invalid " + fmtName + " directory header");
+		return m_error.Fail("Invalid " + fmtName + " directory header");
 	}
 
 	entries.clear();
@@ -384,38 +412,53 @@ void PS2SaveFile::Impl::loadSharkPort(std::ifstream& file)
 	for (uint32_t i = 0; i < dirlen - 2; ++i)
 	{
 		uint16_t fhlen = 0;
-		file.read(reinterpret_cast<char*>(&fhlen), 2);
+		if (!readBytes(file, &fhlen, 2))
+			return false;
 
 		std::vector<uint8_t> fname_buf(64);
-		file.read(reinterpret_cast<char*>(fname_buf.data()), 64);
+		if (!readBytes(file, fname_buf.data(), 64))
+			return false;
 		std::string fname(reinterpret_cast<const char*>(fname_buf.data()));
 		fname = zeroTerminate(fname);
 
 		uint32_t fsize = 0;
-		file.read(reinterpret_cast<char*>(&fsize), 4);
-		readFixed(file, 8); // skip 8 bytes
+		if (!readBytes(file, &fsize, 4))
+			return false;
+		if (!readFixed(file, 8, unused)) // skip 8 bytes
+			return false;
 
 		uint16_t fmode = 0;
-		file.read(reinterpret_cast<char*>(&fmode), 2);
-		readFixed(file, 2); // skip 2 bytes
+		if (!readBytes(file, &fmode, 2))
+			return false;
+		if (!readFixed(file, 2, unused)) // skip 2 bytes
+			return false;
 
-		auto fcreated_data = readFixed(file, 8);
+		std::vector<uint8_t> fcreated_data;
+		if (!readFixed(file, 8, fcreated_data))
+			return false;
 		PS2McTod fcreated = unpackTod(fcreated_data);
 
-		auto fmodified_data = readFixed(file, 8);
+		std::vector<uint8_t> fmodified_data;
+		if (!readFixed(file, 8, fmodified_data))
+			return false;
 		PS2McTod fmodified = unpackTod(fmodified_data);
 
 		if (fhlen > 98)
-			readFixed(file, fhlen - 98);
+		{
+			if (!readFixed(file, fhlen - 98, unused))
+				return false;
+		}
 
 		fmode = ((fmode / 256) % 256) + ((fmode % 256) * 256);
 
 		if (!(fmode & DF_FILE))
 		{
-			throw PS2SaveError("Non-file in " + fmtName + " directory");
+			return m_error.Fail("Non-file in " + fmtName + " directory");
 		}
 
-		auto fdata = readFixed(file, fsize);
+		std::vector<uint8_t> fdata;
+		if (!readFixed(file, fsize, fdata))
+			return false;
 
 		PS2McDirEntry ent;
 		ent.mode = fmode | DF_EXISTS;
@@ -432,6 +475,7 @@ void PS2SaveFile::Impl::loadSharkPort(std::ifstream& file)
 	{
 		format = SaveFormat::SHARKPORT;
 	}
+	return true;
 }
 
 namespace
@@ -490,22 +534,26 @@ namespace
 	}
 } // namespace
 
-void PS2SaveFile::Impl::loadCodeBreaker(std::ifstream& file)
+bool PS2SaveFile::Impl::loadCodeBreaker(std::ifstream& file)
 {
-	auto magic = readFixed(file, 4);
+	std::vector<uint8_t> magic;
+	if (!readFixed(file, 4, magic))
+		return false;
 	if (std::memcmp(magic.data(), PS2SAVE_CBS_MAGIC, 4) != 0)
 	{
-		throw PS2SaveError("Not a CodeBreaker save");
+		return m_error.Fail("Not a CodeBreaker save");
 	}
 
 	uint32_t d04 = 0, hlen = 0;
-	file.read(reinterpret_cast<char*>(&d04), 4);
-	file.read(reinterpret_cast<char*>(&hlen), 4);
+	if (!readBytes(file, &d04, 4) || !readBytes(file, &hlen, 4))
+		return false;
 
 	if (hlen < 124)
-		throw PS2SaveError("CodeBreaker header too short");
+		return m_error.Fail("CodeBreaker header too short");
 
-	std::vector<uint8_t> header = readFixed(file, hlen - 12);
+	std::vector<uint8_t> header;
+	if (!readFixed(file, hlen - 12, header))
+		return false;
 
 	uint32_t dlen = 0, flen = 0;
 	std::memcpy(&dlen, header.data() + 0, 4);
@@ -548,10 +596,12 @@ void PS2SaveFile::Impl::loadCodeBreaker(std::ifstream& file)
 	}
 	if (body_len != flen && body_len != flen - hlen)
 	{
-		throw PS2SaveError("Unexpected EOF");
+		return m_error.Fail("Unexpected EOF");
 	}
 
-	auto body = readFixed(file, body_len);
+	std::vector<uint8_t> body;
+	if (!readFixed(file, body_len, body))
+		return false;
 
 	std::vector<uint8_t> rc4_key(std::begin(PS2SAVE_CBS_RC4S), std::end(PS2SAVE_CBS_RC4S));
 	auto decrypted = rc4_crypt(rc4_key, body);
@@ -565,7 +615,7 @@ void PS2SaveFile::Impl::loadCodeBreaker(std::ifstream& file)
 
 	if (inflateInit(&stream) != Z_OK || inflate(&stream, Z_FINISH) != Z_STREAM_END)
 	{
-		throw PS2SaveError("CodeBreaker zlib decompress failed");
+		return m_error.Fail("CodeBreaker zlib decompress failed");
 	}
 	inflateEnd(&stream);
 
@@ -599,7 +649,7 @@ void PS2SaveFile::Impl::loadCodeBreaker(std::ifstream& file)
 
 		if (!(fmode & DF_FILE))
 		{
-			throw PS2SaveError("Non-file in CodeBreaker save");
+			return m_error.Fail("Non-file in CodeBreaker save");
 		}
 
 		std::vector<uint8_t> fdata(decompressed.begin() + off, decompressed.begin() + off + fsize);
@@ -617,63 +667,80 @@ void PS2SaveFile::Impl::loadCodeBreaker(std::ifstream& file)
 
 	title = zeroTerminate(std::string(dirname, 32));
 	format = SaveFormat::CODEBREAKER;
+	return true;
 }
 
-void PS2SaveFile::Impl::loadPsv(std::ifstream& file)
+bool PS2SaveFile::Impl::loadPsv(std::ifstream& file)
 {
-	auto magic_data = readFixed(file, 4);
+	std::vector<uint8_t> magic_data;
+	if (!readFixed(file, 4, magic_data))
+		return false;
 	if (std::memcmp(magic_data.data(), PS2SAVE_PSV_MAGIC, 4) != 0)
 	{
-		throw PS2SaveError("Not a PSV file");
+		return m_error.Fail("Not a PSV file");
 	}
 
 	uint32_t version = 0, next_section_size = 0, savetype = 0;
-	file.read(reinterpret_cast<char*>(&version), 4);
-	readFixed(file, 40); // signature
-	readFixed(file, 8); // reserved
-	file.read(reinterpret_cast<char*>(&next_section_size), 4);
-	file.read(reinterpret_cast<char*>(&savetype), 4);
+	if (!readBytes(file, &version, 4))
+		return false;
+	std::vector<uint8_t> unused;
+	if (!readFixed(file, 40, unused)) // signature
+		return false;
+	if (!readFixed(file, 8, unused)) // reserved
+		return false;
+	if (!readBytes(file, &next_section_size, 4))
+		return false;
+	if (!readBytes(file, &savetype, 4))
+		return false;
 
 	if (version != 0)
 	{
-		throw PS2SaveError("Unsupported PSV version");
+		return m_error.Fail("Unsupported PSV version");
 	}
 
 	if (savetype != 2 && savetype != 1)
 	{
-		throw PS2SaveError("Unsupported PSV save type");
+		return m_error.Fail("Unsupported PSV save type");
 	}
 
 	if (savetype == 2)
 	{
-		uint32_t unused, sys_pos, sys_size;
+		uint32_t unused_field, sys_pos, sys_size;
 		uint32_t icon1_pos, icon1_size, icon2_pos, icon2_size;
 		uint32_t icon3_pos, icon3_size, files_count;
 
-		file.read(reinterpret_cast<char*>(&unused), 4);
-		file.read(reinterpret_cast<char*>(&sys_pos), 4);
-		file.read(reinterpret_cast<char*>(&sys_size), 4);
-		file.read(reinterpret_cast<char*>(&icon1_pos), 4);
-		file.read(reinterpret_cast<char*>(&icon1_size), 4);
-		file.read(reinterpret_cast<char*>(&icon2_pos), 4);
-		file.read(reinterpret_cast<char*>(&icon2_size), 4);
-		file.read(reinterpret_cast<char*>(&icon3_pos), 4);
-		file.read(reinterpret_cast<char*>(&icon3_size), 4);
-		file.read(reinterpret_cast<char*>(&files_count), 4);
+		if (!readBytes(file, &unused_field, 4) ||
+			!readBytes(file, &sys_pos, 4) ||
+			!readBytes(file, &sys_size, 4) ||
+			!readBytes(file, &icon1_pos, 4) ||
+			!readBytes(file, &icon1_size, 4) ||
+			!readBytes(file, &icon2_pos, 4) ||
+			!readBytes(file, &icon2_size, 4) ||
+			!readBytes(file, &icon3_pos, 4) ||
+			!readBytes(file, &icon3_size, 4) ||
+			!readBytes(file, &files_count, 4))
+		{
+			return false;
+		}
 
-		auto root_created_data = readFixed(file, 8);
-		auto root_modified_data = readFixed(file, 8);
+		std::vector<uint8_t> root_created_data;
+		if (!readFixed(file, 8, root_created_data))
+			return false;
+		std::vector<uint8_t> root_modified_data;
+		if (!readFixed(file, 8, root_modified_data))
+			return false;
 		uint32_t root_size = 0;
 		uint32_t root_mode = 0;
-		file.read(reinterpret_cast<char*>(&root_size), 4);
-		file.read(reinterpret_cast<char*>(&root_mode), 4);
+		if (!readBytes(file, &root_size, 4) || !readBytes(file, &root_mode, 4))
+			return false;
 
 		std::vector<uint8_t> root_filename(32);
-		file.read(reinterpret_cast<char*>(root_filename.data()), 32);
+		if (!readBytes(file, root_filename.data(), 32))
+			return false;
 
 		if (!(root_mode & DF_DIR))
 		{
-			throw PS2SaveError("PSV root is not a directory");
+			return m_error.Fail("PSV root is not a directory");
 		}
 
 		title = zeroTerminate(std::string(reinterpret_cast<const char*>(root_filename.data()), 32));
@@ -684,18 +751,24 @@ void PS2SaveFile::Impl::loadPsv(std::ifstream& file)
 		std::vector<std::pair<uint32_t, PS2McDirEntry>> file_list;
 		for (uint32_t i = 0; i < files_count; ++i)
 		{
-			auto file_created_data = readFixed(file, 8);
-			auto file_modified_data = readFixed(file, 8);
+			std::vector<uint8_t> file_created_data;
+			if (!readFixed(file, 8, file_created_data))
+				return false;
+			std::vector<uint8_t> file_modified_data;
+			if (!readFixed(file, 8, file_modified_data))
+				return false;
 			uint32_t file_size = 0;
 			uint32_t file_mode = 0;
-			file.read(reinterpret_cast<char*>(&file_size), 4);
-			file.read(reinterpret_cast<char*>(&file_mode), 4);
+			if (!readBytes(file, &file_size, 4) || !readBytes(file, &file_mode, 4))
+				return false;
 
 			std::vector<uint8_t> filename_buf(32);
-			file.read(reinterpret_cast<char*>(filename_buf.data()), 32);
+			if (!readBytes(file, filename_buf.data(), 32))
+				return false;
 
 			uint32_t file_offset = 0;
-			file.read(reinterpret_cast<char*>(&file_offset), 4);
+			if (!readBytes(file, &file_offset, 4))
+				return false;
 
 			PS2McDirEntry ent;
 			ent.mode = static_cast<uint16_t>(file_mode | DF_EXISTS);
@@ -713,22 +786,28 @@ void PS2SaveFile::Impl::loadPsv(std::ifstream& file)
 		for (const auto& [offset, ent] : file_list)
 		{
 			file.seekg(offset);
-			auto fdata = readFixed(file, ent.length);
+			std::vector<uint8_t> fdata;
+			if (!readFixed(file, ent.length, fdata))
+				return false;
 			entries.push_back({ent, std::move(fdata)});
 		}
 	}
 	else
 	{
 		uint32_t save_size = 0, save_offset = 0;
-		file.read(reinterpret_cast<char*>(&save_size), 4);
-		file.read(reinterpret_cast<char*>(&save_offset), 4);
-		readFixed(file, 20); // reserved
+		if (!readBytes(file, &save_size, 4) || !readBytes(file, &save_offset, 4))
+			return false;
+		if (!readFixed(file, 20, unused)) // reserved
+			return false;
 		uint32_t unused_next = 0;
-		file.read(reinterpret_cast<char*>(&unused_next), 4);
-		readFixed(file, 4); // reserved
+		if (!readBytes(file, &unused_next, 4))
+			return false;
+		if (!readFixed(file, 4, unused)) // reserved
+			return false;
 
 		std::vector<uint8_t> prod_code(20);
-		file.read(reinterpret_cast<char*>(prod_code.data()), 20);
+		if (!readBytes(file, prod_code.data(), 20))
+			return false;
 
 		title = zeroTerminate(std::string(reinterpret_cast<const char*>(prod_code.data()), 20));
 
@@ -742,14 +821,17 @@ void PS2SaveFile::Impl::loadPsv(std::ifstream& file)
 		ent.created = ent.modified = timeToTod(std::time(nullptr));
 
 		file.seekg(save_offset);
-		auto fdata = readFixed(file, save_size);
+		std::vector<uint8_t> fdata;
+		if (!readFixed(file, save_size, fdata))
+			return false;
 		entries.push_back({ent, std::move(fdata)});
 	}
 
 	format = SaveFormat::PSV;
+	return true;
 }
 
-void PS2SaveFile::Impl::saveMaxDrive(std::ofstream& file)
+bool PS2SaveFile::Impl::saveMaxDrive(std::ofstream& file)
 {
 	std::vector<uint8_t> blob;
 	const bool hasDirHeader = !entries.empty() && (entries[0].dirEntry.mode & DF_DIR);
@@ -800,19 +882,26 @@ void PS2SaveFile::Impl::saveMaxDrive(std::ofstream& file)
 	file.write(reinterpret_cast<const char*>(&length), 4);
 	file.write(reinterpret_cast<const char*>(compressed.data()), compressed.size());
 	file.flush();
+	if (!file)
+		return m_error.Fail("Failed to write MAX save");
+	return true;
 }
 
-void PS2SaveFile::Impl::loadEms(std::ifstream& file)
+bool PS2SaveFile::Impl::loadEms(std::ifstream& file)
 {
-	auto direntRaw = readFixed(file, PS2MC_DIRENT_LENGTH);
-	auto dotRaw = readFixed(file, PS2MC_DIRENT_LENGTH);
-	auto dotdotRaw = readFixed(file, PS2MC_DIRENT_LENGTH);
+	std::vector<uint8_t> direntRaw, dotRaw, dotdotRaw;
+	if (!readFixed(file, PS2MC_DIRENT_LENGTH, direntRaw) ||
+		!readFixed(file, PS2MC_DIRENT_LENGTH, dotRaw) ||
+		!readFixed(file, PS2MC_DIRENT_LENGTH, dotdotRaw))
+	{
+		return false;
+	}
 	auto dirent = unpackDirEntry(direntRaw);
 	auto dotent = unpackDirEntry(dotRaw);
 	auto dotdot = unpackDirEntry(dotdotRaw);
 	if (!modeIsDir(dirent.mode) || !modeIsDir(dotent.mode) || !modeIsDir(dotdot.mode) || dirent.length < 2)
 	{
-		throw PS2SaveError("Not a valid PSU file");
+		return m_error.Fail("Not a valid PSU file");
 	}
 	uint32_t fileCount = dirent.length - 2;
 	entries.clear();
@@ -823,7 +912,9 @@ void PS2SaveFile::Impl::loadEms(std::ifstream& file)
 	entries.push_back(std::move(dirSlot));
 	for (uint32_t i = 0; i < fileCount; ++i)
 	{
-		auto entRaw = readFixed(file, PS2MC_DIRENT_LENGTH);
+		std::vector<uint8_t> entRaw;
+		if (!readFixed(file, PS2MC_DIRENT_LENGTH, entRaw))
+			return false;
 		auto ent = unpackDirEntry(entRaw);
 		if (!modeIsFile(ent.mode))
 		{
@@ -831,17 +922,24 @@ void PS2SaveFile::Impl::loadEms(std::ifstream& file)
 			Logger::warn("Skipping subdir (entry {}): {}", i, name);
 			continue;
 		}
-		auto data = readFixed(file, ent.length);
+		std::vector<uint8_t> data;
+		if (!readFixed(file, ent.length, data))
+			return false;
 		size_t pad = roundUp(static_cast<int>(ent.length), 1024) - ent.length;
 		if (pad)
-			readFixed(file, pad);
+		{
+			std::vector<uint8_t> padData;
+			if (!readFixed(file, pad, padData))
+				return false;
+		}
 		entries.push_back({ent, std::move(data)});
 	}
 	format = SaveFormat::EMS;
 	title = dirent.name;
+	return true;
 }
 
-void PS2SaveFile::Impl::saveEms(std::ofstream& file)
+bool PS2SaveFile::Impl::saveEms(std::ofstream& file)
 {
 	const bool hasDirHeader = !entries.empty() && (entries[0].dirEntry.mode & DF_DIR);
 	const size_t numFiles = hasDirHeader ? entries.size() - 1 : entries.size();
@@ -885,6 +983,9 @@ void PS2SaveFile::Impl::saveEms(std::ofstream& file)
 		}
 	}
 	file.flush();
+	if (!file)
+		return m_error.Fail("Failed to write PSU save");
+	return true;
 }
 
 std::string sjisToUtf8(const std::string& sjis)

--- a/src/core/formats/ps2save.h
+++ b/src/core/formats/ps2save.h
@@ -4,34 +4,16 @@
 #pragma once
 
 #include "ps2mc_dir.h"
+#include "Error.h"
 #include <string>
 #include <vector>
 #include <memory>
-#include <stdexcept>
 
 const char PS2SAVE_MAX_MAGIC[] = "Ps2PowerSave";
 const char PS2SAVE_SPS_MAGIC[] = "\x0d\0\0\0SharkPortSave";
 const char PS2SAVE_CBS_MAGIC[] = "CFU\0";
 const char PS2SAVE_NPO_MAGIC[] = "nPort";
 const char PS2SAVE_PSV_MAGIC[] = "\x00VSP";
-
-class PS2SaveError : public std::runtime_error
-{
-public:
-	explicit PS2SaveError(const std::string& msg)
-		: std::runtime_error(msg)
-	{
-	}
-};
-
-class PS2SaveCorrupt : public PS2SaveError
-{
-public:
-	explicit PS2SaveCorrupt(const std::string& msg)
-		: PS2SaveError("Corrupt save file: " + msg)
-	{
-	}
-};
 
 enum class SaveFormat
 {
@@ -57,8 +39,10 @@ public:
 	PS2SaveFile();
 	~PS2SaveFile();
 
-	void load(const std::string& filename);
-	void save(const std::string& filename, SaveFormat format = SaveFormat::MAX_DRIVE);
+	const Error& GetError() const { return m_error; }
+
+	bool load(const std::string& filename);
+	bool save(const std::string& filename, SaveFormat format = SaveFormat::MAX_DRIVE);
 
 	std::vector<PS2SaveEntry>& getEntries();
 	const std::vector<PS2SaveEntry>& getEntries() const;
@@ -71,6 +55,7 @@ public:
 	static std::string formatToExtension(SaveFormat format);
 
 private:
+	Error m_error;
 	class Impl;
 	std::unique_ptr<Impl> pImpl;
 };

--- a/src/ui/CardActionHandler.cpp
+++ b/src/ui/CardActionHandler.cpp
@@ -22,46 +22,38 @@ CardActionHandler::CardActionHandler(QWidget* parent)
 
 PS2MemoryCard* CardActionHandler::openCard(const QString& filename)
 {
-	try
-	{
-		auto card = std::make_unique<PS2MemoryCard>();
-		card->open(filename.toStdString());
-
-		if (statusBar)
-		{
-			statusBar->showMessage(tr("Opened: %1").arg(filename), 3000);
-		}
-
-		return card.release();
-	}
-	catch (const std::exception& e)
+	auto card = std::make_unique<PS2MemoryCard>();
+	if (!card->open(filename.toStdString()))
 	{
 		QMessageBox::critical(parentWidget, tr("Error"),
-			tr("Failed to open memory card: %1").arg(e.what()));
+			tr("Failed to open memory card: %1").arg(QString::fromStdString(card->GetError().GetDescription())));
 		return nullptr;
 	}
+
+	if (statusBar)
+	{
+		statusBar->showMessage(tr("Opened: %1").arg(filename), 3000);
+	}
+
+	return card.release();
 }
 
 PS2MemoryCard* CardActionHandler::createCard(const QString& filename, int sizeMB, bool disableEcc)
 {
-	try
-	{
-		auto card = std::make_unique<PS2MemoryCard>();
-		card->create(filename.toStdString(), sizeMB, disableEcc);
-
-		if (statusBar)
-		{
-			statusBar->showMessage(tr("Created: %1").arg(filename), 3000);
-		}
-
-		return card.release();
-	}
-	catch (const std::exception& e)
+	auto card = std::make_unique<PS2MemoryCard>();
+	if (!card->create(filename.toStdString(), sizeMB, disableEcc))
 	{
 		QMessageBox::critical(parentWidget, tr("Error"),
-			tr("Failed to create memory card: %1").arg(e.what()));
+			tr("Failed to create memory card: %1").arg(QString::fromStdString(card->GetError().GetDescription())));
 		return nullptr;
 	}
+
+	if (statusBar)
+	{
+		statusBar->showMessage(tr("Created: %1").arg(filename), 3000);
+	}
+
+	return card.release();
 }
 
 void CardActionHandler::closeCard()
@@ -89,92 +81,95 @@ CardActionHandler::ImportResult CardActionHandler::importSave(PS2MemoryCard* car
 		return ImportResult::Failed;
 	}
 
-	try
+	const auto& entries = saveFile->getEntries();
+	if (entries.empty())
 	{
-		const auto& entries = saveFile->getEntries();
-		if (entries.empty())
+		if (showDialogs)
+		{
+			QMessageBox::warning(parentWidget, tr("Warning"),
+				tr("Save file is empty or contains no valid entries"));
+		}
+		return ImportResult::Failed;
+	}
+
+	const bool hasDirHeader = !entries.empty() && (entries[0].dirEntry.mode & DF_DIR);
+	std::string saveName = hasDirHeader ? entries[0].dirEntry.name : saveFile->getTitle();
+	if (saveName.empty())
+	{
+		saveName = entries[0].dirEntry.name;
+	}
+
+	bool result = card->importSaveFile(*saveFile, forceOverwrite, "");
+
+	if (result)
+	{
+		if (showDialogs)
+		{
+			QMessageBox::information(parentWidget, tr("Success"),
+				tr("Successfully imported save: %1")
+					.arg(QString::fromStdString(saveName)));
+		}
+
+		if (statusBar)
+		{
+			statusBar->showMessage(tr("Imported: %1").arg(QString::fromStdString(saveName)), 3000);
+		}
+		return ImportResult::Success;
+	}
+	else
+	{
+		if (card->GetError().IsValid())
 		{
 			if (showDialogs)
 			{
-				QMessageBox::warning(parentWidget, tr("Warning"),
-					tr("Save file is empty or contains no valid entries"));
+				QMessageBox::critical(parentWidget, tr("Error"),
+					tr("Failed to import save: %1").arg(QString::fromStdString(card->GetError().GetDescription())));
 			}
 			return ImportResult::Failed;
 		}
 
-		const bool hasDirHeader = !entries.empty() && (entries[0].dirEntry.mode & DF_DIR);
-		std::string saveName = hasDirHeader ? entries[0].dirEntry.name : saveFile->getTitle();
-		if (saveName.empty())
+		if (!showDialogs)
 		{
-			saveName = entries[0].dirEntry.name;
+			return ImportResult::Failed;
 		}
 
-		bool result = card->importSaveFile(*saveFile, forceOverwrite, "");
+		auto reply = QMessageBox::question(parentWidget, tr("Save Exists"),
+			tr("Save '%1' already exists. Overwrite?")
+				.arg(QString::fromStdString(saveName)),
+			QMessageBox::Yes | QMessageBox::No);
 
-		if (result)
+		if (reply == QMessageBox::Yes)
 		{
-			if (showDialogs)
+			result = card->importSaveFile(*saveFile, true, "");
+
+			if (result)
 			{
 				QMessageBox::information(parentWidget, tr("Success"),
-					tr("Successfully imported save: %1")
-						.arg(QString::fromStdString(saveName)));
-			}
+					tr("Successfully imported and overwrote existing save"));
 
-			if (statusBar)
-			{
-				statusBar->showMessage(tr("Imported: %1").arg(QString::fromStdString(saveName)), 3000);
-			}
-			return ImportResult::Success;
-		}
-		else
-		{
-			if (!showDialogs)
-			{
-				return ImportResult::Failed;
-			}
-
-			auto reply = QMessageBox::question(parentWidget, tr("Save Exists"),
-				tr("Save '%1' already exists. Overwrite?")
-					.arg(QString::fromStdString(saveName)),
-				QMessageBox::Yes | QMessageBox::No);
-
-			if (reply == QMessageBox::Yes)
-			{
-				result = card->importSaveFile(*saveFile, true, "");
-
-				if (result)
+				if (statusBar)
 				{
-					QMessageBox::information(parentWidget, tr("Success"),
-						tr("Successfully imported and overwrote existing save"));
-
-					if (statusBar)
-					{
-						statusBar->showMessage(tr("Imported (overwrite): %1")
-												   .arg(QString::fromStdString(saveName)),
-							3000);
-					}
-					return ImportResult::Success;
+					statusBar->showMessage(tr("Imported (overwrite): %1")
+											   .arg(QString::fromStdString(saveName)),
+						3000);
 				}
-				else
-				{
-					return ImportResult::Failed;
-				}
+				return ImportResult::Success;
 			}
 			else
 			{
-				return ImportResult::Skipped;
+				if (showDialogs && card->GetError().IsValid())
+				{
+					QMessageBox::critical(parentWidget, tr("Error"),
+						tr("Failed to import save: %1").arg(QString::fromStdString(card->GetError().GetDescription())));
+				}
+				return ImportResult::Failed;
 			}
 		}
-	}
-	catch (const std::exception& e)
-	{
-		if (showDialogs)
+		else
 		{
-			QMessageBox::critical(parentWidget, tr("Error"),
-				tr("Failed to import save: %1").arg(e.what()));
+			return ImportResult::Skipped;
 		}
 	}
-	return ImportResult::Failed;
 }
 
 bool CardActionHandler::exportSave(PS2MemoryCard* card, const QString& savePath, const QString& outputFilename, bool showSuccessDialog)
@@ -186,43 +181,46 @@ bool CardActionHandler::exportSave(PS2MemoryCard* card, const QString& savePath,
 		return false;
 	}
 
-	try
-	{
-		PS2SaveFile saveFile;
-		card->exportSaveFile(savePath.toStdString(), saveFile);
-
-		SaveFormat format = PS2SaveFile::detectFormat(outputFilename.toStdString());
-		if (format == SaveFormat::UNKNOWN)
-			format = SaveFormat::EMS;
-
-		saveFile.save(outputFilename.toStdString(), format);
-
-		if (showSuccessDialog)
-		{
-			QMessageBox msgBox(parentWidget);
-			msgBox.setWindowTitle(tr("Success"));
-			msgBox.setText(tr("Successfully exported save to:\n%1").arg(outputFilename));
-			msgBox.setIcon(QMessageBox::Information);
-			QPushButton* openFolderButton = msgBox.addButton(tr("Open Folder"), QMessageBox::ActionRole);
-			msgBox.addButton(QMessageBox::Ok);
-			msgBox.exec();
-
-			if (msgBox.clickedButton() == openFolderButton)
-			{
-				QString folderPath = QFileInfo(outputFilename).absolutePath();
-				QDesktopServices::openUrl(QUrl::fromLocalFile(folderPath));
-			}
-		}
-		if (statusBar && showSuccessDialog)
-			statusBar->showMessage(tr("Exported: %1").arg(savePath), 3000);
-		return true;
-	}
-	catch (const std::exception& e)
+	PS2SaveFile saveFile;
+	if (!card->exportSaveFile(savePath.toStdString(), saveFile))
 	{
 		if (showSuccessDialog)
-			QMessageBox::critical(parentWidget, tr("Error"), tr("Failed to export save: %1").arg(e.what()));
+			QMessageBox::critical(parentWidget, tr("Error"),
+				tr("Failed to export save: %1").arg(QString::fromStdString(card->GetError().GetDescription())));
 		return false;
 	}
+
+	SaveFormat format = PS2SaveFile::detectFormat(outputFilename.toStdString());
+	if (format == SaveFormat::UNKNOWN)
+		format = SaveFormat::EMS;
+
+	if (!saveFile.save(outputFilename.toStdString(), format))
+	{
+		if (showSuccessDialog)
+			QMessageBox::critical(parentWidget, tr("Error"),
+				tr("Failed to export save: %1").arg(QString::fromStdString(saveFile.GetError().GetDescription())));
+		return false;
+	}
+
+	if (showSuccessDialog)
+	{
+		QMessageBox msgBox(parentWidget);
+		msgBox.setWindowTitle(tr("Success"));
+		msgBox.setText(tr("Successfully exported save to:\n%1").arg(outputFilename));
+		msgBox.setIcon(QMessageBox::Information);
+		QPushButton* openFolderButton = msgBox.addButton(tr("Open Folder"), QMessageBox::ActionRole);
+		msgBox.addButton(QMessageBox::Ok);
+		msgBox.exec();
+
+		if (msgBox.clickedButton() == openFolderButton)
+		{
+			QString folderPath = QFileInfo(outputFilename).absolutePath();
+			QDesktopServices::openUrl(QUrl::fromLocalFile(folderPath));
+		}
+	}
+	if (statusBar && showSuccessDialog)
+		statusBar->showMessage(tr("Exported: %1").arg(savePath), 3000);
+	return true;
 }
 
 bool CardActionHandler::exportSaveAsFolder(PS2MemoryCard* card, const QString& savePath, const QString& targetDir, bool showSuccessDialog)
@@ -234,87 +232,93 @@ bool CardActionHandler::exportSaveAsFolder(PS2MemoryCard* card, const QString& s
 		return false;
 	}
 
-	try
-	{
-		PS2SaveFile saveFile;
-		card->exportSaveFile(savePath.toStdString(), saveFile);
-
-		QStringList sanitizedChanges;
-		QString rawFolderName = QFileInfo(savePath).fileName();
-		QString saveFolderName = QtUtils::sanitizeFilename(rawFolderName);
-		if (saveFolderName != rawFolderName)
-		{
-			sanitizedChanges.append(tr("'%1' -> '%2'").arg(rawFolderName, saveFolderName));
-		}
-		QDir destParentDir(targetDir);
-		QString fullDestPath = destParentDir.filePath(saveFolderName);
-
-		QDir destDir(fullDestPath);
-		if (!destDir.exists())
-		{
-			if (!destParentDir.mkpath(saveFolderName))
-			{
-				throw std::runtime_error(tr("Failed to create directory: %1").arg(fullDestPath).toStdString());
-			}
-		}
-
-		const auto& entries = saveFile.getEntries();
-		for (const auto& entry : entries)
-		{
-			if (entry.dirEntry.mode & DF_DIR)
-			{
-				continue;
-			}
-
-			QString rawFileName = QString::fromStdString(entry.dirEntry.name);
-			QString fileName = QtUtils::sanitizeFilename(rawFileName);
-			if (fileName != rawFileName)
-			{
-				sanitizedChanges.append(tr("'%1' -> '%2'").arg(rawFileName, fileName));
-			}
-			QString filePath = destDir.filePath(fileName);
-
-			QFile file(filePath);
-			if (!file.open(QIODevice::WriteOnly))
-			{
-				throw std::runtime_error(tr("Failed to write file: %1").arg(filePath).toStdString());
-			}
-			if (file.write(reinterpret_cast<const char*>(entry.data.data()), entry.data.size()) != static_cast<qint64>(entry.data.size()))
-			{
-				throw std::runtime_error(tr("Failed to write all data to file: %1").arg(filePath).toStdString());
-			}
-		}
-
-		if (showSuccessDialog)
-		{
-			QMessageBox msgBox(parentWidget);
-			msgBox.setWindowTitle(tr("Success"));
-			QString msgText = tr("Successfully exported save as folder to:\n%1").arg(fullDestPath);
-			if (!sanitizedChanges.isEmpty())
-			{
-				msgText += "\n\n" + tr("Note: The following names were sanitized due to invalid characters:\n%1").arg(sanitizedChanges.join("\n"));
-			}
-			msgBox.setText(msgText);
-			msgBox.setIcon(QMessageBox::Information);
-			QPushButton* openFolderButton = msgBox.addButton(tr("Open Folder"), QMessageBox::ActionRole);
-			msgBox.addButton(QMessageBox::Ok);
-			msgBox.exec();
-
-			if (msgBox.clickedButton() == openFolderButton)
-			{
-				QDesktopServices::openUrl(QUrl::fromLocalFile(fullDestPath));
-			}
-		}
-		if (statusBar && showSuccessDialog)
-			statusBar->showMessage(tr("Exported: %1").arg(savePath), 3000);
-		return true;
-	}
-	catch (const std::exception& e)
+	PS2SaveFile saveFile;
+	if (!card->exportSaveFile(savePath.toStdString(), saveFile))
 	{
 		if (showSuccessDialog)
-			QMessageBox::critical(parentWidget, tr("Error"), tr("Failed to export save: %1").arg(e.what()));
+			QMessageBox::critical(parentWidget, tr("Error"),
+				tr("Failed to export save: %1").arg(QString::fromStdString(card->GetError().GetDescription())));
 		return false;
 	}
+
+	QStringList sanitizedChanges;
+	QString rawFolderName = QFileInfo(savePath).fileName();
+	QString saveFolderName = QtUtils::sanitizeFilename(rawFolderName);
+	if (saveFolderName != rawFolderName)
+	{
+		sanitizedChanges.append(tr("'%1' -> '%2'").arg(rawFolderName, saveFolderName));
+	}
+	QDir destParentDir(targetDir);
+	QString fullDestPath = destParentDir.filePath(saveFolderName);
+
+	QDir destDir(fullDestPath);
+	if (!destDir.exists())
+	{
+		if (!destParentDir.mkpath(saveFolderName))
+		{
+			if (showSuccessDialog)
+				QMessageBox::critical(parentWidget, tr("Error"),
+					tr("Failed to create directory: %1").arg(fullDestPath));
+			return false;
+		}
+	}
+
+	const auto& entries = saveFile.getEntries();
+	for (const auto& entry : entries)
+	{
+		if (entry.dirEntry.mode & DF_DIR)
+		{
+			continue;
+		}
+
+		QString rawFileName = QString::fromStdString(entry.dirEntry.name);
+		QString fileName = QtUtils::sanitizeFilename(rawFileName);
+		if (fileName != rawFileName)
+		{
+			sanitizedChanges.append(tr("'%1' -> '%2'").arg(rawFileName, fileName));
+		}
+		QString filePath = destDir.filePath(fileName);
+
+		QFile file(filePath);
+		if (!file.open(QIODevice::WriteOnly))
+		{
+			if (showSuccessDialog)
+				QMessageBox::critical(parentWidget, tr("Error"),
+					tr("Failed to write file: %1").arg(filePath));
+			return false;
+		}
+		if (file.write(reinterpret_cast<const char*>(entry.data.data()), entry.data.size()) != static_cast<qint64>(entry.data.size()))
+		{
+			if (showSuccessDialog)
+				QMessageBox::critical(parentWidget, tr("Error"),
+					tr("Failed to write all data to file: %1").arg(filePath));
+			return false;
+		}
+	}
+
+	if (showSuccessDialog)
+	{
+		QMessageBox msgBox(parentWidget);
+		msgBox.setWindowTitle(tr("Success"));
+		QString msgText = tr("Successfully exported save as folder to:\n%1").arg(fullDestPath);
+		if (!sanitizedChanges.isEmpty())
+		{
+			msgText += "\n\n" + tr("Note: The following names were sanitized due to invalid characters:\n%1").arg(sanitizedChanges.join("\n"));
+		}
+		msgBox.setText(msgText);
+		msgBox.setIcon(QMessageBox::Information);
+		QPushButton* openFolderButton = msgBox.addButton(tr("Open Folder"), QMessageBox::ActionRole);
+		msgBox.addButton(QMessageBox::Ok);
+		msgBox.exec();
+
+		if (msgBox.clickedButton() == openFolderButton)
+		{
+			QDesktopServices::openUrl(QUrl::fromLocalFile(fullDestPath));
+		}
+	}
+	if (statusBar && showSuccessDialog)
+		statusBar->showMessage(tr("Exported: %1").arg(savePath), 3000);
+	return true;
 }
 
 bool CardActionHandler::deleteSave(PS2MemoryCard* card, const QString& savePath, bool showDialogs)
@@ -332,25 +336,21 @@ bool CardActionHandler::deleteSave(PS2MemoryCard* card, const QString& savePath,
 		saveName = saveName.mid(1);
 	}
 
-	try
-	{
-		card->remove(savePath.toStdString());
-
-		if (showDialogs && statusBar)
-		{
-			statusBar->showMessage(tr("Deleted: %1").arg(saveName), 3000);
-		}
-		return true;
-	}
-	catch (const std::exception& e)
+	if (!card->remove(savePath.toStdString()))
 	{
 		if (showDialogs)
 		{
 			QMessageBox::critical(parentWidget, tr("Error"),
-				tr("Failed to delete save:\n\n%1").arg(e.what()));
+				tr("Failed to delete save:\n\n%1").arg(QString::fromStdString(card->GetError().GetDescription())));
 		}
 		return false;
 	}
+
+	if (showDialogs && statusBar)
+	{
+		statusBar->showMessage(tr("Deleted: %1").arg(saveName), 3000);
+	}
+	return true;
 }
 
 void CardActionHandler::formatCard(PS2MemoryCard* card, const QString& cardPath, int sizeMB)
@@ -371,36 +371,41 @@ void CardActionHandler::formatCard(PS2MemoryCard* card, const QString& cardPath,
 
 	if (ret == QMessageBox::Yes)
 	{
-		try
+		if (effectiveSizeMB <= 0)
 		{
+			const auto info = card->getCardInfo();
+			if (card->GetError().IsValid())
+			{
+				QMessageBox::critical(parentWidget, tr("Error"),
+					tr("Failed to read card info:\n\n%1").arg(QString::fromStdString(card->GetError().GetDescription())));
+				return;
+			}
+			effectiveSizeMB = static_cast<int>(info.imageSizeBytes / (1024ull * 1024ull));
 			if (effectiveSizeMB <= 0)
 			{
-				const auto info = card->getCardInfo();
-				effectiveSizeMB = static_cast<int>(info.imageSizeBytes / (1024ull * 1024ull));
-				if (effectiveSizeMB <= 0)
-				{
-					throw std::runtime_error("Invalid memory card size");
-				}
+				QMessageBox::critical(parentWidget, tr("Error"),
+					tr("Failed to format card:\n\nInvalid memory card size"));
+				return;
 			}
-
-			const bool disableEcc = !card->hasEcc();
-
-			card->close();
-			card->create(cardPath.toStdString(), effectiveSizeMB, disableEcc);
-
-			if (statusBar)
-			{
-				statusBar->showMessage(tr("Card formatted successfully"), 3000);
-			}
-
-			QMessageBox::information(parentWidget, tr("Success"),
-				tr("Memory card formatted successfully (%1 MB)").arg(effectiveSizeMB));
 		}
-		catch (const std::exception& e)
+
+		const bool disableEcc = !card->hasEcc();
+
+		card->close();
+		if (!card->create(cardPath.toStdString(), effectiveSizeMB, disableEcc))
 		{
 			QMessageBox::critical(parentWidget, tr("Error"),
-				tr("Failed to format card:\n\n%1").arg(e.what()));
+				tr("Failed to format card:\n\n%1").arg(QString::fromStdString(card->GetError().GetDescription())));
+			return;
 		}
+
+		if (statusBar)
+		{
+			statusBar->showMessage(tr("Card formatted successfully"), 3000);
+		}
+
+		QMessageBox::information(parentWidget, tr("Success"),
+			tr("Memory card formatted successfully (%1 MB)").arg(effectiveSizeMB));
 	}
 }
 

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -226,16 +226,15 @@ MainWindow::MainWindow(Config* config, QWidget* parent)
 
 		if (!filename.isEmpty())
 		{
-			try
+			QString fullPath = savePath + "/" + fileName;
+			if (memoryCard->exportFile(fullPath.toStdString(), filename.toStdString()))
 			{
-				QString fullPath = savePath + "/" + fileName;
-				memoryCard->exportFile(fullPath.toStdString(), filename.toStdString());
 				ui->statusBar->showMessage(tr("Exported %1").arg(fileName), 5000);
 			}
-			catch (const std::exception& e)
+			else
 			{
 				QMessageBox::critical(this, tr("Error"),
-					tr("Failed to export file: %1").arg(e.what()));
+					tr("Failed to export file: %1").arg(QString::fromStdString(memoryCard->GetError().GetDescription())));
 			}
 		}
 	});
@@ -377,19 +376,18 @@ MainWindow::MainWindow(Config* config, QWidget* parent)
 		QStringList failedNames;
 		for (const QString& fileName : fileNames)
 		{
-			try
+			QString fullPath = savePath + "/" + fileName;
+			QString cleanFileName = QtUtils::sanitizeFilename(fileName);
+			if (cleanFileName != fileName)
 			{
-				QString fullPath = savePath + "/" + fileName;
-				QString cleanFileName = QtUtils::sanitizeFilename(fileName);
-				if (cleanFileName != fileName)
-				{
-					sanitizedChanges.append(tr("'%1' -> '%2'").arg(fileName, cleanFileName));
-				}
-				QString targetFilePath = dir.filePath(cleanFileName);
-				memoryCard->exportFile(fullPath.toStdString(), targetFilePath.toStdString());
+				sanitizedChanges.append(tr("'%1' -> '%2'").arg(fileName, cleanFileName));
+			}
+			QString targetFilePath = dir.filePath(cleanFileName);
+			if (memoryCard->exportFile(fullPath.toStdString(), targetFilePath.toStdString()))
+			{
 				++ok;
 			}
-			catch (const std::exception&)
+			else
 			{
 				++failed;
 				failedNames.append(fileName);
@@ -460,22 +458,19 @@ MainWindow::MainWindow(Config* config, QWidget* parent)
 		QString folderName = QInputDialog::getText(this, tr("New Folder"),
 			tr("Folder name:"), QLineEdit::Normal, "", &ok);
 
-
-
 		if (ok && !folderName.isEmpty())
 		{
-			try
+			QString fullPath = parentPath == "/" ? "/" + folderName : parentPath + "/" + folderName;
+			if (memoryCard->makeDir(fullPath.toStdString()))
 			{
-				QString fullPath = parentPath == "/" ? "/" + folderName : parentPath + "/" + folderName;
-				memoryCard->makeDir(fullPath.toStdString());
 				ui->statusBar->showMessage(tr("Created folder %1").arg(folderName), 5000);
 				ui->cardBrowser->navigateTo(parentPath);
 				updateCardView();
 			}
-			catch (const std::exception& e)
+			else
 			{
 				QMessageBox::critical(this, tr("Error"),
-					tr("Failed to create folder: %1").arg(e.what()));
+					tr("Failed to create folder: %1").arg(QString::fromStdString(memoryCard->GetError().GetDescription())));
 			}
 		}
 	});
@@ -768,11 +763,15 @@ void MainWindow::importSaveFiles(const QStringList& paths)
 		ImportExportSavesDialog::ImportItem item;
 		item.filePath = filepath;
 
-		try
+		auto save = std::make_shared<PS2SaveFile>();
+		if (!save->load(filepath.toStdString()))
 		{
-			auto save = std::make_shared<PS2SaveFile>();
-			save->load(filepath.toStdString());
-
+			item.corrupt = true;
+			item.errorText = QString::fromStdString(save->GetError().GetDescription());
+			item.gameTitle = QFileInfo(filepath).fileName();
+		}
+		else
+		{
 			std::string saveName = save->getTitle();
 			if (saveName.empty())
 			{
@@ -810,25 +809,23 @@ void MainWindow::importSaveFiles(const QStringList& paths)
 
 			if (memoryCard)
 			{
-				try
+				if (memoryCard->hasEntry("/" + dirId))
 				{
-					memoryCard->getEntry("/" + dirId);
 					item.exists = true;
 					item.overwriteSelected = forceOverwrite;
 				}
-				catch (...)
+				else if (memoryCard->GetError().IsValid())
+				{
+					item.corrupt = true;
+					item.errorText = QString::fromStdString(memoryCard->GetError().GetDescription());
+				}
+				else
 				{
 					item.exists = false;
 				}
 			}
 
 			item.saveFile = save;
-		}
-		catch (const std::exception& e)
-		{
-			item.corrupt = true;
-			item.errorText = QString::fromStdString(e.what());
-			item.gameTitle = QFileInfo(filepath).fileName();
 		}
 
 		importItems.append(item);
@@ -1248,24 +1245,18 @@ void MainWindow::onCardItemSelected()
 			return fallback;
 		}
 
-		try
-		{
-			const std::string savePath = ui->cardBrowser->getCurrentPath().toStdString();
-			const std::string title = memoryCard->getSaveTitle(savePath);
-			const std::string subtitle = memoryCard->getSaveSubtitle(savePath);
+		const std::string savePath = ui->cardBrowser->getCurrentPath().toStdString();
+		const std::string title = memoryCard->getSaveTitle(savePath);
+		const std::string subtitle = memoryCard->getSaveSubtitle(savePath);
 
-			if (!title.empty())
-			{
-				QString display = QString::fromStdString(title);
-				if (!subtitle.empty())
-				{
-					display += QStringLiteral(" ") + QString::fromStdString(subtitle);
-				}
-				return display;
-			}
-		}
-		catch (...)
+		if (!title.empty())
 		{
+			QString display = QString::fromStdString(title);
+			if (!subtitle.empty())
+			{
+				display += QStringLiteral(" ") + QString::fromStdString(subtitle);
+			}
+			return display;
 		}
 
 		return fallback;
@@ -1378,68 +1369,71 @@ void MainWindow::onEditTimestamp(const QString& mcPath)
 	if (!memoryCard)
 		return;
 
-	try
-	{
-		const std::string path = mcPath.toStdString();
-		PS2McDirEntry entry = memoryCard->getEntry(path);
-		std::time_t currentTime = todToTime(entry.modified);
-
-		QDateTime currentDateTime;
-		if (currentTime == 0)
-		{
-			currentDateTime = QDateTime::currentDateTime();
-		}
-		else
-		{
-			currentDateTime = QDateTime::fromSecsSinceEpoch(static_cast<qint64>(currentTime));
-		}
-
-		QDialog dialog(this);
-		dialog.setWindowTitle(tr("Edit Modified Date"));
-
-		QVBoxLayout* layout = new QVBoxLayout(&dialog);
-
-		QLabel* pathLabel = new QLabel(mcPath, &dialog);
-		pathLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
-		layout->addWidget(pathLabel);
-
-		QDateTimeEdit* dateTimeEdit = new QDateTimeEdit(currentDateTime, &dialog);
-		dateTimeEdit->setDisplayFormat("yyyy-MM-dd hh:mm");
-		dateTimeEdit->setCalendarPopup(true);
-		layout->addWidget(dateTimeEdit);
-
-		QPushButton* nowButton = new QPushButton(tr("Set to Now"), &dialog);
-		connect(nowButton, &QPushButton::clicked, &dialog, [dateTimeEdit]() {
-			dateTimeEdit->setDateTime(QDateTime::currentDateTime());
-		});
-		layout->addWidget(nowButton);
-
-		QDialogButtonBox* buttonBox = new QDialogButtonBox(
-			QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &dialog);
-		layout->addWidget(buttonBox);
-
-		connect(buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
-		connect(buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
-
-		if (dialog.exec() != QDialog::Accepted)
-			return;
-
-		QDateTime newDateTime = dateTimeEdit->dateTime();
-		if (!newDateTime.isValid())
-			return;
-
-		std::time_t newTime = static_cast<std::time_t>(newDateTime.toSecsSinceEpoch());
-
-		memoryCard->setModifiedTime(path, newTime);
-
-		updateCardView();
-		ui->cardBrowser->navigateTo(ui->cardBrowser->getCurrentPath());
-	}
-	catch (const std::exception& e)
+	const std::string path = mcPath.toStdString();
+	PS2McDirEntry entry = memoryCard->getEntry(path);
+	if (memoryCard->GetError().IsValid())
 	{
 		QMessageBox::critical(this, tr("Error"),
-			tr("Failed to edit timestamp: %1").arg(e.what()));
+			tr("Failed to read entry: %1").arg(QString::fromStdString(memoryCard->GetError().GetDescription())));
+		return;
 	}
+	std::time_t currentTime = todToTime(entry.modified);
+
+	QDateTime currentDateTime;
+	if (currentTime == 0)
+	{
+		currentDateTime = QDateTime::currentDateTime();
+	}
+	else
+	{
+		currentDateTime = QDateTime::fromSecsSinceEpoch(static_cast<qint64>(currentTime));
+	}
+
+	QDialog dialog(this);
+	dialog.setWindowTitle(tr("Edit Modified Date"));
+
+	QVBoxLayout* layout = new QVBoxLayout(&dialog);
+
+	QLabel* pathLabel = new QLabel(mcPath, &dialog);
+	pathLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+	layout->addWidget(pathLabel);
+
+	QDateTimeEdit* dateTimeEdit = new QDateTimeEdit(currentDateTime, &dialog);
+	dateTimeEdit->setDisplayFormat("yyyy-MM-dd hh:mm");
+	dateTimeEdit->setCalendarPopup(true);
+	layout->addWidget(dateTimeEdit);
+
+	QPushButton* nowButton = new QPushButton(tr("Set to Now"), &dialog);
+	connect(nowButton, &QPushButton::clicked, &dialog, [dateTimeEdit]() {
+		dateTimeEdit->setDateTime(QDateTime::currentDateTime());
+	});
+	layout->addWidget(nowButton);
+
+	QDialogButtonBox* buttonBox = new QDialogButtonBox(
+		QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &dialog);
+	layout->addWidget(buttonBox);
+
+	connect(buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+	connect(buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+
+	if (dialog.exec() != QDialog::Accepted)
+		return;
+
+	QDateTime newDateTime = dateTimeEdit->dateTime();
+	if (!newDateTime.isValid())
+		return;
+
+	std::time_t newTime = static_cast<std::time_t>(newDateTime.toSecsSinceEpoch());
+
+	if (!memoryCard->setModifiedTime(path, newTime))
+	{
+		QMessageBox::critical(this, tr("Error"),
+			tr("Failed to edit timestamp: %1").arg(QString::fromStdString(memoryCard->GetError().GetDescription())));
+		return;
+	}
+
+	updateCardView();
+	ui->cardBrowser->navigateTo(ui->cardBrowser->getCurrentPath());
 }
 
 void MainWindow::updateCardView()
@@ -1452,24 +1446,29 @@ void MainWindow::updateStatusBar()
 {
 	if (memoryCard)
 	{
-		try
+		uint32_t freeSpace = memoryCard->getFreeSpace();
+		if (memoryCard->GetError().IsValid())
 		{
-			uint32_t freeSpace = memoryCard->getFreeSpace();
-			uint32_t allocatable = memoryCard->getAllocatableSpace();
-			double freeMB = freeSpace / (1024.0 * 1024.0);
-			double totalMB = allocatable / (1024.0 * 1024.0);
-			bool hasEcc = memoryCard->hasEcc();
-			QString eccLabel = hasEcc ? tr("ECC") : tr("No ECC");
-			ui->statusBar->showMessage(
-				tr("Free: %2 MB / Total: %1 MB (%3)")
-					.arg(totalMB, 0, 'f', 2)
-					.arg(freeMB, 0, 'f', 2)
-					.arg(eccLabel));
+			ui->statusBar->showMessage(tr("Failed to read free space: %1")
+					.arg(QString::fromStdString(memoryCard->GetError().GetDescription())));
+			return;
 		}
-		catch (...)
+		uint32_t allocatable = memoryCard->getAllocatableSpace();
+		if (memoryCard->GetError().IsValid())
 		{
-			ui->statusBar->showMessage(tr("Memory card open"));
+			ui->statusBar->showMessage(tr("Failed to read card capacity: %1")
+					.arg(QString::fromStdString(memoryCard->GetError().GetDescription())));
+			return;
 		}
+		double freeMB = freeSpace / (1024.0 * 1024.0);
+		double totalMB = allocatable / (1024.0 * 1024.0);
+		bool hasEcc = memoryCard->hasEcc();
+		QString eccLabel = hasEcc ? tr("ECC") : tr("No ECC");
+		ui->statusBar->showMessage(
+			tr("Free: %2 MB / Total: %1 MB (%3)")
+				.arg(totalMB, 0, 'f', 2)
+				.arg(freeMB, 0, 'f', 2)
+				.arg(eccLabel));
 	}
 	else
 	{
@@ -1533,22 +1532,20 @@ void MainWindow::onSaveAs()
 		return;
 	}
 
-	try
-	{
-		memoryCard->saveAs(filename.toStdString(), memoryCard->hasEcc());
-		if (m_discordRpc)
-		{
-			m_discordRpc->setTemporaryPresence(
-				tr("Card: %1").arg(makeCardDisplayLabel(currentCardPath)),
-				tr("Copy saved: %1").arg(QFileInfo(filename).fileName()));
-		}
-		ui->statusBar->showMessage(tr("Copy saved to %1").arg(filename), 5000);
-	}
-	catch (const std::exception& e)
+	if (!memoryCard->saveAs(filename.toStdString(), memoryCard->hasEcc()))
 	{
 		QMessageBox::critical(this, tr("Error"),
-			tr("Failed to save: %1").arg(e.what()));
+			tr("Failed to save: %1").arg(QString::fromStdString(memoryCard->GetError().GetDescription())));
+		return;
 	}
+
+	if (m_discordRpc)
+	{
+		m_discordRpc->setTemporaryPresence(
+			tr("Card: %1").arg(makeCardDisplayLabel(currentCardPath)),
+			tr("Copy saved: %1").arg(QFileInfo(filename).fileName()));
+	}
+	ui->statusBar->showMessage(tr("Copy saved to %1").arg(filename), 5000);
 }
 
 void MainWindow::onCardInfo()
@@ -1556,88 +1553,99 @@ void MainWindow::onCardInfo()
 	if (!memoryCard)
 		return;
 
-	try
-	{
-		PS2MemoryCard::CardInfo info = memoryCard->getCardInfo();
-
-		QDialog dialog(this);
-		dialog.setWindowTitle(tr("Card Info"));
-
-		QFormLayout* layout = new QFormLayout(&dialog);
-
-		auto addRow = [layout](const QString& label, const QString& value) {
-			layout->addRow(new QLabel(label), new QLabel(value));
-		};
-
-		auto addSection = [layout](const QString& label) {
-			QLabel* header = new QLabel(label);
-			header->setStyleSheet(QStringLiteral("font-weight: bold; margin-top: 8px;"));
-			layout->addRow(header, new QLabel);
-		};
-
-		const double imageMiB = static_cast<double>(info.imageSizeBytes) / (1024.0 * 1024.0);
-		const double usedMiB = static_cast<double>(info.usedBytes) / (1024.0 * 1024.0);
-		const double freeMiB = static_cast<double>(info.freeBytes) / (1024.0 * 1024.0);
-
-		addSection(tr("Header"));
-		addRow(tr("Magic"), QString::fromLatin1(PS2MC_MAGIC));
-		addRow(tr("Image Size"), tr("%1 MiB").arg(imageMiB, 0, 'f', 2));
-
-		addSection(tr("Geometry"));
-		addRow(tr("Page Length"), tr("%1 bytes").arg(info.pageSize));
-		addRow(tr("Page Physical"), tr("%1 bytes").arg(info.rawPageSize));
-		addRow(tr("Pages / Cluster"), QString::number(info.pagesPerCluster));
-		addRow(tr("Cluster Size"), tr("%1 KiB").arg(info.clusterSize / 1024.0, 0, 'f', 2));
-		addRow(tr("Clusters / Card"), QString::number(info.clustersPerCard));
-
-		addSection(tr("Type and Flags"));
-		QString typeLabel = tr("Unknown (%1)").arg(info.cardType);
-		if (info.cardType == 2)
-			typeLabel = tr("PS2 (2)");
-		else if (info.cardType == 1)
-			typeLabel = tr("PSX (1)");
-		addRow(tr("Card Type"), typeLabel);
-
-		QStringList flagBits;
-		if (info.cardFlags & 0x01)
-			flagBits << tr("USE_ECC");
-		if (info.cardFlags & 0x08)
-			flagBits << tr("BAD_BLOCK");
-		if (info.cardFlags & 0x10)
-			flagBits << tr("ERASE_ZEROES");
-		QString flagsText = tr("0x%1").arg(QString::number(info.cardFlags, 16).toUpper());
-		if (!flagBits.isEmpty())
-			flagsText += tr(" (%1)").arg(flagBits.join(tr(", ")));
-		addRow(tr("Card Flags"), flagsText);
-
-		addRow(tr("ECC Layout"), info.withEcc ? tr("Yes (512+16)") : tr("No (512 only)"));
-
-		addSection(tr("Allocation"));
-		addRow(tr("Alloc Offset"), QString::number(info.allocatableOffset));
-		addRow(tr("Alloc Count"), QString::number(info.allocatableCount));
-		addRow(tr("Reserved Clusters"), QString::number(info.reservedClusters));
-		addRow(tr("Root Dir Cluster"), QString::number(info.rootDirCluster));
-		addRow(tr("Backup Block 1"), QString::number(info.backupBlock1));
-		addRow(tr("Backup Block 2"), QString::number(info.backupBlock2));
-		addRow(tr("Bad Blocks"), QString::number(info.badBlockCount));
-
-		addSection(tr("Usage"));
-		addRow(tr("Used / Free Clusters"),
-			tr("%1 / %2").arg(info.usedClusters).arg(info.freeClusters));
-		addRow(tr("Used Bytes"), tr("%1 MiB").arg(usedMiB, 0, 'f', 2));
-		addRow(tr("Free Bytes"), tr("%1 MiB").arg(freeMiB, 0, 'f', 2));
-
-		addSection(tr("Health"));
-		const bool fsOk = memoryCard->check();
-		addRow(tr("Filesystem Check"), fsOk ? tr("OK") : tr("Problems detected"));
-
-		dialog.exec();
-	}
-	catch (const std::exception& e)
+	PS2MemoryCard::CardInfo info = memoryCard->getCardInfo();
+	if (memoryCard->GetError().IsValid())
 	{
 		QMessageBox::critical(this, tr("Error"),
-			tr("Failed to read card info: %1").arg(e.what()));
+			tr("Failed to read card info: %1").arg(QString::fromStdString(memoryCard->GetError().GetDescription())));
+		return;
 	}
+
+	QDialog dialog(this);
+	dialog.setWindowTitle(tr("Card Info"));
+
+	QFormLayout* layout = new QFormLayout(&dialog);
+
+	auto addRow = [layout](const QString& label, const QString& value) {
+		layout->addRow(new QLabel(label), new QLabel(value));
+	};
+
+	auto addSection = [layout](const QString& label) {
+		QLabel* header = new QLabel(label);
+		header->setStyleSheet(QStringLiteral("font-weight: bold; margin-top: 8px;"));
+		layout->addRow(header, new QLabel);
+	};
+
+	const double imageMiB = static_cast<double>(info.imageSizeBytes) / (1024.0 * 1024.0);
+	const double usedMiB = static_cast<double>(info.usedBytes) / (1024.0 * 1024.0);
+	const double freeMiB = static_cast<double>(info.freeBytes) / (1024.0 * 1024.0);
+
+	addSection(tr("Header"));
+	addRow(tr("Magic"), QString::fromLatin1(PS2MC_MAGIC));
+	addRow(tr("Image Size"), tr("%1 MiB").arg(imageMiB, 0, 'f', 2));
+
+	addSection(tr("Geometry"));
+	addRow(tr("Page Length"), tr("%1 bytes").arg(info.pageSize));
+	addRow(tr("Page Physical"), tr("%1 bytes").arg(info.rawPageSize));
+	addRow(tr("Pages / Cluster"), QString::number(info.pagesPerCluster));
+	addRow(tr("Cluster Size"), tr("%1 KiB").arg(info.clusterSize / 1024.0, 0, 'f', 2));
+	addRow(tr("Clusters / Card"), QString::number(info.clustersPerCard));
+
+	addSection(tr("Type and Flags"));
+	QString typeLabel = tr("Unknown (%1)").arg(info.cardType);
+	if (info.cardType == 2)
+		typeLabel = tr("PS2 (2)");
+	else if (info.cardType == 1)
+		typeLabel = tr("PSX (1)");
+	addRow(tr("Card Type"), typeLabel);
+
+	QStringList flagBits;
+	if (info.cardFlags & 0x01)
+		flagBits << tr("USE_ECC");
+	if (info.cardFlags & 0x08)
+		flagBits << tr("BAD_BLOCK");
+	if (info.cardFlags & 0x10)
+		flagBits << tr("ERASE_ZEROES");
+	QString flagsText = tr("0x%1").arg(QString::number(info.cardFlags, 16).toUpper());
+	if (!flagBits.isEmpty())
+		flagsText += tr(" (%1)").arg(flagBits.join(tr(", ")));
+	addRow(tr("Card Flags"), flagsText);
+
+	addRow(tr("ECC Layout"), info.withEcc ? tr("Yes (512+16)") : tr("No (512 only)"));
+
+	addSection(tr("Allocation"));
+	addRow(tr("Alloc Offset"), QString::number(info.allocatableOffset));
+	addRow(tr("Alloc Count"), QString::number(info.allocatableCount));
+	addRow(tr("Reserved Clusters"), QString::number(info.reservedClusters));
+	addRow(tr("Root Dir Cluster"), QString::number(info.rootDirCluster));
+	addRow(tr("Backup Block 1"), QString::number(info.backupBlock1));
+	addRow(tr("Backup Block 2"), QString::number(info.backupBlock2));
+	addRow(tr("Bad Blocks"), QString::number(info.badBlockCount));
+
+	addSection(tr("Usage"));
+	addRow(tr("Used / Free Clusters"),
+		tr("%1 / %2").arg(info.usedClusters).arg(info.freeClusters));
+	addRow(tr("Used Bytes"), tr("%1 MiB").arg(usedMiB, 0, 'f', 2));
+	addRow(tr("Free Bytes"), tr("%1 MiB").arg(freeMiB, 0, 'f', 2));
+
+	addSection(tr("Health"));
+	const bool fsOk = memoryCard->check();
+	QString checkStatus;
+	if (fsOk)
+	{
+		checkStatus = tr("OK");
+	}
+	else if (memoryCard->GetError().IsValid())
+	{
+		checkStatus = tr("Problems detected (%1)").arg(QString::fromStdString(memoryCard->GetError().GetDescription()));
+	}
+	else
+	{
+		checkStatus = tr("Problems detected");
+	}
+	addRow(tr("Filesystem Check"), checkStatus);
+
+	dialog.exec();
 }
 
 void MainWindow::onSelectAll()
@@ -1681,22 +1689,20 @@ void MainWindow::onEccTool()
 		return;
 	}
 
-	try
-	{
-		memoryCard->saveAs(filename.toStdString(), !hasEcc);
-		if (m_discordRpc)
-		{
-			m_discordRpc->setTemporaryPresence(
-				tr("Card: %1").arg(makeCardDisplayLabel(currentCardPath)),
-				hasEcc ? tr("Removed ECC") : tr("Added ECC"));
-		}
-		ui->statusBar->showMessage(tr("ECC copy saved to %1").arg(filename), 5000);
-	}
-	catch (const std::exception& e)
+	if (!memoryCard->saveAs(filename.toStdString(), !hasEcc))
 	{
 		QMessageBox::critical(this, tr("Error"),
-			tr("Failed to save: %1").arg(e.what()));
+			tr("Failed to save: %1").arg(QString::fromStdString(memoryCard->GetError().GetDescription())));
+		return;
 	}
+
+	if (m_discordRpc)
+	{
+		m_discordRpc->setTemporaryPresence(
+			tr("Card: %1").arg(makeCardDisplayLabel(currentCardPath)),
+			hasEcc ? tr("Removed ECC") : tr("Added ECC"));
+	}
+	ui->statusBar->showMessage(tr("ECC copy saved to %1").arg(filename), 5000);
 }
 
 void MainWindow::onRenameEntry(const QString& mcPath)
@@ -1728,25 +1734,22 @@ void MainWindow::onRenameEntry(const QString& mcPath)
 		return;
 	}
 
-	try
-	{
-		memoryCard->renameEntry(mcPath.toStdString(), newName.toStdString());
-
-		QString parentPath;
-		int slash = mcPath.lastIndexOf('/');
-		if (slash <= 0)
-			parentPath = "/";
-		else
-			parentPath = mcPath.left(slash);
-
-		updateCardView();
-		ui->cardBrowser->navigateTo(parentPath);
-	}
-	catch (const std::exception& e)
+	if (!memoryCard->renameEntry(mcPath.toStdString(), newName.toStdString()))
 	{
 		QMessageBox::critical(this, tr("Error"),
-			tr("Failed to rename: %1").arg(e.what()));
+			tr("Failed to rename: %1").arg(QString::fromStdString(memoryCard->GetError().GetDescription())));
+		return;
 	}
+
+	QString parentPath;
+	int slash = mcPath.lastIndexOf('/');
+	if (slash <= 0)
+		parentPath = "/";
+	else
+		parentPath = mcPath.left(slash);
+
+	updateCardView();
+	ui->cardBrowser->navigateTo(parentPath);
 }
 
 void MainWindow::onToggleAscii()
@@ -1796,41 +1799,39 @@ void MainWindow::importFileToCard(const QString& savePath, const QString& hostFi
 	if (!memoryCard)
 		return;
 
-	try
-	{
-		QFile file(hostFilePath);
-		if (!file.open(QIODevice::ReadOnly))
-		{
-			QMessageBox::critical(this, tr("Error"),
-				tr("Failed to open file: %1").arg(hostFilePath));
-			return;
-		}
-
-		QByteArray rawBytes = file.readAll();
-		std::vector<uint8_t> fileData(rawBytes.begin(), rawBytes.end());
-
-		QFileInfo fileInfo(hostFilePath);
-		QString targetPath = savePath;
-		if (!targetPath.endsWith('/'))
-			targetPath += "/";
-		targetPath += fileInfo.fileName();
-
-		memoryCard->writeFile(targetPath.toStdString(), fileData);
-		if (m_discordRpc)
-		{
-			m_discordRpc->setTemporaryPresence(
-				tr("Inside: %1").arg(savePath),
-				tr("Imported File: %1").arg(fileInfo.fileName()));
-		}
-		ui->statusBar->showMessage(tr("Imported %1").arg(fileInfo.fileName()), 5000);
-
-		ui->cardBrowser->navigateTo(savePath);
-	}
-	catch (const std::exception& e)
+	QFile file(hostFilePath);
+	if (!file.open(QIODevice::ReadOnly))
 	{
 		QMessageBox::critical(this, tr("Error"),
-			tr("Failed to import file: %1").arg(e.what()));
+			tr("Failed to open file: %1").arg(hostFilePath));
+		return;
 	}
+
+	QByteArray rawBytes = file.readAll();
+	std::vector<uint8_t> fileData(rawBytes.begin(), rawBytes.end());
+
+	QFileInfo fileInfo(hostFilePath);
+	QString targetPath = savePath;
+	if (!targetPath.endsWith('/'))
+		targetPath += "/";
+	targetPath += fileInfo.fileName();
+
+	if (!memoryCard->writeFile(targetPath.toStdString(), fileData))
+	{
+		QMessageBox::critical(this, tr("Error"),
+			tr("Failed to import file: %1").arg(QString::fromStdString(memoryCard->GetError().GetDescription())));
+		return;
+	}
+
+	if (m_discordRpc)
+	{
+		m_discordRpc->setTemporaryPresence(
+			tr("Inside: %1").arg(savePath),
+			tr("Imported File: %1").arg(fileInfo.fileName()));
+	}
+	ui->statusBar->showMessage(tr("Imported %1").arg(fileInfo.fileName()), 5000);
+
+	ui->cardBrowser->navigateTo(savePath);
 }
 
 void MainWindow::updateForceImportWarning()

--- a/src/ui/widgets/MemoryCardBrowser.cpp
+++ b/src/ui/widgets/MemoryCardBrowser.cpp
@@ -55,92 +55,77 @@ void MemoryCardBrowser::loadRootDirectory()
 	if (!m_card)
 		return;
 
-	try
+	auto entries = m_card->listDir("/");
+	if (m_card->GetError().IsValid())
 	{
-		auto entries = m_card->listDir("/");
+		QMessageBox::critical(this, tr("Error"),
+			tr("Failed to read memory card: %1").arg(QString::fromStdString(m_card->GetError().GetDescription())));
+		return;
+	}
 
-		for (const auto& entry : entries)
+	for (const auto& entry : entries)
+	{
+		if ((entry.mode & DF_EXISTS) && !(entry.mode & DF_HIDDEN))
 		{
-			if ((entry.mode & DF_EXISTS) && !(entry.mode & DF_HIDDEN))
+			if (entry.name == "." || entry.name == "..")
+				continue;
+
+			QTreeWidgetItem* item = new QTreeWidgetItem(this);
+			QString savePath = "/" + QString::fromStdString(entry.name);
+			QString displayName;
+
+			bool isDir = (entry.mode & DF_DIR) != 0;
+
+			if (isDir)
 			{
-				if (entry.name == "." || entry.name == "..")
-					continue;
+				std::string title = m_card->getSaveTitle(savePath.toStdString());
+				std::string subtitle = m_card->getSaveSubtitle(savePath.toStdString());
 
-				QTreeWidgetItem* item = new QTreeWidgetItem(this);
-				QString savePath = "/" + QString::fromStdString(entry.name);
-				QString displayName;
-
-				bool isDir = (entry.mode & DF_DIR) != 0;
-
-				if (isDir)
+				if (!title.empty())
 				{
-					try
+					displayName = QString::fromStdString(title);
+					if (!subtitle.empty())
 					{
-						std::string title = m_card->getSaveTitle(savePath.toStdString());
-						std::string subtitle = m_card->getSaveSubtitle(savePath.toStdString());
-
-						if (!title.empty())
-						{
-							displayName = QString::fromStdString(title);
-							if (!subtitle.empty())
-							{
-								displayName += " " + QString::fromStdString(subtitle);
-							}
-						}
-					}
-					catch (...)
-					{
+						displayName += " " + QString::fromStdString(subtitle);
 					}
 				}
-
-				if (displayName.isEmpty())
-				{
-					displayName = QString::fromStdString(entry.name);
-				}
-
-				item->setText(0, displayName);
-
-				if (isDir)
-				{
-					try
-					{
-						uint32_t saveSize = m_card->getSaveSize(savePath.toStdString());
-						double sizeKB = saveSize / 1024.0;
-						item->setText(1, tr("%1 KB").arg(static_cast<int>(sizeKB)));
-					}
-					catch (...)
-					{
-						item->setText(1, tr("?"));
-					}
-				}
-				else
-				{
-					double sizeKB = entry.length / 1024.0;
-					if (sizeKB < 1.0)
-						item->setText(1, tr("%1 B").arg(entry.length));
-					else
-						item->setText(1, tr("%1 KB").arg(static_cast<int>(sizeKB)));
-				}
-
-				item->setData(0, Qt::UserRole, QString::fromStdString(entry.name));
-				item->setData(0, Qt::UserRole + 1, isDir);
-				auto time = todToTime(entry.modified);
-				QDateTime dateTime = QDateTime::fromSecsSinceEpoch(time);
-				item->setText(2, dateTime.toString("yyyy-MM-dd hh:mm"));
-
-				addTopLevelItem(item);
 			}
-		}
 
-		expandAll();
-		clearSelection();
-		setCurrentItem(nullptr);
+			if (displayName.isEmpty())
+			{
+				displayName = QString::fromStdString(entry.name);
+			}
+
+			item->setText(0, displayName);
+
+			if (isDir)
+			{
+				uint32_t saveSize = m_card->getSaveSize(savePath.toStdString());
+				double sizeKB = saveSize / 1024.0;
+				item->setText(1, tr("%1 KB").arg(static_cast<int>(sizeKB)));
+			}
+			else
+			{
+				double sizeKB = entry.length / 1024.0;
+				if (sizeKB < 1.0)
+					item->setText(1, tr("%1 B").arg(entry.length));
+				else
+					item->setText(1, tr("%1 KB").arg(static_cast<int>(sizeKB)));
+			}
+
+			item->setData(0, Qt::UserRole, QString::fromStdString(entry.name));
+			item->setData(0, Qt::UserRole + 1, isDir);
+			auto time = todToTime(entry.modified);
+			QDateTime dateTime = QDateTime::fromSecsSinceEpoch(time);
+			item->setText(2, dateTime.toString("yyyy-MM-dd hh:mm"));
+
+			addTopLevelItem(item);
+		}
 	}
-	catch (const std::exception& e)
-	{
-		QMessageBox::critical(nullptr, tr("Error"),
-			tr("Failed to read memory card: %1").arg(e.what()));
-	}
+
+	expandAll();
+	clearSelection();
+	setCurrentItem(nullptr);
 }
 
 void MemoryCardBrowser::loadSaveDirectory(const QString& savePath)
@@ -150,61 +135,59 @@ void MemoryCardBrowser::loadSaveDirectory(const QString& savePath)
 	if (!m_card)
 		return;
 
-	try
+	QTreeWidgetItem* parentItem = new QTreeWidgetItem(this);
+	parentItem->setText(0, "..");
+	parentItem->setText(1, "");
+	parentItem->setText(2, "");
+	parentItem->setData(0, Qt::UserRole, "..");
+	parentItem->setData(0, Qt::UserRole + 1, true);
+	addTopLevelItem(parentItem);
+
+	auto entries = m_card->listDir(savePath.toStdString());
+	if (m_card->GetError().IsValid())
 	{
-		QTreeWidgetItem* parentItem = new QTreeWidgetItem(this);
-		parentItem->setText(0, "..");
-		parentItem->setText(1, "");
-		parentItem->setText(2, "");
-		parentItem->setData(0, Qt::UserRole, "..");
-		parentItem->setData(0, Qt::UserRole + 1, true);
-		addTopLevelItem(parentItem);
+		QMessageBox::critical(this, tr("Error"),
+			tr("Failed to read save directory: %1").arg(QString::fromStdString(m_card->GetError().GetDescription())));
+		return;
+	}
 
-		auto entries = m_card->listDir(savePath.toStdString());
+	for (const auto& entry : entries)
+	{
+		if (!(entry.mode & DF_EXISTS) || (entry.mode & DF_HIDDEN))
+			continue;
 
-		for (const auto& entry : entries)
+		if (entry.name == "." || entry.name == "..")
+			continue;
+
+		QTreeWidgetItem* item = new QTreeWidgetItem(this);
+
+		item->setText(0, QString::fromStdString(entry.name));
+
+		bool isDir = (entry.mode & DF_DIR) != 0;
+		item->setData(0, Qt::UserRole, QString::fromStdString(entry.name));
+		item->setData(0, Qt::UserRole + 1, isDir);
+
+		if (!isDir)
 		{
-			if (!(entry.mode & DF_EXISTS) || (entry.mode & DF_HIDDEN))
-				continue;
-
-			if (entry.name == "." || entry.name == "..")
-				continue;
-
-			QTreeWidgetItem* item = new QTreeWidgetItem(this);
-
-			item->setText(0, QString::fromStdString(entry.name));
-
-			bool isDir = (entry.mode & DF_DIR) != 0;
-			item->setData(0, Qt::UserRole, QString::fromStdString(entry.name));
-			item->setData(0, Qt::UserRole + 1, isDir);
-
-			if (!isDir)
-			{
-				double sizeKB = entry.length / 1024.0;
-				if (sizeKB < 1.0)
-					item->setText(1, tr("%1 B").arg(entry.length));
-				else
-					item->setText(1, tr("%1 KB").arg(static_cast<int>(sizeKB)));
-			}
+			double sizeKB = entry.length / 1024.0;
+			if (sizeKB < 1.0)
+				item->setText(1, tr("%1 B").arg(entry.length));
 			else
-			{
-				item->setText(1, tr("<DIR>"));
-			}
-
-			auto time = todToTime(entry.modified);
-			QDateTime dateTime = QDateTime::fromSecsSinceEpoch(time);
-			item->setText(2, dateTime.toString("yyyy-MM-dd hh:mm"));
-
-			addTopLevelItem(item);
+				item->setText(1, tr("%1 KB").arg(static_cast<int>(sizeKB)));
+		}
+		else
+		{
+			item->setText(1, tr("<DIR>"));
 		}
 
-		expandAll();
+		auto time = todToTime(entry.modified);
+		QDateTime dateTime = QDateTime::fromSecsSinceEpoch(time);
+		item->setText(2, dateTime.toString("yyyy-MM-dd hh:mm"));
+
+		addTopLevelItem(item);
 	}
-	catch (const std::exception& e)
-	{
-		QMessageBox::critical(nullptr, tr("Error"),
-			tr("Failed to read save directory: %1").arg(e.what()));
-	}
+
+	expandAll();
 }
 
 void MemoryCardBrowser::navigateTo(const QString& path)

--- a/src/ui/widgets/SaveDetailsPanel.cpp
+++ b/src/ui/widgets/SaveDetailsPanel.cpp
@@ -91,7 +91,6 @@ void SaveDetailsPanel::setSave(PS2MemoryCard* card, const QString& savePath,
 	}
 
 	QString fullTitle = saveName;
-	try
 	{
 		std::string title = card->getSaveTitle(savePath.toStdString());
 		std::string subtitle = card->getSaveSubtitle(savePath.toStdString());
@@ -105,25 +104,24 @@ void SaveDetailsPanel::setSave(PS2MemoryCard* card, const QString& savePath,
 			}
 		}
 	}
-	catch (...)
-	{
-	}
 
 	ui->titleLabel->setText(fullTitle);
 	ui->dirNameLabel->setText(saveName);
 
 	QString details = tr("Size: %1\nModified: %2").arg(size, modified);
 
-	try
 	{
 		auto entries = card->listDir(savePath.toStdString());
 		int fileCount = 0;
 
-		for (const auto& entry : entries)
+		if (!card->GetError().IsValid())
 		{
-			if (!(entry.mode & DF_DIR) && !(entry.mode & DF_HIDDEN))
+			for (const auto& entry : entries)
 			{
-				fileCount++;
+				if (!(entry.mode & DF_DIR) && !(entry.mode & DF_HIDDEN))
+				{
+					fileCount++;
+				}
 			}
 		}
 
@@ -132,13 +130,9 @@ void SaveDetailsPanel::setSave(PS2MemoryCard* card, const QString& savePath,
 			details += tr("\nFiles: %1").arg(fileCount);
 		}
 	}
-	catch (...)
-	{
-	}
 
 	ui->detailsLabel->setText(details);
 
-	try
 	{
 		auto iconData = card->getIconData(savePath.toStdString());
 
@@ -173,19 +167,10 @@ void SaveDetailsPanel::setSave(PS2MemoryCard* card, const QString& savePath,
 			}
 			else
 			{
-				iconWidget->hide();
+				if (iconWidget)
+					iconWidget->hide();
 			}
 		}
-	}
-	catch (const std::exception&)
-	{
-		if (iconWidget)
-			iconWidget->hide();
-	}
-	catch (...)
-	{
-		if (iconWidget)
-			iconWidget->hide();
 	}
 	updatePlayPauseButton();
 }


### PR DESCRIPTION
### Description of Changes
Ditched the exception classes (`PS2McError`, `PS2SaveError`, etc), and Ripped out all the try/catch from Qt/CLI side too.

### Rationale behind Changes
I originally used exceptions here, but they don't really make sense for cases like a file not being found on the card.

### Suggested Testing Steps
Open/save cards, import/export saves, poke at the CLI a bit.

### Related Issues / Links
N/A

### Did you use AI to help find, test, or implement this issue or feature?
No